### PR TITLE
Fix missing/broken requirements in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,13 +42,14 @@ install_requires =
     django-phonenumber-field[phonenumberslite]
     djangorestframework
     factory_boy
+    psycopg2
     python-dataporten-auth
     python-social-auth
     pytz>=2020.1
     social-auth-app-django
     whitenoise
-    channels
-    channels-redis
+    channels==2.4.0
+    channels-redis==3.1.0
     aioredis
 
 [options.extras_require]


### PR DESCRIPTION
Because:
- pip installing the module (i.e. via setuptools) and pip-installing the
  requirements files have very different results.
- Argus seems to work poorly with Django Channels 3 and the Daphne
  server that comes with it, so we should lock the version until we can
  make it work.
- psycopg2 is required for production work with PostgreSQL.