### PR TITLE
Add issue templates. Resolves #266

### DIFF
--- a/.github/blank_issue.md
+++ b/.github/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: "Bug Report"
+about: Create a bug report for Argus server
+title: ''
+labels: bug
+assignees: ''
+---
+<!--
+  Thank you for filing a bug report! 🐛 Please provide a short summary of the
+  bug, along with any information you feel relevant to replicating it.
+-->
+
+### Code/API request
+
+I tried this code/API request:
+
+```
+<code>
+```
+
+### Expected behaviour
+
+I expected to see this happen: *write a short explanation*
+
+### Actual behaviour
+
+Instead, this happened: *write a short explanation, and optionally include an
+error message you received*

--- a/.github/documentation_error.md
+++ b/.github/documentation_error.md
@@ -1,0 +1,56 @@
+---
+name: "Documentation error"
+about: Describe an error or things missing in Argus' documentation
+title: ''
+labels: documentation
+assignees: ''
+---
+<!--
+  Thank you for reporting a documentation error! 📖 Please provide a short
+  summary of what is missing or should be corrected, along with any information
+  you feel relevant for improving this.
+-->
+
+<!--
+  Please mark what applies. ('Activate' a checkbox like this: [x])
+-->
+
+Documentation is
+
+[ ] incomplete
+[ ] incorrect or misleading
+[ ] outdated
+[ ] missing
+
+### Where?
+
+<!--
+  Please describe where the error is located, if applicable.
+  You can name the text section and/or provide a .rst file name. A readthedocs
+  link also works.
+-->
+
+The error is located at …
+
+### Expected documentation
+
+I expected to find this:
+
+*Describe what you would like to learn or find out*
+
+### Actual documentation
+
+Instead, this is the current documentation:
+
+*Short description of what you found*
+
+*OR:* The current feature/behaviour is not documented at all.
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+*Write your answer here*

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: "Feature Request"
+about: Suggest an idea for improving Argus
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+### Is your proposal related to a problem?
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when…"
+-->
+
+*Write your answer here*
+
+### Desired solution
+
+<!--
+  Provide a clear and concise description of what you would like to happen.
+-->
+
+*Describe your proposed/prefered solution here*
+
+### Alternatives already considered
+
+<!--
+  Optionally: Let us know about other solutions you've tried or researched.
+-->
+
+*Write your answer here*
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+*Write your answer here*


### PR DESCRIPTION
Adding templates that will help users and developers help to write feature requests, bug reports and documentation error reports. Also maintain the ability to create a blank issue on the repository without any templates.