### PR TITLE
Set GitHub CI environment vars the "new way"

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,10 +34,10 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=DJANGO_SETTINGS_MODULE::argus.site.settings.test_CI"
-          echo "::set-env name=POSTGRES_DB::argus_db"
-          echo "::set-env name=POSTGRES_USER::argus"
-          echo "::set-env name=POSTGRES_PASSWORD::password"
+          echo "DJANGO_SETTINGS_MODULE=argus.site.settings.test_CI" >> $GITHUB_ENV
+          echo "POSTGRES_DB=argus_db" >> $GITHUB_ENV
+          echo "POSTGRES_USER=argus" >> $GITHUB_ENV
+          echo "POSTGRES_PASSWORD=password" >> $GITHUB_ENV
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
Because:
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/