### PR TITLE
Fix notification profiles

### DIFF
--- a/src/argus/auth/V1/serializers.py
+++ b/src/argus/auth/V1/serializers.py
@@ -40,5 +40,5 @@ class UserSerializerV1(serializers.ModelSerializer):
     def get_phone_numbers(self, user: User) -> List[dict]:
         return [
             {"pk": destination.pk, "user": user.pk, "phone_number": destination.settings["phone_number"]}
-            for destination in user.destinations.filter(media__slug="sms")
+            for destination in user.destinations.filter(media_id="sms")
         ]

--- a/src/argus/auth/V1/views.py
+++ b/src/argus/auth/V1/views.py
@@ -59,7 +59,6 @@ class PhoneNumberViewV1(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         destination = get_object_or_404(self.queryset.filter(media__slug="sms"), pk=pk)
         serializer = self.serializer_class(destination)
-        breakpoint()
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def update(self, request, pk=None):

--- a/src/argus/auth/V1/views.py
+++ b/src/argus/auth/V1/views.py
@@ -35,15 +35,15 @@ class PhoneNumberViewV1(viewsets.ViewSet):
     permission_classes = [IsAuthenticated, IsOwner]
     serializer_class = ResponsePhoneNumberSerializerV1
     write_serializer_class = RequestDestinationConfigSerializer
-    queryset = DestinationConfig.objects.all()
+    queryset = DestinationConfig.objects.filter(media_id="sms").all()
 
     def list(self, request):
-        serializer = self.serializer_class(self.queryset.filter(media__slug="sms"), many=True)
+        serializer = self.serializer_class(self.queryset.filter(user=request.user), many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def create(self, request, pk=None):
         if pk:
-            destination = get_object_or_404(self.queryset.filter(media__slug="sms"), pk=pk)
+            destination = get_object_or_404(self.queryset.filter(user=request.user), pk=pk)
             serializer = self.write_serializer_class(destination, data={"media": "sms", "settings": request.data})
         else:
             serializer = self.write_serializer_class(data={"media": "sms", "settings": request.data})
@@ -57,15 +57,15 @@ class PhoneNumberViewV1(viewsets.ViewSet):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def retrieve(self, request, pk=None):
-        destination = get_object_or_404(self.queryset.filter(media__slug="sms"), pk=pk)
+        destination = get_object_or_404(self.queryset.filter(user=request.user), pk=pk)
         serializer = self.serializer_class(destination)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def update(self, request, pk=None):
         if request.stream.method == "PUT":
-            destination = self.queryset.filter(media__slug="sms").filter(pk=pk).first()
+            destination = self.queryset.filter(user=request.user).filter(pk=pk).first()
         elif request.stream.method == "PATCH":
-            destination = get_object_or_404(self.queryset.filter(media__slug="sms"), pk=pk)
+            destination = get_object_or_404(self.queryset.filter(user=request.user), pk=pk)
         serializer = self.write_serializer_class(destination, data={"media": "sms", "settings": request.data})
         if serializer.is_valid():
             serializer.save(user=request.user)
@@ -77,7 +77,7 @@ class PhoneNumberViewV1(viewsets.ViewSet):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def partial_update(self, request, pk=None):
-        destination = get_object_or_404(self.queryset.filter(media__slug="sms"), pk=pk)
+        destination = get_object_or_404(self.queryset.filter(user=request.user), pk=pk)
         serializer = self.write_serializer_class(
             destination, data={"media": "sms", "settings": request.data}, partial=True
         )
@@ -91,6 +91,6 @@ class PhoneNumberViewV1(viewsets.ViewSet):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def destroy(self, request, pk=None):
-        destination = get_object_or_404(self.queryset.filter(media__slug="sms"), pk=pk)
+        destination = get_object_or_404(self.queryset.filter(user=request.user), pk=pk)
         destination.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/argus/notificationprofile/V1/serializers.py
+++ b/src/argus/notificationprofile/V1/serializers.py
@@ -8,6 +8,31 @@ from ..models import NotificationProfile
 from ..serializers import FilterSerializer, RequestDestinationConfigSerializer, TimeslotSerializer
 
 
+def _switch_phone_numbers(first_sms_destination, new_phone_number, instance):
+    current_sms_destination = (
+        instance.user.destinations.filter(media__slug="sms")
+        .filter(settings__phone_number=new_phone_number.as_e164)
+        .first()
+    )
+    old_phone_number = first_sms_destination.settings["phone_number"]
+    # Set phone number to None to avoid unique together restriction
+    first_sms_destination.settings["phone_number"] = None
+    first_sms_destination.save(update_fields=["settings"])
+    if current_sms_destination:
+        current_sms_destination.settings["phone_number"] = old_phone_number
+        current_sms_destination.save(update_fields=["settings"])
+        instance.destinations.add(current_sms_destination)
+    else:
+        sms_serializer = RequestDestinationConfigSerializer(
+            data={"media": "sms", "settings": {"phone_number": old_phone_number}}
+        )
+        if sms_serializer.is_valid():
+            sms_serializer.save(user=instance.user)
+            instance.destinations.add(sms_serializer.instance)
+    first_sms_destination.settings["phone_number"] = new_phone_number.as_e164
+    first_sms_destination.save(update_fields=["settings"])
+
+
 class ResponseNotificationProfileSerializerV1(serializers.ModelSerializer):
     timeslot = TimeslotSerializer()
     filters = FilterSerializer(many=True)
@@ -59,7 +84,7 @@ class RequestNotificationProfileSerializerV1(serializers.ModelSerializer):
         read_only_fields = ["pk"]
 
     def create(self, validated_data: dict):
-        phone_number = validated_data.pop("phone_number")
+        phone_number = validated_data.pop("phone_number", None)
         media_v1 = validated_data.pop("media_v1")
         user = validated_data["user"]
         destinations = []
@@ -111,15 +136,22 @@ class RequestNotificationProfileSerializerV1(serializers.ModelSerializer):
 
         phone_number = validated_data.pop("phone_number", None)
         media_v1 = validated_data.pop("media_v1", None)
+        # Update phone number without updating media_v1
+        if phone_number and not media_v1 and instance.destinations.filter(media__slug="sms").exists():
+            first_sms_destination = instance.destinations.filter(media__slug="sms").order_by("pk").first()
+            if not first_sms_destination.settings["phone_number"] == phone_number.as_e164:
+                _switch_phone_numbers(first_sms_destination, phone_number, instance)
+
+        # Update media
         if media_v1:
             if "SM" in media_v1:
-                sms_destination = instance.destinations.filter(media__slug="sms").first()
-                if sms_destination:
-                    if not sms_destination.settings["phone_number"] == phone_number.as_e164:
-                        if not phone_number:
-                            raise serializers.ValidationError({"phone_number": ["This field may not be null."]})
-                        sms_destination.settings["phone_number"] = phone_number.as_e164
-                        sms_destination.save(updated_fields=["settings"])
+                if "EM" not in media_v1:
+                    email_destinations = instance.destinations.filter(media__slug="email")
+                    instance.destinations.remove(*email_destinations)
+                first_sms_destination = instance.destinations.filter(media__slug="sms").order_by("pk").first()
+                if first_sms_destination:
+                    if phone_number and not first_sms_destination.settings["phone_number"] == phone_number.as_e164:
+                        _switch_phone_numbers(first_sms_destination, phone_number, instance)
                 else:
                     if not phone_number:
                         raise serializers.ValidationError({"phone_number": ["This field may not be null."]})
@@ -130,26 +162,19 @@ class RequestNotificationProfileSerializerV1(serializers.ModelSerializer):
                         sms_serializer.save(user=instance.user)
                         instance.destinations.add(sms_serializer.instance)
             if "EM" in media_v1:
-                if not instance.user.email:
+                if "SM" not in media_v1:
+                    sms_destinations = instance.destinations.filter(media__slug="sms")
+                    instance.destinations.remove(*sms_destinations)
+                if not instance.user.email and not instance.destinations.filter(media__slug="email").exists():
                     raise serializers.ValidationError(
                         {"media_v1": ["User email is not set, therefore this field cannot include email."]}
                     )
-                if not instance.destinations.filter(media__slug="email").first():
-                    instance.destinations.add(
-                        instance.user.destinations.filter(media__slug="email")
-                        .filter(settings__email_address=instance.user.email)
-                        .first()
+                if instance.user.email:
+                    default_email_destination = instance.user.destinations.filter(media__slug="email").get(
+                        settings__email_address=instance.user.email
                     )
-            if "SM" not in media_v1 and instance.destinations.filter(media__slug="sms").exists():
-                sms_destinations = instance.destinations.filter(media__slug="sms")
-                instance.destinations.remove(*sms_destinations)
-            if "EM" not in media_v1 and instance.destinations.filter(media__slug="email").exists():
-                email_destinations = instance.destinations.filter(media__slug="email")
-                instance.destinations.remove(*email_destinations)
-        if not phone_number:
-            if instance.destinations.filter(media__slug="sms").exists():
-                sms_destinations = instance.destinations.filter(media__slug="sms")
-                instance.destinations.remove(*sms_destinations)
+                    if not default_email_destination in instance.destinations.all():
+                        instance.destinations.add(default_email_destination)
 
         return super().update(instance, validated_data)
 

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -5,13 +5,23 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argus.incident.models import Event
-    from argus.notificationprofile.models import NotificationProfile
+    from argus.notificationprofile.models import DestinationConfig, NotificationProfile
 
 
 __all__ = ["NotificationMedium"]
 
 
 class NotificationMedium(ABC):
+    @classmethod
+    @abstractmethod
+    def validate(cls, instance, dict):
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def get_label(destination: DestinationConfig):
+        pass
+
     @staticmethod
     @abstractmethod
     def send(event: Event, profile: NotificationProfile, **kwargs):

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -30,3 +30,7 @@ class NotificationMedium(ABC):
     @staticmethod
     def is_deletable(destination: DestinationConfig):
         return None
+
+    @staticmethod
+    def update(destination, validated_data):
+        return None

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -26,3 +26,7 @@ class NotificationMedium(ABC):
     @abstractmethod
     def send(event: Event, profile: NotificationProfile, **kwargs):
         pass
+
+    @staticmethod
+    def is_deletable(destination: DestinationConfig):
+        return None

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -75,8 +75,8 @@ class EmailNotification(NotificationMedium):
 
         return form.cleaned_data
 
-    @classmethod
-    def get_label(self, destination):
+    @staticmethod
+    def get_label(destination):
         return destination.settings.get("email_address")
 
     @staticmethod

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -76,6 +76,23 @@ class EmailNotification(NotificationMedium):
         return form.cleaned_data
 
     @staticmethod
+    def is_deletable(destination: DestinationConfig):
+        if destination.settings["synced"]:
+            return "Cannot delete this email destination since it was defined by an outside source."
+
+        connected_profiles = destination.notification_profiles.all()
+        if connected_profiles:
+            profiles = ", ".join([str(profile) for profile in connected_profiles])
+            return "".join(
+                [
+                    "Cannot delete this destination since it is in use in the notification profile(s): ",
+                    profiles,
+                    ".",
+                ]
+            )
+        return None
+
+    @staticmethod
     def get_label(destination):
         return destination.settings.get("email_address")
 

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -110,7 +110,7 @@ class EmailNotification(NotificationMedium):
 
     @staticmethod
     def send(event: Event, destinations: QuerySet[DestinationConfig], **_):
-        email_destinations = destinations.filter(media__slug=EmailNotification.MEDIA_SLUG)
+        email_destinations = destinations.filter(media_id=EmailNotification.MEDIA_SLUG)
         if not email_destinations:
             return False
 

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -55,8 +55,8 @@ class SMSNotification(NotificationMedium):
 
         return form.cleaned_data
 
-    @classmethod
-    def get_label(self, destination):
+    @staticmethod
+    def get_label(destination):
         return destination.settings.get("phone_number")
 
     @staticmethod

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -66,7 +66,7 @@ class SMSNotification(NotificationMedium):
             LOG.error("SMS_GATEWAY_ADDRESS is not set, cannot dispatch SMS notifications using this plugin")
             return
 
-        sms_destinations = destinations.filter(media__slug=SMSNotification.MEDIA_SLUG)
+        sms_destinations = destinations.filter(media_id=SMSNotification.MEDIA_SLUG)
         if not sms_destinations:
             return False
         phone_numbers = [destination.settings["phone_numbers"] for destination in sms_destinations]

--- a/src/argus/notificationprofile/models.py
+++ b/src/argus/notificationprofile/models.py
@@ -300,7 +300,7 @@ class NotificationProfile(models.Model):
     phone_number = models.ForeignKey("argus_auth.PhoneNumber", on_delete=models.SET_NULL, blank=True, null=True)
     destinations = models.ManyToManyField(
         to=DestinationConfig,
-        related_name="notification_profile",
+        related_name="notification_profiles",
         blank=True,
     )
 

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -155,9 +155,20 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
         if self.instance and "media" in attrs.keys() and not attrs["media"].slug == self.instance.media.slug:
             raise serializers.ValidationError("Media cannot be updated, only settings.")
         if "settings" in attrs.keys():
-            attrs["settings"] = MEDIA_CLASSES_DICT[attrs["media"].slug].validate(self, attrs)
+            if self.instance:
+                attrs["settings"] = MEDIA_CLASSES_DICT[self.instance.media.slug].validate(self, attrs)
+            else:
+                attrs["settings"] = MEDIA_CLASSES_DICT[attrs["media"].slug].validate(self, attrs)
 
         return attrs
+
+    def update(self, destination: DestinationConfig, validated_data: dict):
+        updated_destination = MEDIA_CLASSES_DICT[destination.media.slug].update(destination, validated_data)
+
+        if updated_destination:
+            return updated_destination
+
+        return super().update(destination, validated_data)
 
 
 class ResponseNotificationProfileSerializer(serializers.ModelSerializer):

--- a/src/argus/notificationprofile/views.py
+++ b/src/argus/notificationprofile/views.py
@@ -163,6 +163,19 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
+    def destroy(self, request, *args, **kwargs):
+        pk = self.kwargs["pk"]
+        try:
+            destination = self.get_queryset().get(pk=pk)
+        except DestinationConfig.DoesNotExist:
+            raise ValidationError(f"Destination with pk={pk} does not exist.")
+
+        error_message = MEDIA_CLASSES_DICT[destination.media.slug].is_deletable(destination)
+        if not error_message:
+            return super().destroy(destination)
+        else:
+            raise ValidationError(error_message)
+
 
 class TimeslotViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsOwner]

--- a/tests/notificationprofile/V1/test_switch_phone_numbers.py
+++ b/tests/notificationprofile/V1/test_switch_phone_numbers.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from phonenumber_field.phonenumber import PhoneNumber
+
+from argus.auth.factories import PersonUserFactory
+from argus.notificationprofile.factories import DestinationConfigFactory, NotificationProfileFactory
+from argus.notificationprofile.media import MEDIA_CLASSES_DICT
+from argus.notificationprofile.V1.serializers import _switch_phone_numbers
+
+
+class SwitchPhoneNumberTests(TestCase):
+    def setUp(self):
+        if not "sms" in MEDIA_CLASSES_DICT.keys():
+            return
+
+        self.user = PersonUserFactory()
+        self.profile = NotificationProfileFactory(user=self.user)
+        self.destination = DestinationConfigFactory(
+            user=self.user,
+            media_id="sms",
+            settings={"phone_number": "+4747474746"},
+        )
+        self.profile.destinations.add(self.destination)
+        self.new_phone_number = PhoneNumber.from_string("+4747474747")
+
+    def test_switch_phone_number(self):
+        if not "sms" in MEDIA_CLASSES_DICT.keys():
+            self.skipTest("No sms plugin available")
+
+        _switch_phone_numbers(self.destination, self.new_phone_number, self.profile)
+
+        self.assertEqual(
+            self.profile.destinations.order_by("pk").first().settings["phone_number"], self.new_phone_number.as_e164
+        )

--- a/tests/notificationprofile/V1/test_views.py
+++ b/tests/notificationprofile/V1/test_views.py
@@ -37,12 +37,12 @@ class ViewTests(APITestCase, IncidentAPITestCaseHelper):
         self.notification_profile1.destinations.set(self.user1.destinations.all())
         self.media_v1 = []
         self.phone_number = None
-        if self.notification_profile1.destinations.filter(media__slug="email").exists():
+        if self.notification_profile1.destinations.filter(media_id="email").exists():
             self.media_v1.append("EM")
-        if self.notification_profile1.destinations.filter(media__slug="sms").exists():
+        if self.notification_profile1.destinations.filter(media_id="sms").exists():
             self.media_v1.append("SM")
             self.phone_number = (
-                self.notification_profile1.destinations.filter(media__slug="sms")
+                self.notification_profile1.destinations.filter(media_id="sms")
                 .order_by("pk")
                 .first()
                 .settings["phone_number"]

--- a/tests/notificationprofile/test_serializers.py
+++ b/tests/notificationprofile/test_serializers.py
@@ -239,7 +239,11 @@ class DestinationConfigSerializerTests(TestCase):
         )
 
     def test_update_existing_email_destination(self):
-        destination = DestinationConfigFactory(user=self.user, settings={"email_address": "user@example.com"})
+        destination = DestinationConfigFactory(
+            user=self.user,
+            media_id="email",
+            settings={"email_address": "user@example.com", "synced": False},
+        )
 
         request = self.request_factory.post("/")
         request.user = self.user
@@ -372,7 +376,11 @@ class DestinationConfigSerializerTests(TestCase):
     def test_update_existing_sms_destination(self):
         if not "sms" in MEDIA_CLASSES_DICT.keys():
             self.skipTest("No sms plugin available")
-        destination = DestinationConfigFactory(user=self.user, settings={"phone_number": "+4747474747"})
+        destination = DestinationConfigFactory(
+            user=self.user,
+            media_id="sms",
+            settings={"phone_number": "+4747474747"},
+        )
 
         request = self.request_factory.post("/")
         request.user = self.user


### PR DESCRIPTION
Fixes some mistakes that were left by #333:  
- removes forgotten breakpoint
- include validate and get_label function in base for media plugins
- simplify updating of destinations in v1 and v2
- change updating of synced email destination when user.email changes
- prevent deletion of destinations if they are synced or connected to notification profiles
- in v1 only show phone numbers belonging to the current user