### PR TITLE
Prevent setup password from going missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ Run the initial Argus setup, and make note of the admin password that is generat
 
 ```console
 $ python manage.py initial_setup
-Successfully created superuser "admin" with the generated password "2S0qJbjVEew0GunL".
-Please change the password via the admin.
-Ensured the existence of the source, source type and user "argus"```
+******************************************************************************
+
+  Created Argus superuser "admin" with password "2S0qJbjVEew0GunL".
+
+   Please change the password via the admin interface.
+
+******************************************************************************
 ```
 
 Then run the Argus API server:
@@ -89,11 +93,14 @@ Run the initial Argus setup, and make note of the admin password that is generat
 
 ```console
 $ docker-compose exec argus-api django-admin initial_setup
-Successfully created superuser "admin" with the generated password "2S0qJbjVEew0GunL".
-Please change the password via the admin.
-Ensured the existence of the source, source type and user "argus"
-```
+******************************************************************************
 
+  Created Argus superuser "admin" with password "ns6bfoKquW12koIP".
+
+   Please change the password via the admin interface.
+
+******************************************************************************
+```
 
 You will find Argus running at http://localhost:8000/.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,4 @@
 cd /argus
 python3 manage.py collectstatic --noinput
 python3 manage.py migrate --noinput
-python3 manage.py initial_setup
-python3 manage.py create_fake_incident -b 15
 exec gunicorn --forwarded-allow-ips="*" --log-level debug --access-logfile - argus.site.wsgi -b 0.0.0.0:8000

--- a/src/argus/dev/management/commands/initial_setup.py
+++ b/src/argus/dev/management/commands/initial_setup.py
@@ -37,17 +37,18 @@ class Command(BaseCommand):
                 username=username, email=email, first_name=first_name, last_name="", password=password
             )
             if options_password:
-                msg = f'Successfully created superuser "{admin.username}" with the chosen password'
+                msg = f'Successfully created Argus superuser "{admin.username}" with the chosen password'
             else:
                 msg = (
-                    f'Successfully created superuser "{admin.username}" with the generated password "{password}".\n'
-                    "Please change the password via the admin."
+                    "******************************************************************************\n\n"
+                    f'  Created Argus superuser "{admin.username}" with password "{password}".\n\n'
+                    "   Please change the password via the admin interface.\n\n"
+                    "******************************************************************************"
                 )
             self.stdout.write(self.style.SUCCESS(msg))
         else:
-            msg = f"The admin user {username} already exists, you might want to change the password"
+            msg = f"Argus superuser {username} already exists!"
             self.stderr.write(self.style.WARNING(msg))
-
 
         # Create source for argus, also creates a user
         get_or_create_default_instances()


### PR DESCRIPTION
- Remove initial_setup from docker-compose

It's simply not needed. The current docker-compose setup is for development, commands will be run by developers via exec. No need to automate here.

Also initial_setup creates a randomly generated admin password that is only outputted once via console. It's easy to miss in the docker output.

Related:

- Make sure the admin password is super duper *** visible *** during initial_setup

Add some newlines and *** to make sure no one will miss it.