### PR TITLE
Add "all_day" key to timeslot endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,94 @@ All endpoints require requests to contain a header with key `Authorization` and 
         ]
     }
     ```
+
+    The optional key `"all_day"` indicates that Argus should use `Time.min` and `Time.max` as `"start"` and `"end"` respectively. This also overrides any provided values for `"start"` and `"end"`. An example request body:
+    ```json
+    {
+        "name": "Immediately",
+        "time_intervals": [
+            {
+                "day": "MO",
+                "all_day": true
+            },
+            {
+                "day": "TU",
+                "all_day": true
+            },
+            {
+                "day": "WE",
+                "all_day": true
+            },
+            {
+                "day": "TH",
+                "all_day": true
+            },
+            {
+                "day": "FR",
+                "all_day": true
+            },
+            {
+                "day": "SA",
+                "all_day": true
+            },
+            {
+                "day": "SU",
+                "all_day": true
+            }
+        ]
+    }
+    ```
+    which would yield the response:
+    ```json
+    {
+        "pk": 2,
+        "name": "Immediately",
+        "time_intervals": [
+            {
+                "day": "MO",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            },
+            {
+                "day": "TU",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            },
+            {
+                "day": "WE",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            },
+            {
+                "day": "TH",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            },
+            {
+                "day": "FR",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            },
+            {
+                "day": "SA",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            },
+            {
+                "day": "SU",
+                "start": "00:00:00",
+                "end": "23:59:59.999999",
+                "all_day": true
+            }
+        ]
+    }
+    ```
     </details>
 
 * `/api/v1/notificationprofiles/timeslots/<int:pk>`:

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -7,6 +7,8 @@ from .validators import FilterStringValidator
 
 
 class TimeIntervalSerializer(serializers.ModelSerializer):
+    ALL_DAY_KEY = "all_day"
+
     class Meta:
         model = TimeInterval
         fields = ["day", "start", "end"]
@@ -15,6 +17,20 @@ class TimeIntervalSerializer(serializers.ModelSerializer):
         if attrs["start"] >= attrs["end"]:
             raise serializers.ValidationError("Start time must be before end time.")
         return attrs
+
+    def to_internal_value(self, data):
+        if data.get(self.ALL_DAY_KEY):
+            data["start"] = TimeInterval.DAY_START
+            data["end"] = TimeInterval.DAY_END
+
+        return super().to_internal_value(data)
+
+    def to_representation(self, instance: TimeInterval):
+        instance_dict = super().to_representation(instance)
+        if instance_dict["start"] == str(TimeInterval.DAY_START) and instance_dict["end"] == str(TimeInterval.DAY_END):
+            instance_dict[self.ALL_DAY_KEY] = True
+
+        return instance_dict
 
 
 class TimeslotSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This makes it easier for the frontend to adress Uninett/Argus-frontend#91.