### PR TITLE
Upgrade to django-rest-framework 3.13

### DIFF
--- a/requirements-django32.txt
+++ b/requirements-django32.txt
@@ -75,7 +75,7 @@ django-multiselectfield==0.1.12
     # via -r requirements/base.txt
 django-phonenumber-field[phonenumberslite]==5.0.0
     # via -r requirements/base.txt
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
@@ -138,6 +138,7 @@ pytz==2021.1
     # via
     #   -r requirements/base.txt
     #   django
+    #   djangorestframework
 pyyaml==5.4.1
     # via
     #   -r requirements/forced-upgrade.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ django-multiselectfield==0.1.12
     # via -r requirements/base.txt
 django-phonenumber-field[phonenumberslite]==5.0.0
     # via -r requirements/base.txt
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
@@ -138,6 +138,7 @@ pytz==2021.1
     # via
     #   -r requirements/base.txt
     #   django
+    #   djangorestframework
 pyyaml==5.4.1
     # via
     #   -r requirements/forced-upgrade.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ django-cors-headers>=3.2
 django-filter
 django-multiselectfield
 django-phonenumber-field[phonenumberslite]
-djangorestframework<3.13
+djangorestframework>=3.13,<3.14
 drf-spectacular>=0.17
 drf-rw-serializers
 factory_boy

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     django-filter
     django-multiselectfield
     django-phonenumber-field[phonenumberslite]
-    djangorestframework<3.13
+    djangorestframework>=3.13,<3.14
     drf-rw-serializers
     drf-spectacular>=0.11
     factory_boy

--- a/src/argus/notificationprofile/primitive_serializers.py
+++ b/src/argus/notificationprofile/primitive_serializers.py
@@ -23,5 +23,5 @@ class FilterBlobSerializer(serializers.Serializer):
 
 
 class FilterPreviewSerializer(serializers.Serializer):
-    sourceSystemIds = serializers.ListField(serializers.IntegerField(min_value=1), allow_empty=True)
-    tags = serializers.ListField(serializers.CharField(min_length=3), allow_empty=True)
+    sourceSystemIds = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=True)
+    tags = serializers.ListField(child=serializers.CharField(min_length=3), allow_empty=True)


### PR DESCRIPTION
* Fields and serializer inits only take keyword arguments, never positional arguments