### PR TITLE
Update docker-compose dev environment to support the realtime/websockets feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ docker-compose up
 Run the initial Argus setup, and make note of the admin password that is generated:
 
 ```console
-$ docker-compose exec argus-api django-admin initial_setup
+$ docker-compose exec api django-admin initial_setup
 ******************************************************************************
 
   Created Argus superuser "admin" with password "ns6bfoKquW12koIP".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - postgres
     environment:
       - TIME_ZONE=Europe/Oslo
-      - DJANGO_SETTINGS_MODULE=argus.site.settings.dev
+      - DJANGO_SETTINGS_MODULE=argus.site.settings.docker
       - DATABASE_URL=postgresql://argus:HahF9araeKoo@postgres/argus
     volumes:
       - ${PWD}:/argus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - redis
     environment:
       - TIME_ZONE=Europe/Oslo
-      - DJANGO_SETTINGS_MODULE=argus.site.settings.docker
+      - DJANGO_SETTINGS_MODULE=argus.site.settings.dockerdev
       - DATABASE_URL=postgresql://argus:HahF9araeKoo@postgres/argus
     volumes:
       - ${PWD}:/argus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "8000:8000"
     depends_on:
       - postgres
+      - redis
     environment:
       - TIME_ZONE=Europe/Oslo
       - DJANGO_SETTINGS_MODULE=argus.site.settings.docker
@@ -24,6 +25,12 @@ services:
       - POSTGRES_USER=argus
       - POSTGRES_PASSWORD=HahF9araeKoo
       - POSTGRES_DB=argus
+
+
+  redis:
+    image: "redis:latest"
+    restart: always
+
 
 volumes:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - TIME_ZONE=Europe/Oslo
       - DJANGO_SETTINGS_MODULE=argus.site.settings.dockerdev
       - DATABASE_URL=postgresql://argus:HahF9araeKoo@postgres/argus
+      - ARGUS_REDIS_SERVER=redis
     volumes:
       - ${PWD}:/argus
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.5'
 services:
-  argus-api:
+  api:
     build: .
     ports:
       - "8000:8000"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,4 @@
 cd /argus
 python3 manage.py collectstatic --noinput
 python3 manage.py migrate --noinput
-exec gunicorn --forwarded-allow-ips="*" --log-level debug --access-logfile - argus.site.wsgi -b 0.0.0.0:8000
+exec daphne -b 0.0.0.0 -p 8000 argus.ws.asgi:application

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -118,6 +118,20 @@ use:
 * ``DEFAULT_SMS_MEDIA`` is disabled by default, since there is no standardized way of
   sending SMS messages.
 
+Realtime updates
+----------------
+
+The Argus API can notify the frontend about changes in the list of open
+incidents in realtime, using a websocket (implemented using Django
+Channels). The realtime interface requires access to a Redis server for message
+passing.
+
+By default, Argus will look for a Redis server on ``localhost:6379``. To use a
+different server, set the ``ARGUS_REDIS_SERVER`` environment variable, e.g::
+
+  ARGUS_REDIS_SERVER=my-redis-server.example.org:6379
+
+
 Debugging settings
 ------------------
 

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -9,6 +9,8 @@ https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
+from urllib.parse import urlsplit
+
 import dj_database_url
 
 # Import some helpers
@@ -201,11 +203,12 @@ AUTH_TOKEN_EXPIRES_AFTER_DAYS = 14
 ASGI_APPLICATION = "argus.ws.routing.application"
 
 # fmt: off
+_REDIS = urlsplit("//" + get_str_env("ARGUS_REDIS_SERVER", "127.0.0.1:6379"))
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [("127.0.0.1", 6379)],
+            "hosts": [(_REDIS.hostname, _REDIS.port or 6379)],
         },
     },
 }

--- a/src/argus/site/settings/docker.py
+++ b/src/argus/site/settings/docker.py
@@ -1,0 +1,4 @@
+from .dev import *
+
+# Allow all hosts, since all requests will typically come from outside the container
+ALLOWED_HOSTS = ["*"]

--- a/src/argus/site/settings/docker.py
+++ b/src/argus/site/settings/docker.py
@@ -2,3 +2,15 @@ from .dev import *
 
 # Allow all hosts, since all requests will typically come from outside the container
 ALLOWED_HOSTS = ["*"]
+
+# Redis server for channels, expected to run as a service in the docker-compose setup
+# fmt: off
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("redis", 6379)],
+        },
+    },
+}
+# fmt: on

--- a/src/argus/site/settings/dockerdev.py
+++ b/src/argus/site/settings/dockerdev.py
@@ -1,3 +1,4 @@
+"""Settings specific for Docker-based development environments"""
 from .dev import *
 
 # Allow all hosts, since all requests will typically come from outside the container

--- a/src/argus/site/settings/dockerdev.py
+++ b/src/argus/site/settings/dockerdev.py
@@ -3,15 +3,3 @@ from .dev import *
 
 # Allow all hosts, since all requests will typically come from outside the container
 ALLOWED_HOSTS = ["*"]
-
-# Redis server for channels, expected to run as a service in the docker-compose setup
-# fmt: off
-CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": [("redis", 6379)],
-        },
-    },
-}
-# fmt: on


### PR DESCRIPTION
This changes the docker-compose dev environment to:

- Run a Redis server for message passing
- Run the Django-based API using Daphne, rather than gunicorn, to support dynamic upgrade to websockets when the frontend asks for it
- Use a separate Django settings file for the docker deployment, based on the dev settings.
