### PR TITLE
Add endpoint for manipulating incident tags only

### DIFF
--- a/src/argus/incident/V1/urls.py
+++ b/src/argus/incident/V1/urls.py
@@ -19,6 +19,8 @@ event_detail = views.EventViewSet.as_view({"get": "retrieve"})
 ack_list = views.AcknowledgementViewSet.as_view({"get": "list", "post": "create"})
 ack_detail = views.AcknowledgementViewSet.as_view({"get": "retrieve"})
 
+tag_list = views.IncidentTagViewSet.as_view({"get": "list", "post": "create"})
+tag_detail = views.IncidentTagViewSet.as_view({"get": "retrieve", "delete": "destroy"})
 
 app_name = "incident"
 urlpatterns = [
@@ -27,6 +29,8 @@ urlpatterns = [
     path("<int:incident_pk>/events/<int:pk>/", event_detail, name="incident-event"),
     path("<int:incident_pk>/acks/", ack_list, name="incident-acks"),
     path("<int:incident_pk>/acks/<int:pk>/", ack_detail, name="incident-ack"),
+    path("<int:incident_pk>/tags/", tag_list, name="incident-tags"),
+    path("<int:incident_pk>/tags/<str:tag>/", tag_detail, name="incident-tag"),
     path("open/", views_V1.OpenIncidentListV1.as_view(), name="incidents-open"),
     path("open+unacked/", views_V1.OpenUnAckedIncidentListV1.as_view(), name="incidents-open-unacked"),
 ] + router.urls

--- a/src/argus/incident/urls.py
+++ b/src/argus/incident/urls.py
@@ -18,6 +18,8 @@ event_detail = views.EventViewSet.as_view({"get": "retrieve"})
 ack_list = views.AcknowledgementViewSet.as_view({"get": "list", "post": "create"})
 ack_detail = views.AcknowledgementViewSet.as_view({"get": "retrieve"})
 
+tag_list = views.IncidentTagViewSet.as_view({"get": "list", "post": "create"})
+tag_detail = views.IncidentTagViewSet.as_view({"get": "retrieve", "delete": "destroy"})
 
 app_name = "incident"
 urlpatterns = [
@@ -26,4 +28,6 @@ urlpatterns = [
     path("<int:incident_pk>/events/<int:pk>/", event_detail, name="incident-event"),
     path("<int:incident_pk>/acks/", ack_list, name="incident-acks"),
     path("<int:incident_pk>/acks/<int:pk>/", ack_detail, name="incident-ack"),
+    path("<int:incident_pk>/tags/", tag_list, name="incident-tags"),
+    path("<int:incident_pk>/tags/<str:tag>/", tag_detail, name="incident-tag"),
 ] + router.urls

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -24,6 +24,7 @@ from .models import (
     Incident,
     SourceSystem,
     SourceSystemType,
+    Tag,
 )
 from .serializers import (
     AcknowledgementSerializer,
@@ -34,6 +35,8 @@ from .serializers import (
     SourceSystemSerializer,
     SourceSystemTypeSerializer,
     MetadataSerializer,
+    TagSerializer,
+    IncidentTagRelation,
 )
 
 
@@ -230,6 +233,62 @@ class IncidentViewSet(
             "sourceSystems": source_systems.data,
         }
         return Response(data)
+
+
+class IncidentTagViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = Tag.objects.prefetch_related("incident_tag_relations")
+    serializer_class = TagSerializer
+    lookup_url_kwarg = "tag"
+    lookup_field = lookup_url_kwarg
+
+    def _get_incident(self):
+        incident_pk = self.kwargs.get("incident_pk")
+        try:
+            incident = Incident.objects.get(pk=incident_pk)
+        except Incident.DoesNotExist:
+            raise NotFound("An incident with this id does not exist")
+        return incident
+
+    def get_object(self):
+        queryset = self.filter_queryset(self.get_queryset())
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        assert lookup_url_kwarg in self.kwargs, (
+            "Expected view %s to be called with a URL keyword argument "
+            'named "%s". Fix your URL conf, or set the `.lookup_field` '
+            "attribute on the view correctly." % (self.__class__.__name__, lookup_url_kwarg)
+        )
+        key, value = Tag.split(self.kwargs[lookup_url_kwarg])
+        filter_kwargs = {"key": key, "value": value}
+        obj = get_object_or_404(queryset, **filter_kwargs)
+
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    def get_queryset(self, *args, **kwargs):
+        incident = self._get_incident()
+        return self.queryset.filter(incident_tag_relations__incident=incident)
+
+    def perform_create(self, serializer):
+        data = serializer.validated_data
+        tag, _ = Tag.objects.get_or_create(**data)
+        incident = self._get_incident()
+        IncidentTagRelation.objects.get_or_create(incident=incident, tag=tag, defaults={"added_by": self.request.user})
+
+    def perform_destroy(self, instance):
+        incident = self._get_incident()
+        # Delete the connection between tag and incident
+        itrs = IncidentTagRelation.objects.filter(incident=incident, tag=instance)
+        if itrs.exists():
+            itrs.delete()
+            # If the tag is now unused, delete it
+            if not IncidentTagRelation.objects.filter(tag=instance).exists():
+                instance.delete()
 
 
 class SourceLockedIncidentViewSet(IncidentViewSet):

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -7,6 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 from rest_framework import generics, mixins, serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
@@ -263,7 +264,11 @@ class IncidentTagViewSet(
             'named "%s". Fix your URL conf, or set the `.lookup_field` '
             "attribute on the view correctly." % (self.__class__.__name__, lookup_url_kwarg)
         )
-        key, value = Tag.split(self.kwargs[lookup_url_kwarg])
+        try:
+            key, value = Tag.split(self.kwargs[lookup_url_kwarg])
+        except ValueError:
+            # Not a valid tag. Misses the delimiter, or multiple delimiters
+            raise NotFound("A tag like this does not exist for this incident")
         filter_kwargs = {"key": key, "value": value}
         obj = get_object_or_404(queryset, **filter_kwargs)
 

--- a/tests/incident/test_tags.py
+++ b/tests/incident/test_tags.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta
+
+from django.db.models import signals
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+from django.utils.timezone import make_aware
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from argus.util import datetime_utils
+from argus.util.utils import duplicate
+from argus.util.testing import disconnect_signals, connect_signals
+from argus.incident.factories import IncidentFactory, SourceSystemFactory
+from argus.incident.models import Event, Incident
+from . import IncidentBasedAPITestCaseHelper
+
+
+class IncidentTagViewSetTests(APITestCase, IncidentBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+        self.stateful_incident1 = IncidentFactory(
+            source=self.source1,
+            source_incident_id="1",
+        )
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_view_incident_tags_when_no_tags(self):
+        incident = IncidentFactory()
+        self.assertFalse(incident.tags)
+        response = self.user1_rest_client.get(reverse("v1:incident:incident-tags", kwargs={"incident_pk": incident.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
+    def test_view_incident_tags_when_some_tags(self):
+        incident = IncidentFactory()


### PR DESCRIPTION
The new endpoint lists all tags for an incident with GET, you can POST a new tag or DELETE an existing one and for completion's sake you can GET a single tag.

Works in the swagger-ui sp can be played with there.

The IncidenTagRelation model is hidden away, this endpoint only operates with "key=value"-strings.

To be improved: tests, no hardcoding of the equals-sign, maybe use django-nested-routers instead of manually writing the urls.