### PR TITLE
Make it possible to add a tags-field to Incident

### DIFF
--- a/src/argus/incident/V1/serializers.py
+++ b/src/argus/incident/V1/serializers.py
@@ -1,10 +1,15 @@
 from rest_framework import serializers
 
+from ..fields import DateTimeInfinitySerializerField
 from ..models import Incident
-from ..serializers import IncidentSerializer, SourceSystemSerializer
+from ..serializers import IncidentSerializer, SourceSystemSerializer, IncidentTagRelationSerializer
 
 
 class IncidentSerializerV1(IncidentSerializer):
+    end_time = DateTimeInfinitySerializerField(required=False, allow_null=True)
+    source = SourceSystemSerializer(read_only=True)
+    tags = IncidentTagRelationSerializer(many=True, write_only=True, source="deprecated_tags")
+
     class Meta:
         model = Incident
         fields = [

--- a/src/argus/incident/admin.py
+++ b/src/argus/incident/admin.py
@@ -140,7 +140,9 @@ class IncidentAdmin(TextWidgetsOverrideModelAdmin):
         html_open_tag = '<div style="display: inline-block; white-space: nowrap;">'
         html_bullet = "<b>&bull;</b>"
         return format_html_join(
-            mark_safe("<br />"), f"{html_open_tag}{html_bullet} {{}}</div>", ((tag,) for tag in incident.tags)
+            mark_safe("<br />"),
+            f"{html_open_tag}{html_bullet} {{}}</div>",
+            ((tag,) for tag in incident.deprecated_tags),
         )
 
     get_tags.short_description = "Tags"

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from functools import reduce
+import logging
 from operator import and_
 from random import randint
 from urllib.parse import urljoin
@@ -15,6 +16,9 @@ from argus.util.datetime_utils import INFINITY_REPR, get_infinity_repr
 from .constants import INCIDENT_LEVELS, INCIDENT_LEVEL_CHOICES
 from .fields import DateTimeInfinityField
 from .validators import validate_lowercase, validate_key
+
+
+LOG = logging.getLogger(__name__)
 
 
 def get_or_create_default_instances():
@@ -260,9 +264,18 @@ class Incident(models.Model):
         return self.stateful and self.end_time > timezone.now()
 
     @property
-    def tags(self):
+    def deprecated_tags(self):
         # Don't do `Tag.objects.filter()`, which ignores prefetched data
         return [relation.tag for relation in self.incident_tag_relations.all()]
+
+    @property
+    def tags(self):
+        # In preparation for making a tags-field on the model
+        try:
+            raise Exception("Nothing should use this label directly")
+        except Exception:
+            LOG.exception("Deprecated label: Incident.tags")
+        return self.deprecated_tags
 
     @property
     def incident_relations(self):

--- a/src/argus/notificationprofile/models.py
+++ b/src/argus/notificationprofile/models.py
@@ -225,7 +225,7 @@ class Filter(models.Model):
         if not tags_list:
             # We're not limiting on tags!
             return None
-        tags = set(tag.representation for tag in incident.tags)
+        tags = set(tag.representation for tag in incident.deprecated_tags)
         return tags.issuperset(tags_list)
 
     def incident_fits(self, incident: Incident):

--- a/tests/incident/test_tags.py
+++ b/tests/incident/test_tags.py
@@ -31,9 +31,9 @@ class IncidentTagViewSetTests(APITestCase, IncidentBasedAPITestCaseHelper):
     def tearDown(self):
         connect_signals()
 
-    def test_view_incident_tags_when_no_tags(self):
+    def test_view_V1_incident_tags_when_no_tags(self):
         incident = IncidentFactory()
-        self.assertFalse(incident.tags)
+        self.assertFalse(incident.deprecated_tags)
         response = self.user1_rest_client.get(reverse("v1:incident:incident-tags", kwargs={"incident_pk": incident.pk}))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])


### PR DESCRIPTION
Rename Incident.tags to Incident.deprecated_tags, and log a stack trace when Incident.tags is used, in case there is some
overlooked access somewhere.

Luckily, most accesses to tags goes via IncidentTagRelation, which we don't need to touch until the replacement structure is ready.