### PR TITLE
Add an endpoint for setting ticket-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,20 @@ All endpoints require requests to contain a header with key `Authorization` and 
     * `tags`
     </details>
 
+* `/api/v1/incidents/<int:pk>/ticket_url/`:
+  * `PUT`: modifies just the ticket url of an incident and returns it
+    <details>
+    <summary>Example request body:</summary>
+
+    ```json
+    {
+        "ticket_url": "https://tickettracker.com/tickets/987654/",
+    }
+    ```
+
+    Only `ticket_url` may be modified.
+    </details>
+
 * `/api/v1/incidents/<int:pk>/events/`:
   * `GET`: returns all events related to the specified incident
     <details>
@@ -452,7 +466,8 @@ All endpoints require requests to contain a header with key `Authorization` and 
 
 * `GET` to `/api/v1/incidents/<int:pk>/acks/<int:pk>/`: returns a specific acknowledgement of the specified incident
 
-* `GET` to `/api/v1/incidents/open/`: returns all open incidents that have not been acked
+* `GET` to `/api/v1/incidents/open/`: returns all open incidents
+* `GET` to `/api/v1/incidents/open+unacked/`: returns all open incidents that have not been acked
 * `GET` to `/api/v1/incidents/metadata/`: returns relevant metadata for all incidents
 
 </details>

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -72,6 +72,15 @@ class IncidentTagRelationSerializer(serializers.ModelSerializer):
         return tag_repr
 
 
+class IncidentTicketUrlSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Incident
+        fields = [
+            "ticket_url",
+        ]
+
+
 class IncidentSerializer(serializers.ModelSerializer):
     end_time = fields.DateTimeInfinitySerializerField(required=False, allow_null=True)
     source = SourceSystemSerializer(read_only=True)

--- a/src/argus/incident/urls.py
+++ b/src/argus/incident/urls.py
@@ -5,6 +5,7 @@ from . import views
 
 incident_list = views.IncidentViewSet.as_view({"get": "list", "post": "create"})
 incident_detail = views.IncidentViewSet.as_view({"get": "retrieve", "patch": "partial_update"})
+incident_ticket_url_update = views.IncidentViewSet.as_view({"put": "ticket_url"})
 
 event_list = views.EventViewSet.as_view({"get": "list", "post": "create"})
 event_detail = views.EventViewSet.as_view({"get": "retrieve"})
@@ -12,11 +13,13 @@ event_detail = views.EventViewSet.as_view({"get": "retrieve"})
 ack_list = views.AcknowledgementViewSet.as_view({"get": "list", "post": "create"})
 ack_detail = views.AcknowledgementViewSet.as_view({"get": "retrieve"})
 
+
 app_name = "incident"
 urlpatterns = [
     path("", incident_list, name="incidents"),
     path("legacy/", views.IncidentCreate_legacy.as_view()),  # TODO: remove once it's not in use anymore
     path("<int:pk>/", incident_detail, name="incident"),
+    path("<int:pk>/ticket_url/", incident_ticket_url_update, name="incident-ticket-url-update"),
     path("<int:incident_pk>/events/", event_list, name="incident-events"),
     path("<int:incident_pk>/events/<int:pk>/", event_detail, name="incident-event"),
     path("<int:incident_pk>/acks/", ack_list, name="incident-acks"),

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from django_filters import rest_framework as filters
 from rest_framework import generics, mixins, serializers, status, viewsets
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, action
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -30,6 +30,7 @@ from .serializers import (
     IncidentPureDeserializer,
     IncidentSerializer,
     IncidentSerializer_legacy,
+    IncidentTicketUrlSerializer,
     SourceSystemSerializer,
     SourceSystemTypeSerializer,
 )
@@ -123,6 +124,18 @@ class IncidentViewSet(
 
     def perform_update(self, serializer):
         serializer.save(user=self.request.user)
+
+    @action(detail=True, methods=['put'])
+    def ticket_url(self, request, pk=None):
+        incident = self.get_object()
+        serializer = IncidentTicketUrlSerializer(data=request.data)
+        if serializer.is_valid():
+            incident.ticket_url = serializer.data['ticket_url']
+            incident.save()
+            # TODO: make argus stateless incident about the url being saved? event?
+            return Response(serializer.data)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 # TODO: remove once it's not in use anymore


### PR DESCRIPTION
While you can PATCH an existing incident-instance, that's a lot of code. This is less complex, easier to reason about and test, and it's easily supported in the front end, see https://github.com/Uninett/Argus-frontend/pull/115.

I am tempted to make something similar for updating `Incident.detail_url` and `Incident.tags` as well.