### PR TITLE
Add metadata endpoint

### DIFF
--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -21,7 +21,7 @@ from social_django.urls import extra
 
 from argus.auth.views import ObtainNewAuthToken
 from argus.dataporten import views as dataporten_views
-from argus.site.views import error
+from argus.site.views import error, MetadataView
 
 
 psa_urls = [
@@ -38,4 +38,5 @@ urlpatterns = [
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema-v1-old"), name="swagger-ui-v1-old"),
     path("api/v1/", include(("argus.site.api_v1_urls", "api"), namespace="v1")),
     path("api/v2/", include(("argus.site.api_v2_urls", "api"), namespace="v2")),
+    path("api/", MetadataView.as_view(), name="metadata"),
 ]


### PR DESCRIPTION
GETting `/api/` will return a json-blob with the following contents.

```json
{
    "server-version": "1.2.3",
    "api-version": {
        "stable": "v1",
        "unstable": "v2"
    },
    "jsonapi-schema": {
        "stable": "/api/schema/",
        "v1": "/api/v1/schema/",
        "v2": "/api/v2/schema/"
    }
}
```
Open questions: 

- Should there be more info in this endpoint?
- Should it be located on some other url?

Making this visible to swagger is probably not happening. JSON API still doesn't have a notion about api stability, and the library used to convert to the schema isn't perfect either.