### PR TITLE
Dockerfile: remove gunicorn from pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt /argus
 COPY requirements/*.txt /argus/requirements/
 
 WORKDIR /argus
-RUN pip install gunicorn -r requirements.txt -r /argus/requirements/dev.txt
+RUN pip install -r requirements.txt -r /argus/requirements/dev.txt
 
 ENV PYTHONPATH=/argus/src
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
commit eeeca3db switched the whole docker-setup to daphne as a web server, so gunicorn installation can be skipped.

Removing gunicorn from the list was probably just overlooked/forgotten.