### PR TITLE
Unveil unfinished api v2

### DIFF
--- a/src/argus/incident/V1/serializers.py
+++ b/src/argus/incident/V1/serializers.py
@@ -1,5 +1,7 @@
+from rest_framework import serializers
+
 from ..models import Incident
-from ..serializers import IncidentSerializer
+from ..serializers import IncidentSerializer, SourceSystemSerializer
 
 
 class IncidentSerializerV1(IncidentSerializer):
@@ -19,3 +21,8 @@ class IncidentSerializerV1(IncidentSerializer):
         ]
         read_only_fields = ["source"]
         extra_kwargs = {"level": {"required": False}}
+
+
+# Get rid of this!
+class MetadataSerializer(serializers.Serializer):
+    sourceSystems = SourceSystemSerializer(many=True)

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -117,7 +117,7 @@ class SourceLockedIncidentViewSetV1(IncidentViewSetV1):
 # DEPRECATED: The following views will be removed in V2
 
 
-@extend_schema_view(list=extend_schema(deprecated=True))
+@extend_schema_view(get=extend_schema(deprecated=True))
 class OpenUnAckedIncidentListV1(generics.ListAPIView):
     """All incidents that are open and unacked
 
@@ -135,7 +135,7 @@ class OpenUnAckedIncidentListV1(generics.ListAPIView):
         return Incident.objects.open().not_acked().prefetch_default_related()
 
 
-@extend_schema_view(list=extend_schema(deprecated=True))
+@extend_schema_view(get=extend_schema(deprecated=True))
 class OpenIncidentListV1(generics.ListAPIView):
     """All incidents that are open
 

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -87,7 +87,7 @@ class IncidentViewSetV1(IncidentViewSet):
             return IncidentPureDeserializer
         return IncidentSerializerV1
 
-    # DEPRECATED: This view will be deprecated in V2
+    # DEPRECATED: This view will be removed in V2
     @extend_schema(
         responses=MetadataSerializer,
         description=("Metadata used by incidents.\n\nDeprecated, use the individual endpoints instead"),
@@ -114,7 +114,7 @@ class SourceLockedIncidentViewSetV1(IncidentViewSetV1):
         return Incident.objects.filter(source__user=self.request.user).prefetch_default_related()
 
 
-# DEPRECATED: The following views will be deprecated in V2
+# DEPRECATED: The following views will be removed in V2
 
 
 @extend_schema_view(list=extend_schema(deprecated=True))

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -35,11 +35,6 @@ class SourceSystemSerializer(serializers.ModelSerializer):
         read_only_fields = ["type", "user", "base_url"]
 
 
-# Get rid of this!
-class MetadataSerializer(serializers.Serializer):
-    sourceSystems = SourceSystemSerializer(many=True)
-
-
 class TagSerializer(serializers.Serializer):
     tag = serializers.CharField()
 

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -35,7 +35,6 @@ from .serializers import (
     IncidentTicketUrlSerializer,
     SourceSystemSerializer,
     SourceSystemTypeSerializer,
-    MetadataSerializer,
     TagSerializer,
     IncidentTagRelation,
 )
@@ -225,15 +224,6 @@ class IncidentViewSet(
             return Response(serializer.data)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-    @extend_schema(responses=MetadataSerializer)
-    @action(detail=False, methods=["get"])
-    def metadata(self, request, **_):
-        source_systems = SourceSystemSerializer(SourceSystem.objects.select_related("type"), many=True)
-        data = {
-            "sourceSystems": source_systems.data,
-        }
-        return Response(data)
 
 
 class IncidentTagViewSet(

--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -37,5 +37,5 @@ urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(api_version="v1"), name="schema-v1-old"),
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema-v1-old"), name="swagger-ui-v1-old"),
     path("api/v1/", include(("argus.site.api_v1_urls", "api"), namespace="v1")),
-    # path("api/v2/", include(("argus.site.api_v2_urls", "api"), namespace="v2")),
+    path("api/v2/", include(("argus.site.api_v2_urls", "api"), namespace="v2")),
 ]


### PR DESCRIPTION
Make the unfinished API V2 visible and accessible.

There's unfortunately no way in OpenAPI to mark a version (or endpoint) as stable vs unstable. V2 is **very much** unstable, all future changes to the API will be on V2 only from now on.