### PR TITLE
Add back path to missing endpoint

### DIFF
--- a/src/argus/incident/urls.py
+++ b/src/argus/incident/urls.py
@@ -10,6 +10,7 @@ router.register(r"sources", views.SourceSystemViewSet)
 router.register(r"source-types", views.SourceSystemTypeViewSet)
 router.register(r"", views.IncidentViewSet)
 
+sourced_incident_list = views.SourceLockedIncidentViewSet.as_view({"get": "list", "post": "create"})
 
 event_list = views.EventViewSet.as_view({"get": "list", "post": "create"})
 event_detail = views.EventViewSet.as_view({"get": "retrieve"})
@@ -20,6 +21,7 @@ ack_detail = views.AcknowledgementViewSet.as_view({"get": "retrieve"})
 
 app_name = "incident"
 urlpatterns = [
+    path("mine/", sourced_incident_list, name="source_locked_incidents"),
     path("<int:incident_pk>/events/", event_list, name="incident-events"),
     path("<int:incident_pk>/events/<int:pk>/", event_detail, name="incident-event"),
     path("<int:incident_pk>/acks/", ack_list, name="incident-acks"),


### PR DESCRIPTION
When merging stable with master, one path to an endpoint important to glue services disappeared. This adds it back in.