### PR TITLE
Support REMOTE_USER for external authentication

### DIFF
--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -66,6 +66,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
+    "django.contrib.auth.middleware.RemoteUserMiddleware",
 ]
 
 ROOT_URLCONF = "argus.site.urls"
@@ -155,6 +156,7 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesSto
 
 AUTHENTICATION_BACKENDS = (
     "argus.dataporten.social.DataportenFeideOAuth2",
+    "django.contrib.auth.backends.RemoteUserBackend",
     "django.contrib.auth.backends.ModelBackend",
 )
 


### PR DESCRIPTION
Fixes #357 

Configures Django to make us of REMOTE_USER environment variable.
Based on https://docs.djangoproject.com/en/4.0/howto/auth-remote-user/

Is this what was intended in the issue?