### PR TITLE
Clean up documentation

### DIFF
--- a/docs/about-argus.rst
+++ b/docs/about-argus.rst
@@ -40,7 +40,7 @@ The API and the user interface
 ------------------------------
 
 In keeping with the single responsibility principle, a complete Argus setup
-consists two separate components, with separate concerns: The Argus API server,
+consists of two separate components, with separate concerns: The Argus API server,
 and the Argus frontend.
 
 The Argus server provides a REST API to interact with the incident database and
@@ -49,7 +49,7 @@ received from source systems, and allows viewing and processing them via the
 REST API.
 It also supports setting up user-specific notification profiles, and sends
 notifications to users based on said profiles.
-Argus server does not provide a user interface targeted at end users.
+The Argus server does not provide a user interface targeted at end users.
 
 Conversely, the `Argus frontend application`_ acts as a client to provide end
 users with a web-based user interface to the Argus API server. Using the
@@ -64,7 +64,7 @@ The frontend application documentation is provided separately.
 The Argus server admin interface
 --------------------------------
 
-Besides the REST API, Argus server has an administration interface.
+Besides the REST API, the Argus server has an administration interface.
 It can be used to perform low-level administration tasks on a running Argus
 server, such as:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,8 +26,10 @@ Auth endpoints
 -  ``POST`` to ``/api/v1/token-auth/``: returns an auth token for the
    posted user
 
-   -  Note that this token will expire after 14 days, and can be
-      replaced by posting to the same endpoint.
+   -  Note that this token will expire after a certain amout of days that is
+      set in the variable ``AUTH_TOKEN_EXPIRES_AFTER_DAYS`` in
+      :ref:`site-specific-settings` (by default 14 days), and can be replaced
+      by posting to the same endpoint.
 
    .. code-block:: json
     :caption: Example request body
@@ -704,8 +706,10 @@ Auth endpoints
 -  ``POST`` to ``/api/v2/token-auth/``: returns an auth token for the
    posted user
 
-   -  Note that this token will expire after 14 days, and can be
-      replaced by posting to the same endpoint.
+   -  Note that this token will expire after a certain amout of days that is
+      set in the variable ``AUTH_TOKEN_EXPIRES_AFTER_DAYS`` in
+      :ref:`site-specific-settings` (by default 14 days), and can be replaced
+      by posting to the same endpoint.
 
    .. code-block:: json
     :caption: Example request body

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,8 @@ replaced by a registered auth token. These are generated per user by
 logging in through Feide, and can be found at
 ``/admin/authtoken/token/``.
 
+.. _api-auth-endpoints:
+
 Auth endpoints
 --------------
 
@@ -145,8 +147,8 @@ Incident endpoints
       ``tags=key1=value1,key1=value2,key2=value``
         Fetch only incidents with one or more of the tags. Tag-format is
         “``key=value``”. If there are multiple tags with the same key, only
-        one of the tags need match. If there are multiple keys, one of
-        each keys must match.
+        one of the tags needs to match. If there are multiple keys, one of
+        each key must match.
 
       So:
 
@@ -163,7 +165,7 @@ Incident endpoints
                             problem=onfire
 
       will fetch incidents that are all of “open”, “unacked”,
-      “stateful”, from source number 1, with “location” either
+      “stateful”, from source number 1, with “location” either being
       “broomcloset” or “understairs”, and that is on fire.
 
       .. note::
@@ -513,7 +515,7 @@ Incident endpoints
 
 -  ``GET`` to ``/api/v1/incidents/mine/``: behaves similar to
    ``/api/v1/incidents/``, but will only show the incidents added by the
-   logged-in user, and no filtering on source or source type is
+   logged in user, and no filtering on source or source type is
    possible.
 
 -  ``GET`` to ``/api/v1/incidents/open/``: returns all open incidents
@@ -532,7 +534,7 @@ Notification profile endpoints
 
    -  ``GET``: returns the logged in user’s notification profiles
 
-   -  ``POST``: creates and returns a notification profile which is then
+   -  ``POST``: creates and returns a notification profile, which is then
       connected to the logged in user
 
       .. code-block:: json
@@ -580,7 +582,7 @@ Notification profile endpoints
 -  ``/api/v1/notificationprofiles/timeslots/``:
 
    -  ``GET``: returns the logged in user’s time slots
-   -  ``POST``: creates and returns a time slot which is then connected
+   -  ``POST``: creates and returns a time slot, which is then connected
       to the logged in user
 
       .. code-block:: json
@@ -653,7 +655,7 @@ Notification profile endpoints
 -  ``/api/v1/notificationprofiles/filters/``:
 
    -  ``GET``: returns the logged in user’s filters
-   -  ``POST``: creates and returns a filter which is then connected to
+   -  ``POST``: creates and returns a filter, which is then connected to
       the logged in user
 
       .. code-block:: json
@@ -695,6 +697,8 @@ Endpoints v2 API
      v2 of the API is not stable yet.
 
 
+.. _api-auth-endpoints-v2:
+
 Auth endpoints
 ==============================
 
@@ -721,6 +725,8 @@ Auth endpoints
 
 -  ``/oidc/login/dataporten_feide/``: redirects to Feide login
 
+
+.. _api-incident-endpoints-v2:
 
 Incident endpoints
 ==============================
@@ -762,8 +768,8 @@ Incident endpoints
       ``tags=key1=value1,key1=value2,key2=value``
         Fetch only incidents with one or more of the tags. Tag-format is
         “``key=value``”. If there are multiple tags with the same key, only
-        one of the tags need match. If there are multiple keys, one of
-        each keys must match.
+        one of the tags needs to match. If there are multiple keys, one of
+        each key must match.
 
       So:
 
@@ -780,7 +786,7 @@ Incident endpoints
                             problem=onfire
 
       will fetch incidents that are all of “open”, “unacked”,
-      “stateful”, from source number 1, with “location” either
+      “stateful”, from source number 1, with “location” either being
       “broomcloset” or “understairs”, and that is on fire.
 
       .. note::
@@ -994,7 +1000,7 @@ Incident endpoints
       system), the ``timestamp`` field is optional. It will default to
       the time the server received the event.
 
-.. _api-incident-event-types:
+.. _api-incident-event-types-v2:
 
       The valid ``type``\ s are:
 
@@ -1130,7 +1136,7 @@ Incident endpoints
 
 -  ``GET`` to ``/api/v2/incidents/mine/``: behaves similar to
    ``/api/v2/incidents/``, but will only show the incidents added by the
-   logged-in user, and no filtering on source or source type is
+   logged in user, and no filtering on source or source type is
    possible.
 
 
@@ -1141,7 +1147,7 @@ Notification profile endpoints
 
    -  ``GET``: returns the logged in user’s notification profiles
 
-   -  ``POST``: creates and returns a notification profile which is then
+   -  ``POST``: creates and returns a notification profile, which is then
       connected to the logged in user
 
       .. code-block:: json
@@ -1187,7 +1193,7 @@ Notification profile endpoints
 
    -  ``GET``: returns the logged in user’s destination-configs
 
-   -  ``POST``: creates and returns a destination-config which is then
+   -  ``POST``: creates and returns a destination-config, which is then
       connected to the logged in user
 
       .. code-block:: json
@@ -1239,7 +1245,7 @@ Notification profile endpoints
 -  ``/api/v2/notificationprofiles/timeslots/``:
 
    -  ``GET``: returns the logged in user’s time slots
-   -  ``POST``: creates and returns a time slot which is then connected
+   -  ``POST``: creates and returns a time slot, which is then connected
       to the logged in user
 
       .. code-block:: json
@@ -1312,7 +1318,7 @@ Notification profile endpoints
 -  ``/api/v2/notificationprofiles/filters/``:
 
    -  ``GET``: returns the logged in user’s filters
-   -  ``POST``: creates and returns a filter which is then connected to
+   -  ``POST``: creates and returns a filter, which is then connected to
       the logged in user
 
       .. code-block:: json

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -126,6 +126,18 @@ Incident endpoints
       ``acked=true|false``
         Fetch only acked (``true``) or unacked (``false``) incidents.
 
+      ``end_time__gte=end-time``
+        Fetch only incidents that ended on or later than (``end-time``).
+
+      ``end_time__isnull=true|false``
+        Fetch only stateless (``true``) or stateful (``false``) incidents.
+
+      ``end_time__lte=end-time``
+        Fetch only incidents that ended on or earlier than (``end-time``).
+
+      ``level__lte=1|2|3|4|5``
+        Fetch only incidents that have a level less or equal than (``level``).
+
       ``open=true|false``
         Fetch only open (``true``) or closed (``false``) incidents.
 
@@ -138,8 +150,21 @@ Incident endpoints
       ``source__name__in=NAME1[,NAME2,..]``
         Fetch only incidents with a source with name ``NAME1`` or ``NAME2`` or..
 
+      ``source__type__in=NAME1[,NAME2,..]``
+        Fetch only incidents with a source of a type with numeric id
+        ``ID1`` or ``ID2`` or..
+
       ``source_incident_id=ID``
         Fetch only incidents with ``source_incident_id`` set to ``ID``.
+
+      ``start_time__gte=start-time``
+        Fetch only incidents that started on or later than (``start-time``).
+
+      ``start_time__lte=start-time``
+        Fetch only incidents that started on or earlier than (``start-time``).
+
+      ``stateful=true|false``
+        Fetch only stateful (``true``) or stateless (``false``) incidents.
 
       ``ticket=true|false``
         Fetch only incidents with a ticket url (``true``) or without (``false``).
@@ -747,6 +772,18 @@ Incident endpoints
       ``acked=true|false``
         Fetch only acked (``true``) or unacked (``false``) incidents.
 
+      ``end_time__gte=end-time``
+        Fetch only incidents that ended on or later than (``end-time``).
+
+      ``end_time__isnull=true|false``
+        Fetch only stateless (``true``) or stateful (``false``) incidents.
+
+      ``end_time__lte=end-time``
+        Fetch only incidents that ended on or earlier than (``end-time``).
+
+      ``level__lte=1|2|3|4|5``
+        Fetch only incidents that have a level less or equal than (``level``).
+
       ``open=true|false``
         Fetch only open (``true``) or closed (``false``) incidents.
 
@@ -759,8 +796,21 @@ Incident endpoints
       ``source__name__in=NAME1[,NAME2,..]``
         Fetch only incidents with a source with name ``NAME1`` or ``NAME2`` or..
 
+      ``source__type__in=NAME1[,NAME2,..]``
+        Fetch only incidents with a source of a type with numeric id
+        ``ID1`` or ``ID2`` or..
+
       ``source_incident_id=ID``
         Fetch only incidents with ``source_incident_id`` set to ``ID``.
+
+      ``start_time__gte=start-time``
+        Fetch only incidents that started on or later than (``start-time``).
+
+      ``start_time__lte=start-time``
+        Fetch only incidents that started on or earlier than (``start-time``).
+
+      ``stateful=true|false``
+        Fetch only stateful (``true``) or stateless (``false``) incidents.
 
       ``ticket=true|false``
         Fetch only incidents with a ticket url (``true``) or without (``false``).

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -5,8 +5,8 @@ Authentication
 Username/password
 =================
 
-Argus supports API login with username and password, see Auth endpoints. This
-will yield a bearer token.
+Argus supports API login with username and password, see :ref:`api-auth-endpoints`.
+This will yield a bearer token.
 
 Also supported is logging in via browser to the admin, at ``/admin/``. This
 will set a session cookie.

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -34,7 +34,7 @@ Variant 2: Using a ``settings.py`` file
 =======================================
 
 A settings file is a regular python file.
-This allows the use more complex Python data types than environment variables.
+This allows the use of more complex Python data types than environment variables.
 A settings file will override any environment variables.
 
 ``argus.site.settings.dev`` and ``argus.site.settings.prod`` provide reasonable defaults
@@ -153,7 +153,7 @@ Notification settings
 
 .. setting:: MEDIA_PLUGINS
 
-In the settings file, there is also the variable :setting:`MEDIA_PLUGINS`, which holds the paths
+In the settings file there is also the variable :setting:`MEDIA_PLUGINS`, which holds the paths
 to the media classes and determines which notification plugins are available to send notifications by.
 
 Email is enabled by default and uses Django's email backend. There are multiple email
@@ -161,7 +161,7 @@ backends available that Argus' plugin supports. It is recommended to simply swit
 the email backend instead of replacing this plugin.
 
 SMS is disabled by default, since there is no standardized way of sending SMS messages.
-The only supported way at the moment is Uninett's internal email-to-SMS gateway.
+The only supported way at the moment is Sikt's internal email-to-SMS gateway.
 
 Enabling the email-to-SMS gateway
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -209,7 +209,7 @@ Realtime updates
 .. setting:: ARGUS_REDIS_SERVER
 
 The Argus API can notify the frontend about changes in the list of open
-incidents in realtime, using a websocket (implemented using Django
+incidents in realtime using a websocket (implemented using Django
 Channels). The realtime interface requires access to a Redis server for message
 passing.
 
@@ -234,7 +234,7 @@ Debugging settings
 .. setting:: TEMPLATE_DEBUG
 
 * :setting:`TEMPLATE_DEBUG` (optional) provides a convenient way to turn debugging on and off
-  for templates. If undefined, it will default to the value of :setting:`DEBUG`.
+  for templates. If undefined it will default to the value of :setting:`DEBUG`.
 
 Other settings
 --------------

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -218,6 +218,11 @@ different server, set the :setting:`ARGUS_REDIS_SERVER` environment variable, e.
 
   ARGUS_REDIS_SERVER=my-redis-server.example.org:6379
 
+Token settings
+------------------
+.. setting:: AUTH_TOKEN_EXPIRES_AFTER_DAYS
+* :setting:`AUTH_TOKEN_EXPIRES_AFTER_DAYS`  determines how long an authentication token is valid.
+    If undefined it will default to the value of 14 days.
 
 Debugging settings
 ------------------

--- a/docs/writing-glueservices.rst
+++ b/docs/writing-glueservices.rst
@@ -77,7 +77,7 @@ A glue service mainly concerns itself with:
 * Creating new incidents in Argus whenever a source system reports a problem.
 * Describing and tagging created incidents in an expressive, meaningful way for
   the users' consumption.
-* Closing existing Argus incidents it has created, when the source system
+* Closing existing Argus incidents it has created when the source system
   reports that a problem has been resolved.
 
 Creating a new incident
@@ -177,10 +177,10 @@ Closing incidents that have been resolved
 -----------------------------------------
 
 Once the source system reports an incident as resolved, the glue service
-needs to close the corresponding Argus incident. But, how can it keep track of
+needs to close the corresponding Argus incident. But how can it keep track of
 which Argus incident maps to the resolved problem?
 
-There could be a multitude of approaches to this, but in essence, there are two
+There could be a multitude of approaches to this, but in essence there are two
 distinct scenarios that come into play:
 
 - The source system already keeps track of its own state.
@@ -244,8 +244,8 @@ An incident with the id ``27`` can be closed by **POST**-ing a new event to
    }
 
 You should only ever use the ``END`` event type to indicate that the incident
-was resolved from the source system.  :ref:`The available types
-<api-incident-event-types>` are documented in the API endpoint documentation.
+was resolved from the source system.  The available types of events are
+documented in :ref:`api-incident-event-types`.
 
 
 On stateful incidents vs. stateless incidents
@@ -273,8 +273,8 @@ A stateless incident only represents something that happened at a single point
 in time, and otherwise has *no extent in time*. It can never be considered to
 be *open* nor *closed*.
 
-Whether stateless incidents are useful to you, depends on your needs and the
-source systems you want to integrate with Argud. Some source systems will
+Whether stateless incidents are useful to you depends on your needs and the
+source systems you want to integrate with Argus. Some source systems will
 generate alerts that are just one-off notifications, and are not considered to
 represent a state or an ongoing problem.
 
@@ -300,7 +300,7 @@ value ``infinity`` is used as the value of ``end_time``. This signals that the
 incident is expected to end at some unknown point in the future, and is quite
 useful when doing time-based queries on stateful incidents.
 
-Conversely, stateless incidents will never have a ``end_time`` value, which
+Conversely, stateless incidents will never have an ``end_time`` value, which
 means that these incidents explicitly set this to a ``null`` value.
 
 These special values are also exposed through the API.


### PR DESCRIPTION
1. Add AUTH_TOKEN_EXPIRES_AFTER_DAYS to docs.
2. Fix typos and add links to docs.
3. Add incident filtering parameters to docs.