### PR TITLE
Dockerize development environment

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,6 +38,8 @@ jobs:
           echo "::set-env name=POSTGRES_DB::argus_db"
           echo "::set-env name=POSTGRES_USER::argus"
           echo "::set-env name=POSTGRES_PASSWORD::password"
+          echo "::set-env name=DATABASE_URL::sqlite://argus.db"
+
 
       - name: Run Tests
         run: |
@@ -54,6 +56,7 @@ jobs:
       - name: Run Tests with PostgreSQL
         env:
           POSTGRES: true
+          DATABASE_URL: postgresql://argus:password@localhost/argus_db
         run: |
           python manage.py collectstatic --no-input
           coverage run -p manage.py test src

--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ pip-selfcheck.json
 npm-debug.log
 cloc.xml
 pylint.txt
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# This Dockerfile is designed to run a development environment for Argus,
+# with the Argus source code tree mounted at /argus
+#
+FROM python:3.8
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends tini build-essential
+RUN mkdir -p /argus
+COPY requirements.txt /argus
+COPY requirements/*.txt /argus/requirements/
+
+WORKDIR /argus
+RUN pip install gunicorn -r requirements.txt
+
+ENV PYTHONPATH=/argus/src
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PORT=8000
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/bin/tini", "-v", "--"]
+CMD ["/argus/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This repository hosts the backend built with Django, while the frontend is hoste
 
 Start the server with `python manage.py runserver`.
 
+#### Alternative setup using Docker Compose
+
+* `docker-compose up`
+* `docker-compose exec argus-api django-admin initial_setup`
+* Visit http://localhost:8000/
+
 ### Site- and deployment-specific settings
 
 Site-specific settings are set as per 12 factor, with environment variables. For more details, see the relevant section in the docs: [Setting site-specific settings](https://argus.readthedocs.io/en/latest/site-specific-settings.html).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.5'
+services:
+  argus-api:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+    environment:
+      - TIME_ZONE=Europe/Oslo
+      - DJANGO_SETTINGS_MODULE=argus.site.settings.dev
+      - DATABASE_URL=postgresql://argus:HahF9araeKoo@postgres/argus
+    volumes:
+      - ${PWD}:/argus
+    restart: always
+
+
+  postgres:
+    image: "postgres:12"
+    volumes:
+      - postgres:/var/lib/postgresql/data:Z
+    restart: always
+    environment:
+      - POSTGRES_USER=argus
+      - POSTGRES_PASSWORD=HahF9araeKoo
+      - POSTGRES_DB=argus
+
+volumes:
+  postgres:
+    driver: local

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+
+cd /argus
+python3 manage.py collectstatic --noinput
+python3 manage.py migrate --noinput
+exec gunicorn --forwarded-allow-ips="*" --log-level debug --access-logfile - argus.site.wsgi -b 0.0.0.0:8000

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
+import dj_database_url
 
 # Import some helpers
 from . import *
@@ -84,11 +85,9 @@ WSGI_APPLICATION = "argus.site.wsgi.application"
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 # fmt: off
+DATABASE_URL = get_str_env("DATABASE_URL", required=True)
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": str(SITE_DIR / "db.sqlite3"),
-    }
+    "default": dj_database_url.parse(DATABASE_URL),
 }
 # fmt: on
 


### PR DESCRIPTION
This adds a simple Docker-based development environment. All you need to get the API backend up and running (with a PostgreSQL backend) is:

`docker-compose up`