### PR TITLE
Add button to admin to fake incident

### DIFF
--- a/src/argus/incident/admin.py
+++ b/src/argus/incident/admin.py
@@ -3,6 +3,8 @@ from urllib.parse import urlsplit
 from django.contrib import admin
 from django.contrib.admin import widgets as admin_widgets
 from django.db.models.functions import Concat
+from django.http import HttpResponseRedirect
+from django.urls import path
 from django.utils.html import format_html_join, format_html
 from django.utils.safestring import mark_safe
 
@@ -21,6 +23,7 @@ from .models import (
     SourceSystem,
     SourceSystemType,
     Tag,
+    create_fake_incident,
 )
 
 
@@ -91,6 +94,8 @@ class IncidentAdmin(TextWidgetsOverrideModelAdmin):
         readonly_fields = ("added_time",)
         raw_id_fields = ("tag", "added_by")
         extra = 0
+
+    change_list_template = "incident/incident_change_list.html"
 
     inlines = [IncidentTagRelationInline]
 
@@ -170,6 +175,17 @@ class IncidentAdmin(TextWidgetsOverrideModelAdmin):
 
     get_shown.short_description = "Shown"
     get_shown.boolean = True
+
+    def send_fake(self, request):
+        create_fake_incident()
+        return HttpResponseRedirect("../")
+
+    def get_urls(self):
+        orig_urls = super().get_urls()
+        urls = [
+            path("fake/", self.send_fake),
+        ]
+        return urls + orig_urls
 
     def get_form(self, request, obj: Incident = None, **kwargs):
         form = super().get_form(request, obj, **kwargs)

--- a/src/argus/incident/templates/incident/incident_change_list.html
+++ b/src/argus/incident/templates/incident/incident_change_list.html
@@ -1,0 +1,13 @@
+{% extends 'admin/change_list.html' %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  {% if has_add_permission %}
+  <li>
+    <a href="fake/" class="addlink">
+      Fake incident
+    </a>
+  </li>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
Closes #221

See button at "/admin/argus_incident/incident/". It is not possible to override any of the data, that can be added later.

This will trigger a notification if any notification profiles are set up to notify on these, and thus can be used to test notifications and notification profiles.