### PR TITLE
Add description to start-event

### DIFF
--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -24,6 +24,7 @@ def create_start_event(sender, instance: Incident, created, raw, *args, **kwargs
             actor=instance.source.user,
             timestamp=instance.start_time,
             type=Event.Type.INCIDENT_START,
+            description=instance.description,
         )
 
 


### PR DESCRIPTION
- [x] fix #184 by adding the description to the start event.

Needs unit tests. A new issue will be opened.