### PR TITLE
Add estimated incidents count to pagination response

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -243,6 +243,9 @@ Incident endpoints
         The link to the previous page, according to the cursor, or
         ``null`` if on the first page.
 
+      ``estimated_count``
+        An estimation of the total number of incidents.
+
       ``results``
         An array of the resulting subset of rows, or an empty array if there are no
         results.

--- a/requirements-django32.txt
+++ b/requirements-django32.txt
@@ -64,6 +64,7 @@ django==3.2.13
     #   django-filter
     #   django-multiselectfield
     #   django-phonenumber-field
+    #   django-postgres-fuzzycount
     #   djangorestframework
     #   drf-rw-serializers
     #   drf-spectacular
@@ -74,6 +75,8 @@ django-filter==2.4.0
 django-multiselectfield==0.1.12
     # via -r requirements/base.txt
 django-phonenumber-field[phonenumberslite]==5.0.0
+    # via -r requirements/base.txt
+django-postgres-fuzzycount==0.1.7
     # via -r requirements/base.txt
 djangorestframework==3.12.4
     # via
@@ -163,6 +166,8 @@ social-auth-core==4.2.0
     #   -r requirements/base.txt
     #   python-dataporten-auth
     #   social-auth-app-django
+sphinx-me==0.3
+    # via django-postgres-fuzzycount
 sqlparse==0.4.2
     # via django
 text-unidecode==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ django==3.2.13
     #   django-filter
     #   django-multiselectfield
     #   django-phonenumber-field
+    #   django-postgres-fuzzycount
     #   djangorestframework
     #   drf-rw-serializers
     #   drf-spectacular
@@ -74,6 +75,8 @@ django-filter==2.4.0
 django-multiselectfield==0.1.12
     # via -r requirements/base.txt
 django-phonenumber-field[phonenumberslite]==5.0.0
+    # via -r requirements/base.txt
+django-postgres-fuzzycount==0.1.7
     # via -r requirements/base.txt
 djangorestframework==3.12.4
     # via
@@ -163,6 +166,8 @@ social-auth-core==4.2.0
     #   -r requirements/base.txt
     #   python-dataporten-auth
     #   social-auth-app-django
+sphinx-me==0.3
+    # via django-postgres-fuzzycount
 sqlparse==0.4.2
     # via django
 text-unidecode==1.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ pytz>=2021.1
 social-auth-app-django
 wheel>=0.24.0
 whitenoise
+django-postgres-fuzzycount
 
 # websockets
 channels>=3,<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ install_requires =
     channels>=3,<4
     channels-redis>=3.2.0
     aioredis
+    django-postgres-fuzzycount
 
 [options.extras_require]
 docs = sphinx>=2.2.0

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -5,6 +5,8 @@ from operator import and_
 from random import randint
 from urllib.parse import urljoin
 
+from fuzzycount import FuzzyCountManager
+
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db import models, transaction
@@ -232,6 +234,7 @@ class Incident(models.Model):
     search_text = models.TextField(blank=True, default="", verbose_name="Search Text")
 
     objects = IncidentQuerySet.as_manager()
+    fuzzycount_manager = FuzzyCountManager()
 
     class Meta:
         constraints = [

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -50,6 +50,16 @@ class IncidentPagination(CursorPagination):
     ordering = "-start_time"
     page_size_query_param = "page_size"
 
+    def get_paginated_response(self, data):
+        return Response(
+            {
+                "next": self.get_next_link(),
+                "previous": self.get_previous_link(),
+                "estimated_count": Incident.fuzzycount_manager.count(),
+                "results": data,
+            }
+        )
+
 
 class EventPagination(CursorPagination):
     ordering = "-timestamp"


### PR DESCRIPTION
Fixes #157 

Related to #163 

Adds method of getting estimated number of incidents via `django-postgres-fuzzycount`. Also adds this value to the response for incident pagination requests