### PR TITLE
Add crossreference of settings in docs

### DIFF
--- a/docs/_exts/djangodocs.py
+++ b/docs/_exts/djangodocs.py
@@ -1,0 +1,6 @@
+def setup(app):
+    app.add_crossref_type(
+        directivename = "setting",
+        rolename = "setting",
+        indextemplate = "pair: %s; setting",
+    )

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -17,7 +17,7 @@ OAuth2
 ======
 
 For support of OAuth2/OIDC-logins, the library `python-social-auth (PSA)`_ is
-used. By adding a new backend to the setting ``AUTHENTICATION_BACKENDS`` it is
+used. By adding a new backend to the setting :django:setting:`AUTHENTICATION_BACKENDS` it is
 possible to support all that PSA supports, and it is also not too hard to write
 your own.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../src'))
+sys.path.insert(0, os.path.abspath("_exts"))
 
 
 # -- Project information -----------------------------------------------------
@@ -43,6 +44,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'djangodocs',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
     'djangodocs',
 ]
 
@@ -185,3 +186,12 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Intersphinx configuration -----------------------------------------------
+
+intersphinx_mapping = {
+    'django': (
+        'http://docs.djangoproject.com/en/3.2/',
+        'http://docs.djangoproject.com/en/3.2/_objects/',
+    ),
+}

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -61,45 +61,62 @@ List of settings and environment variables
 Django-specific settings
 ------------------------
 
-* ``DJANGO_SETTINGS_MODULE`` is the environment variable to invoke the Django settings
+.. setting:: DJANGO_SETTINGS_MODULE
+
+* :setting:`DJANGO_SETTINGS_MODULE` is the environment variable to invoke the Django settings
   module, or settings file. For a development environment, reasonable defaults are
   provided in ``argus.site.settings.dev``. In production, a ``settings.py`` file should
   be created and invoked here.
-* ``SECRET_KEY`` is the Django secret key for this particular Argus instance.
+
+.. setting:: SECRET_KEY
+
+* :setting:`SECRET_KEY` is the Django secret key for this particular Argus instance.
   It contains a minimum of 50 random characters.
   The recommended way to generate this key is calling the command::
 
       $ python manage.py gen_secret_key
 
-  .. warning:: Keep the ``SECRET_KEY`` secret, as it is relevant to the
+  .. warning:: Keep the :setting:`SECRET_KEY` secret, as it is relevant to the
     security and integrity of your Argus instance.
 
 Dataporten
 ----------
 
-* ``ARGUS_DATAPORTEN_KEY`` holds the id/key for using dataporten for authentication.
-* ``ARGUS_DATAPORTEN_SECRET`` holds the dataporten password.
+.. setting:: ARGUS_DATAPORTEN_KEY
+
+* :setting:`ARGUS_DATAPORTEN_KEY` holds the id/key for using dataporten for authentication.
+
+.. setting:: ARGUS_DATAPORTEN_SECRET
+
+* :setting:`ARGUS_DATAPORTEN_SECRET` holds the dataporten password.
 
 Refer to the section :ref:`dataporten` for more information.
 
 Domain settings
 ---------------
 
-* ``ARGUS_COOKIE_DOMAIN`` holds the domain of the Argus instance. This is the domain
+.. setting:: ARGUS_COOKIE_DOMAIN
+
+* :setting:`ARGUS_COOKIE_DOMAIN` holds the domain of the Argus instance. This is the domain
   that the cookie is set for. It is needed to log into the frontend.
-* ``ARGUS_FRONTEND_URL`` is used for redirecting back to frontend after logging in
+
+.. setting:: ARGUS_FRONTEND_URL
+
+* :setting:`ARGUS_FRONTEND_URL` is used for redirecting back to frontend after logging in
   through Feide and CORS. Must either be a subdomain of or the same as
-  ``ARGUS_COOKIE_DOMAIN``.
+  :setting:`ARGUS_COOKIE_DOMAIN`.
 
 In production, Argus requires the frontend and the backend to either be deployed on the
-same domain, or the frontend to be on a subdomain of the ``ARGUS_COOKIE_DOMAIN``.
-When running Argus on localhost for development and testing, ``ARGUS_COOKIE_DOMAIN`` can
+same domain, or the frontend to be on a subdomain of the :setting:`ARGUS_COOKIE_DOMAIN`.
+When running Argus on localhost for development and testing, :setting:`ARGUS_COOKIE_DOMAIN` can
 be empty (and will default to localhost).
 
 Database settings
 -----------------
 
-* ``DATABASE_URL`` contains the URL and port, as well as username, password, and name
+.. setting:: DATABASE_URL
+
+* :setting:`DATABASE_URL` contains the URL and port, as well as username, password, and name
   of the database to be used by Argus.
 
 A common value in development would be::
@@ -109,15 +126,34 @@ A common value in development would be::
 Notification settings
 ---------------------
 
-* ``ARGUS_SEND_NOTIFICATIONS`` allows sending or suppressing notifications.
-  Default values are ``1`` in production and ``0`` otherwise.
-* ``DEFAULT_FROM_EMAIL`` the email address Argus uses as sender of email notifications.
-* ``EMAIL_HOST`` contains the smarthost (domain name) to send email through.
-* ``EMAIL_HOST_USER`` (optional) username for email host (if required).
-* ``EMAIL_HOST_PASSWORD`` (optional) password for the email host (if required).
-* ``EMAIL_PORT`` (optional) email port. Defaults to 587 in production.
+.. setting:: ARGUS_SEND_NOTIFICATIONS
 
-In the settings file, there is also the variable ``MEDIA_PLUGINS``, which holds the paths
+* :setting:`ARGUS_SEND_NOTIFICATIONS` allows sending or suppressing notifications.
+  Default values are ``1`` in production and ``0`` otherwise.
+
+.. setting:: DEFAULT_FROM_EMAIL
+
+* :setting:`DEFAULT_FROM_EMAIL` the email address Argus uses as sender of email notifications.
+
+.. setting:: EMAIL_HOST
+
+* :setting:`EMAIL_HOST` contains the smarthost (domain name) to send email through.
+
+.. setting:: EMAIL_HOST_USER
+
+* :setting:`EMAIL_HOST_USER` (optional) username for email host (if required).
+
+.. setting:: EMAIL_HOST_PASSWORD
+
+* :setting:`EMAIL_HOST_PASSWORD` (optional) password for the email host (if required).
+
+.. setting:: EMAIL_PORT
+
+* :setting:`EMAIL_PORT` (optional) email port. Defaults to 587 in production.
+
+.. setting:: MEDIA_PLUGINS
+
+In the settings file, there is also the variable :setting:`MEDIA_PLUGINS`, which holds the paths
 to the media classes and determines which notification plugins are available to send notifications by.
 
 Email is enabled by default and uses Django's email backend. There are multiple email
@@ -130,6 +166,8 @@ The only supported way at the moment is Uninett's internal email-to-SMS gateway.
 Enabling the email-to-SMS gateway
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. setting:: SMS_GATEWAY_ADDRESS
+
 Argus supports sending SMS text messages via an email-to-SMS gateway, provided
 that this gateway conforms to the following interface:
 
@@ -140,13 +178,15 @@ sent as a text message to this number.
 Argus comes with an SMS notification class that supports this kind of
 interface.  To enable it:
 
-* Add ``"argus.notificationprofile.media.sms_as_email.SMSNotification"`` to ``MEDIA_PLUGINS``.
-* Set ``SMS_GATEWAY_ADDRESS`` to the email address of the gateway.
+* Add ``"argus.notificationprofile.media.sms_as_email.SMSNotification"`` to :setting:`MEDIA_PLUGINS`.
+* Set :setting:`SMS_GATEWAY_ADDRESS` to the email address of the gateway.
 
 Using the fallback notification filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The setting ``ARGUS_FALLBACK_FILTER`` is a dict, by default undefined. You can
+.. setting:: ARGUS_FALLBACK_FILTER
+
+The setting  :setting:`ARGUS_FALLBACK_FILTER` is a dict, by default undefined. You can
 set this to ensure a systemwide fallback filter for everyone:
 
 Examples:
@@ -166,13 +206,15 @@ Do both::
 Realtime updates
 ----------------
 
+.. setting:: ARGUS_REDIS_SERVER
+
 The Argus API can notify the frontend about changes in the list of open
 incidents in realtime, using a websocket (implemented using Django
 Channels). The realtime interface requires access to a Redis server for message
 passing.
 
 By default, Argus will look for a Redis server on ``localhost:6379``. To use a
-different server, set the ``ARGUS_REDIS_SERVER`` environment variable, e.g::
+different server, set the :setting:`ARGUS_REDIS_SERVER` environment variable, e.g::
 
   ARGUS_REDIS_SERVER=my-redis-server.example.org:6379
 
@@ -180,9 +222,14 @@ different server, set the ``ARGUS_REDIS_SERVER`` environment variable, e.g::
 Debugging settings
 ------------------
 
-* ``DEBUG`` enables or disables debug-mode.
-* ``TEMPLATE_DEBUG`` (optional) provides a convenient way to turn debugging on and off
-  for templates. If undefined, it will default to the value of ``DEBUG``.
+.. setting:: DEBUG
+
+* :setting:`DEBUG` enables or disables debug-mode.
+
+.. setting:: TEMPLATE_DEBUG
+
+* :setting:`TEMPLATE_DEBUG` (optional) provides a convenient way to turn debugging on and off
+  for templates. If undefined, it will default to the value of :setting:`DEBUG`.
 
 Other settings
 --------------
@@ -190,7 +237,9 @@ Other settings
 Normally, you shouldn't need to ever change these. If you do need to touch
 them, do it via a new settings file containing overrides.
 
-* ``ARGUS_TOKEN_COOKIE_NAME`` is to control the name of the cookie that
+.. setting:: ARGUS_TOKEN_COOKIE_NAME
+
+* :setting:`ARGUS_TOKEN_COOKIE_NAME` is to control the name of the cookie that
   contains a copy of the authentication token which is used when logging in via
   the frontend. The default is ``token``, and you can change this to
   something else if something you cannot change in the same system also creates

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -6,11 +6,11 @@ Site-specific settings
 
 There are several settings that need to be defined within Argus, for example:
 
-* ``SECRET_KEY``
+* :setting:`SECRET_KEY`
 * Any API keys, for instance OIDC keys and secrets
-* ``DEBUG``
-* ``DATABASE``-settings
-* ``EMAIL``-settings
+* :setting:`DEBUG`
+* :setting:`DATABASE_URL`
+* :setting:`DEFAULT_FROM_EMAIL`
 
 Two ways to define these site-specific settings are explained as follows.
 


### PR DESCRIPTION
Fixes #367

Gives rolls to settings defined in `site-specific-settings.rst`, and any mentions of these settings are replaced with references instead.
This makes them clickable to link to the setting, and adds them to the Index (/genindex.html).

Django settings that are not discussed in `site-specific-settings.rst` instead reference the Django documentation (`AUTHENTICATION_BACKENDS`). The Django settings `SECRET_KEY` and `DJANGO_SETTINGS_MODULE` refer to `site-specific-settings.rst` instead of the Django documentation, as they are defined there.

Some minor changes to the introduction of  `site-specific-settings.rst`. Some of the lines there could directly be changed to refer to the related setting, but some (``DATABASE``-settings and ``EMAIL``-settings) had no concrete setting to reference to, so these were changed a little.