### PR TITLE
Add source locked incident endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ All endpoints require requests to contain a header with key `Authorization` and 
 
 * `GET` to `/api/v1/incidents/<int:pk>/acks/<int:pk>/`: returns a specific acknowledgement of the specified incident
 
+* `GET` to `/api/v1/incidents/mine/`: behaves like `/api/v1/incidents/` except
+  only showing the incidents added by the logged-in user, and no filtering on
+  source or source type is possible.
 * `GET` to `/api/v1/incidents/open/`: returns all open incidents
 * `GET` to `/api/v1/incidents/open+unacked/`: returns all open incidents that have not been acked
 * `GET` to `/api/v1/incidents/metadata/`: returns relevant metadata for all incidents

--- a/src/argus/incident/filters.py
+++ b/src/argus/incident/filters.py
@@ -4,7 +4,10 @@ from .fields import KeyValueField
 from .models import Incident
 
 
-__all__ = ['IncidentFilter']
+__all__ = [
+    "IncidentFilter",
+    "SourceLockedIncidentFilter",
+]
 
 
 class TagFilter(filters.Filter):
@@ -54,4 +57,14 @@ class IncidentFilter(filters.FilterSet):
             "source_incident_id": ["exact"],
             'start_time': ['gte', 'lte'],
             'end_time': ['gte', 'lte', 'isnull'],
+        }
+
+
+class SourceLockedIncidentFilter(IncidentFilter):
+    class Meta:
+        model = Incident
+        fields = {
+            "source_incident_id": ["exact"],
+            "start_time": ["gte", "lte"],
+            "end_time": ["gte", "lte", "isnull"],
         }

--- a/src/argus/incident/urls.py
+++ b/src/argus/incident/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 
 incident_list = views.IncidentViewSet.as_view({"get": "list", "post": "create"})
+sourced_incident_list = views.SourceLockedIncidentViewSet.as_view({"get": "list", "post": "create"})
 incident_detail = views.IncidentViewSet.as_view({"get": "retrieve", "patch": "partial_update"})
 incident_ticket_url_update = views.IncidentViewSet.as_view({"put": "ticket_url"})
 
@@ -17,6 +18,7 @@ ack_detail = views.AcknowledgementViewSet.as_view({"get": "retrieve"})
 app_name = "incident"
 urlpatterns = [
     path("", incident_list, name="incidents"),
+    path("mine/", sourced_incident_list, name="source_locked_incidents"),
     path("legacy/", views.IncidentCreate_legacy.as_view()),  # TODO: remove once it's not in use anymore
     path("<int:pk>/", incident_detail, name="incident"),
     path("<int:pk>/ticket_url/", incident_ticket_url_update, name="incident-ticket-url-update"),

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -16,7 +16,7 @@ from argus.notificationprofile.media import background_send_notifications_to_use
 from argus.util.datetime_utils import INFINITY_REPR
 from . import mappings
 from .forms import AddSourceSystemForm
-from .filters import IncidentFilter
+from .filters import IncidentFilter, SourceLockedIncidentFilter
 from .models import (
     Event,
     Incident,
@@ -156,6 +156,13 @@ class IncidentCreate_legacy(generics.CreateAPIView):
             serializer = IncidentSerializer_legacy(created_incidents, many=True)
         return Response(serializer.data)
 
+
+class SourceLockedIncidentViewSet(IncidentViewSet):
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_class = SourceLockedIncidentFilter
+
+    def get_queryset(self):
+        return Incident.objects.filter(source__user=self.request.user).prefetch_default_related()
 
 class OpenUnAckedIncidentList(generics.ListAPIView):
     serializer_class = IncidentSerializer


### PR DESCRIPTION
New endpoint `/api/incidents/mine/` that works exactly like `/api/incidents/` except the incidents are automatically filtered on the source of the requesting user. Meant for glue services.