### PR TITLE
Use factories for notifprofile tests

### DIFF
--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -11,6 +11,7 @@ __all__ = [
     "SourceSystemFactory",
     "TagFactory",
     "IncidentFactory",
+    "IncidentTagRelationFactory",
     "StatefulIncidentFactory",
     "StatelessIncidentFactory",
 ]
@@ -64,3 +65,13 @@ class StatefulIncidentFactory(IncidentFactory):
 
 class StatelessIncidentFactory(IncidentFactory):
     end_time = None
+
+
+class IncidentTagRelationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.IncidentTagRelation
+
+    tag = factory.SubFactory(TagFactory)
+    incident = factory.SubFactory(IncidentFactory)
+    added_by = factory.SubFactory(SourceUserFactory)
+    added_time = factory.Faker("date_time_between", start_date="-1d", end_date="+1d", tzinfo=pytz.UTC)

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -61,15 +61,5 @@ class IncidentFactory(factory.django.DjangoModelFactory):
 StatefulIncidentFactory = IncidentFactory
 
 
-class StatelessIncidentFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = models.Incident
-
-    start_time = factory.Faker("date_time_between", start_date="-1d", end_date="+1d", tzinfo=pytz.UTC)
+class StatelessIncidentFactory(IncidentFactory):
     end_time = None
-    source = factory.SubFactory(SourceSystemFactory)
-    source_incident_id = factory.Faker("md5")
-    details_url = factory.Faker("uri")
-    description = factory.Faker("sentence")
-    level = factory.fuzzy.FuzzyChoice(models.Incident.LEVELS)  # Random valid level
-    ticket_url = factory.Faker("uri")

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -58,7 +58,8 @@ class IncidentFactory(factory.django.DjangoModelFactory):
     ticket_url = factory.Faker("uri")
 
 
-StatefulIncidentFactory = IncidentFactory
+class StatefulIncidentFactory(IncidentFactory):
+    pass
 
 
 class StatelessIncidentFactory(IncidentFactory):

--- a/tests/notificationprofile/V1/test_views.py
+++ b/tests/notificationprofile/V1/test_views.py
@@ -6,11 +6,12 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APITestCase
 
 from argus.incident.serializers import IncidentSerializer
-from argus.notificationprofile.models import (
-    Filter,
-    NotificationProfile,
-    Timeslot,
+from argus.notificationprofile.factories import (
+    TimeslotFactory,
+    FilterFactory,
+    NotificationProfileFactory,
 )
+from argus.notificationprofile.models import NotificationProfile
 from argus.util.testing import disconnect_signals, connect_signals
 
 from .. import IncidentAPITestCaseHelper
@@ -25,14 +26,14 @@ class ViewTests(APITestCase, IncidentAPITestCaseHelper):
         incident1_json = IncidentSerializer([self.incident1], many=True).data
         self.incident1_json = JSONRenderer().render(incident1_json)
 
-        self.timeslot1 = Timeslot.objects.create(user=self.user1, name="Never")
-        self.timeslot2 = Timeslot.objects.create(user=self.user1, name="Never 2: Ever-expanding Void")
-        filter1 = Filter.objects.create(
+        self.timeslot1 = TimeslotFactory(user=self.user1, name="Never")
+        self.timeslot2 = TimeslotFactory(user=self.user1, name="Never 2: Ever-expanding Void")
+        filter1 = FilterFactory(
             user=self.user1,
             name="Critical incidents",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}]}}',
         )
-        self.notification_profile1 = NotificationProfile.objects.create(user=self.user1, timeslot=self.timeslot1)
+        self.notification_profile1 = NotificationProfileFactory(user=self.user1, timeslot=self.timeslot1)
         self.notification_profile1.filters.add(filter1)
         self.notification_profile1.destinations.set(self.user1.destinations.all())
         self.media = []

--- a/tests/notificationprofile/__init__.py
+++ b/tests/notificationprofile/__init__.py
@@ -1,14 +1,11 @@
-from django.utils import timezone
-
-from argus.auth.models import User
-from argus.incident.models import (
-    Incident,
-    IncidentTagRelation,
-    SourceSystem,
-    SourceSystemType,
-    Tag,
+from argus.incident.factories import (
+    IncidentTagRelationFactory,
+    StatelessIncidentFactory,
+    SourceSystemTypeFactory,
+    SourceSystemFactory,
+    SourceUserFactory,
+    TagFactory,
 )
-from argus.util.utils import duplicate
 
 from ..incident import IncidentBasedAPITestCaseHelper
 
@@ -16,26 +13,18 @@ from ..incident import IncidentBasedAPITestCaseHelper
 class IncidentAPITestCaseHelper(IncidentBasedAPITestCaseHelper):
     def init_test_objects(self):
         super().init_test_objects()
+        self.source_type2 = SourceSystemTypeFactory(name="type2")
+        self.source2_user = SourceUserFactory(username="system_2")
+        self.source2 = SourceSystemFactory(name="System 2", type=self.source_type2, user=self.source2_user)
 
-        self.source_type2 = SourceSystemType.objects.create(name="type2")
-        self.source2 = SourceSystem.objects.create(
-            name="System 2",
-            type=self.source_type2,
-            user=User.objects.create(username="system_2"),
-        )
+        self.incident1 = StatelessIncidentFactory(source=self.source1)
+        self.incident2 = StatelessIncidentFactory(source=self.source2)
 
-        self.incident1 = Incident.objects.create(
-            start_time=timezone.now(),
-            source=self.source1,
-            source_incident_id="123",
-        )
-        self.incident2 = duplicate(self.incident1, source=self.source2)
+        self.tag1 = TagFactory(key="object", value="1")
+        self.tag2 = TagFactory(key="object", value="2")
+        self.tag3 = TagFactory(key="location", value="Oslo")
 
-        self.tag1 = Tag.objects.create_from_tag("object=1")
-        self.tag2 = Tag.objects.create_from_tag("object=2")
-        self.tag3 = Tag.objects.create_from_tag("location=Oslo")
-
-        IncidentTagRelation.objects.create(tag=self.tag1, incident=self.incident1, added_by=self.user1)
-        IncidentTagRelation.objects.create(tag=self.tag3, incident=self.incident1, added_by=self.user1)
-        IncidentTagRelation.objects.create(tag=self.tag2, incident=self.incident2, added_by=self.user1)
-        IncidentTagRelation.objects.create(tag=self.tag3, incident=self.incident2, added_by=self.user1)
+        IncidentTagRelationFactory(tag=self.tag1, incident=self.incident1, added_by=self.user1)
+        IncidentTagRelationFactory(tag=self.tag3, incident=self.incident1, added_by=self.user1)
+        IncidentTagRelationFactory(tag=self.tag2, incident=self.incident2, added_by=self.user1)
+        IncidentTagRelationFactory(tag=self.tag3, incident=self.incident2, added_by=self.user1)

--- a/tests/notificationprofile/test_models.py
+++ b/tests/notificationprofile/test_models.py
@@ -271,10 +271,10 @@ class ModelTests(TestCase, IncidentAPITestCaseHelper):
         )
         self.assertEqual(set(filter2.filtered_incidents), {self.incident2})
         filter3 = FilterFactory(user=self.user1, name="Filter3", filter_string=f'{{"tags": ["{self.tag1}"]}}')
-        self.assertEqual(set(filter1.filtered_incidents), {self.incident1})
+        self.assertEqual(set(filter3.filtered_incidents), {self.incident1})
         filter4 = FilterFactory(
             user=self.user1,
             name="Filter4",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}], "tags": ["{self.tag1}"]}}',
         )
-        self.assertEqual(set(filter1.filtered_incidents), {self.incident1})
+        self.assertEqual(set(filter4.filtered_incidents), {self.incident1})

--- a/tests/notificationprofile/test_models.py
+++ b/tests/notificationprofile/test_models.py
@@ -10,9 +10,12 @@ from django.utils.timezone import make_aware
 from argus.incident.models import Incident
 from argus.notificationprofile.models import (
     FilterWrapper,
-    Filter,
     TimeRecurrence,
-    Timeslot,
+)
+from argus.notificationprofile.factories import (
+    TimeslotFactory,
+    TimeRecurrenceFactory,
+    FilterFactory,
 )
 from argus.util.testing import disconnect_signals, connect_signals
 
@@ -154,20 +157,20 @@ class ModelTests(TestCase, IncidentAPITestCaseHelper):
         super().init_test_objects()
         self.monday_datetime = make_aware(parse_datetime("2019-11-25 00:00"))
 
-        self.timeslot1 = Timeslot.objects.create(user=self.user1, name="Test")
-        self.recurrence1 = TimeRecurrence.objects.create(
+        self.timeslot1 = TimeslotFactory(user=self.user1, name="Test")
+        self.recurrence1 = TimeRecurrenceFactory(
             timeslot=self.timeslot1,
             days={TimeRecurrence.Day.MONDAY},
             start=parse_time("00:30:00"),
             end=parse_time("00:30:01"),
         )
-        self.recurrence2 = TimeRecurrence.objects.create(
+        self.recurrence2 = TimeRecurrenceFactory(
             timeslot=self.timeslot1,
             days={TimeRecurrence.Day.MONDAY},
             start=parse_time("00:30:03"),
             end=parse_time("00:31"),
         )
-        self.recurrence_all_day = TimeRecurrence.objects.create(
+        self.recurrence_all_day = TimeRecurrenceFactory(
             timeslot=self.timeslot1,
             days={TimeRecurrence.Day.TUESDAY},
             start=TimeRecurrence.DAY_START,
@@ -194,17 +197,17 @@ class ModelTests(TestCase, IncidentAPITestCaseHelper):
         self.assertTrue(self.timeslot1.timestamp_is_within_time_recurrences(set_time(self.monday_datetime, "00:30:03")))
 
     def test_source_fits(self):
-        filter0 = Filter.objects.create(
+        filter0 = FilterFactory(
             user=self.user1,
             name="Filter no source",
             filter_string='{"sourceSystemIds": []}',
         )
-        filter1 = Filter.objects.create(
+        filter1 = FilterFactory(
             user=self.user1,
             name="Filter1",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}]}}',
         )
-        filter2 = Filter.objects.create(
+        filter2 = FilterFactory(
             user=self.user1,
             name="Filter2",
             filter_string=f'{{"sourceSystemIds": [{self.source2.pk}]}}',
@@ -215,32 +218,32 @@ class ModelTests(TestCase, IncidentAPITestCaseHelper):
         self.assertFalse(filter2.source_system_fits(self.incident1))
 
     def test_tags_fit(self):
-        filter0 = Filter.objects.create(user=self.user1, name="Filter no tags", filter_string='{"tags": []}')
-        filter1 = Filter.objects.create(user=self.user1, name="Filter1", filter_string=f'{{"tags": ["{self.tag1}"]}}')
-        filter2 = Filter.objects.create(user=self.user1, name="Filter2", filter_string=f'{{"tags": ["{self.tag2}"]}}')
+        filter0 = FilterFactory(user=self.user1, name="Filter no tags", filter_string='{"tags": []}')
+        filter1 = FilterFactory(user=self.user1, name="Filter1", filter_string=f'{{"tags": ["{self.tag1}"]}}')
+        filter2 = FilterFactory(user=self.user1, name="Filter2", filter_string=f'{{"tags": ["{self.tag2}"]}}')
 
         self.assertEqual(filter0.tags_fit(self.incident1), None)
         self.assertTrue(filter1.tags_fit(self.incident1))
         self.assertFalse(filter2.tags_fit(self.incident1))
 
     def test_incident_fits(self):
-        filter0 = Filter.objects.create(
+        filter0 = FilterFactory(
             user=self.user1,
             name="Filter empty",
             filter_string='{"sourceSystemIds": [], "tags": []}',
         )
         self.assertFalse(filter0.incident_fits(self.incident1))
-        filter1 = Filter.objects.create(
+        filter1 = FilterFactory(
             user=self.user1,
             name="Filter1",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}]}}',
         )
         self.assertTrue(filter1.incident_fits(self.incident1))
         self.assertFalse(filter1.incident_fits(self.incident2))
-        filter3 = Filter.objects.create(user=self.user1, name="Filter3", filter_string=f'{{"tags": ["{self.tag1}"]}}')
+        filter3 = FilterFactory(user=self.user1, name="Filter3", filter_string=f'{{"tags": ["{self.tag1}"]}}')
         self.assertTrue(filter3.incident_fits(self.incident1))
         self.assertFalse(filter3.incident_fits(self.incident2))
-        filter4 = Filter.objects.create(
+        filter4 = FilterFactory(
             user=self.user1,
             name="Filter4",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}], "tags": ["{self.tag1}"]}}',
@@ -249,27 +252,27 @@ class ModelTests(TestCase, IncidentAPITestCaseHelper):
         self.assertFalse(filter4.incident_fits(self.incident2))
 
     def test_filtered_incidents(self):
-        filter0 = Filter.objects.create(
+        filter0 = FilterFactory(
             user=self.user1,
             name="Filter empty",
             filter_string='{"sourceSystemIds": [], "tags": []}',
         )
         self.assertEqual(set(filter0.filtered_incidents), set())
-        filter1 = Filter.objects.create(
+        filter1 = FilterFactory(
             user=self.user1,
             name="Filter1",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}]}}',
         )
         self.assertEqual(set(filter1.filtered_incidents), {self.incident1})
-        filter2 = Filter.objects.create(
+        filter2 = FilterFactory(
             user=self.user1,
             name="Filter2",
             filter_string=f'{{"sourceSystemIds": [{self.source2.pk}]}}',
         )
         self.assertEqual(set(filter2.filtered_incidents), {self.incident2})
-        filter3 = Filter.objects.create(user=self.user1, name="Filter3", filter_string=f'{{"tags": ["{self.tag1}"]}}')
+        filter3 = FilterFactory(user=self.user1, name="Filter3", filter_string=f'{{"tags": ["{self.tag1}"]}}')
         self.assertEqual(set(filter1.filtered_incidents), {self.incident1})
-        filter4 = Filter.objects.create(
+        filter4 = FilterFactory(
             user=self.user1,
             name="Filter4",
             filter_string=f'{{"sourceSystemIds": [{self.source1.pk}], "tags": ["{self.tag1}"]}}',


### PR DESCRIPTION
Fixes #416 

Replaces lines using objects.create with factories.
Fixes a test.
Makes some changes to how incident factories are defined.


