### PR TITLE
Add tests for filtering on open and stateful for api v1

### DIFF
--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -138,9 +138,8 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.add_stateless_incident()
         response = self.client.get("/api/v1/incidents/?stateful=true")
         self.assertEqual(len(response.data["results"]), 2)
-        response_pks = [result["pk"] for result in response.data["results"]]
-        self.assertTrue(open_pk in response_pks)
-        self.assertTrue(closed_pk in response_pks)
+        response_pks = set([result["pk"] for result in response.data["results"]])
+        self.assertEqual(response_pks, set([open_pk, closed_pk]))
 
     def test_open_true_and_stateful_true_returns_only_open_incidents(self):
         open_pk = self.add_open_incident()

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -123,27 +123,11 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], open_pk)
 
-    def test_open_true_and_stateful_true_returns_only_open_incidents(self):
-        open_pk = self.add_open_incident()
-        self.add_closed_incident()
-        self.add_stateless_incident()
-        response = self.client.get("/api/v1/incidents/?open=true&stateful=true")
-        self.assertEqual(len(response.data["results"]), 1)
-        self.assertEqual(response.data["results"][0]["pk"], open_pk)
-
     def test_open_false_returns_only_closed_incidents(self):
         self.add_open_incident()
         closed_pk = self.add_closed_incident()
         self.add_stateless_incident()
         response = self.client.get("/api/v1/incidents/?open=false")
-        self.assertEqual(len(response.data["results"]), 1)
-        self.assertEqual(response.data["results"][0]["pk"], closed_pk)
-
-    def test_open_false_and_stateful_true_returns_only_closed_incidents(self):
-        self.add_open_incident()
-        closed_pk = self.add_closed_incident()
-        self.add_stateless_incident()
-        response = self.client.get("/api/v1/incidents/?open=false&stateful=true")
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], closed_pk)
 
@@ -155,14 +139,30 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], stateless_pk)
 
-    def test_stateful_false_and_open_true_returns_no_incidents(self):
+    def test_open_true_and_stateful_true_returns_only_open_incidents(self):
+        open_pk = self.add_open_incident()
+        self.add_closed_incident()
+        self.add_stateless_incident()
+        response = self.client.get("/api/v1/incidents/?open=true&stateful=true")
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["pk"], open_pk)
+
+    def test_open_true_and_stateful_false_returns_no_incidents(self):
         self.add_open_incident()
         self.add_closed_incident()
         self.add_stateless_incident()
         response = self.client.get("/api/v1/incidents/?stateful=false&open=true")
         self.assertEqual(len(response.data["results"]), 0, msg=response.data)
 
-    def test_stateful_false_and_open_false_returns_no_incidents(self):
+    def test_open_false_and_stateful_true_returns_only_closed_incidents(self):
+        self.add_open_incident()
+        closed_pk = self.add_closed_incident()
+        self.add_stateless_incident()
+        response = self.client.get("/api/v1/incidents/?open=false&stateful=true")
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["pk"], closed_pk)
+
+    def test_open_false_and_stateful_false_returns_no_incidents(self):
         self.add_open_incident()
         self.add_closed_incident()
         self.add_stateless_incident()

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -5,7 +5,12 @@ from rest_framework import serializers, status, versioning
 from rest_framework.test import APITestCase
 
 from argus.auth.factories import SourceUserFactory
-from argus.incident.factories import SourceSystemTypeFactory, SourceSystemFactory, StatefulIncidentFactory
+from argus.incident.factories import (
+    SourceSystemTypeFactory,
+    SourceSystemFactory,
+    StatefulIncidentFactory,
+    StatelessIncidentFactory,
+)
 from argus.incident.models import Event, Incident, Tag
 from argus.incident.views import EventViewSet
 from argus.util.testing import disconnect_signals, connect_signals
@@ -49,26 +54,14 @@ class IncidentViewSetV1TestCase(APITestCase):
     def tearDownClass(cls):
         connect_signals()
 
-    def add_incident(self, description, end_time):
-        data = {
-            "start_time": "2022-05-24T13:07:29.254Z",
-            "end_time": end_time,
-            "description": description,
-            "level": 1,
-            "tags": [{"tag": "a=b"}],
-        }
-        response = self.client.post("/api/v1/incidents/", data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        return response.data["pk"]
-
     def add_open_incident(self, description="open_incident"):
-        return self.add_incident(description=description, end_time=INFINITY_REPR)
+        return StatefulIncidentFactory(description=description).pk
 
     def add_closed_incident(self, description="closed_incident"):
-        return self.add_incident(description=description, end_time="2022-05-24T13:07:29.254Z")
+        return StatefulIncidentFactory(description=description, end_time="2022-05-24T13:07:29.254Z").pk
 
     def add_stateless_incident(self, description="stateless_incident"):
-        return self.add_incident(description=description, end_time=None)
+        return StatelessIncidentFactory(description=description).pk
 
     def test_no_incidents_returns_empty_list(self):
         response = self.client.get("/api/v1/incidents/")

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -39,7 +39,7 @@ class EventViewSetTestCase(TestCase):
             view.validate_event_type_for_incident(Event.Type.ACKNOWLEDGE, incident)
 
 
-class IncidentViewSetV1TestCase(APITestCase):
+class IncidentAPITestCase(APITestCase):
     @classmethod
     def setUpClass(cls):
         disconnect_signals()
@@ -54,6 +54,8 @@ class IncidentViewSetV1TestCase(APITestCase):
     def tearDownClass(cls):
         connect_signals()
 
+
+class IncidentViewSetV1TestCase(IncidentAPITestCase):
     def add_closed_incident(self, description="closed_incident"):
         return StatefulIncidentFactory(
             description=description, start_time="2022-05-23T13:07:29.254Z", end_time="2022-05-24T13:07:29.254Z"
@@ -105,25 +107,14 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(Incident.objects.get(pk=incident_pk).level, 2)
 
 
-class IncidentFilterByOpenAndStatefulV1TestCase(APITestCase):
-    @classmethod
-    def setUpClass(cls):
-        disconnect_signals()
-        source_type = SourceSystemTypeFactory()
-        cls.user = SourceUserFactory()
-        cls.source = SourceSystemFactory(type=source_type, user=cls.user)
-
+class IncidentFilterByOpenAndStatefulV1TestCase(IncidentAPITestCase):
     def setUp(self):
-        self.client.force_authenticate(user=self.user)
+        super().setUp()
         self.open_pk = StatefulIncidentFactory().pk
         self.closed_pk = StatefulIncidentFactory(
             start_time="2022-05-23T13:07:29.254Z", end_time="2022-05-24T13:07:29.254Z"
         ).pk
         self.stateless_pk = StatelessIncidentFactory().pk
-
-    @classmethod
-    def tearDownClass(cls):
-        connect_signals()
 
     def test_open_true_returns_only_open_incidents(self):
         response = self.client.get("/api/v1/incidents/?open=true")
@@ -165,21 +156,7 @@ class IncidentFilterByOpenAndStatefulV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 0, msg=response.data)
 
 
-class IncidentViewSetTestCase(APITestCase):
-    @classmethod
-    def setUpClass(cls):
-        disconnect_signals()
-        source_type = SourceSystemTypeFactory()
-        cls.user = SourceUserFactory()
-        cls.source = SourceSystemFactory(type=source_type, user=cls.user)
-
-    def setUp(self):
-        self.client.force_authenticate(user=self.user)
-
-    @classmethod
-    def tearDownClass(cls):
-        connect_signals()
-
+class IncidentViewSetTestCase(IncidentAPITestCase):
     def add_incident(self, description="incident"):
         data = {
             "start_time": "2021-08-04T09:13:55.908Z",

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -58,7 +58,7 @@ class IncidentViewSetV1TestCase(APITestCase):
         return StatefulIncidentFactory(description=description).pk
 
     def add_closed_incident(self, description="closed_incident"):
-        return StatefulIncidentFactory(description=description, end_time="2022-05-24T13:07:29.254Z").pk
+        return StatefulIncidentFactory(description=description, start_time="2022-05-23T13:07:29.254Z", end_time="2022-05-24T13:07:29.254Z").pk
 
     def add_stateless_incident(self, description="stateless_incident"):
         return StatelessIncidentFactory(description=description).pk

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -58,7 +58,7 @@ class IncidentViewSetV1TestCase(APITestCase):
             "tags": [{"tag": "a=b"}],
         }
         response = self.client.post("/api/v1/incidents/", data, format="json")
-        self.assertEqual(response.status_code, 201)  # Created
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         return response.data["pk"]
 
     def add_open_incident(self, description="open_incident"):
@@ -73,7 +73,7 @@ class IncidentViewSetV1TestCase(APITestCase):
     def test_no_incidents_returns_empty_list(self):
         response = self.client.get("/api/v1/incidents/")
         self.assertFalse(Incident.objects.exists())
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Paging, so check "results"
         self.assertEqual(response.data["results"], [])
 
@@ -90,7 +90,7 @@ class IncidentViewSetV1TestCase(APITestCase):
             "tags": [{"tag": "a=b"}],
         }
         response = self.client.post("/api/v1/incidents/", data, format="json")
-        self.assertEqual(response.status_code, 201)  # Created
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         # Check that we have made the correct Incident
         self.assertEqual(response.data["description"], data["description"])
         self.assertTrue(Incident.objects.exists())
@@ -204,13 +204,13 @@ class IncidentViewSetTestCase(APITestCase):
             "tags": [{"tag": "a=b"}],
         }
         response = self.client.post("/api/v2/incidents/", data, format="json")
-        self.assertEqual(response.status_code, 201)  # Created
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         return response.data["pk"]
 
     def add_event(self, incident_pk, description="event"):
         event_data = {"timestamp": "2021-08-04T09:14:55.908Z", "type": "OTH", "description": description}
         response = self.client.post(f"/api/v2/incidents/{incident_pk}/events/", event_data, format="json")
-        self.assertEqual(response.status_code, 201)  # Created
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_incident_search_existing_incident_description(self):
         pk = self.add_incident("incident1")

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -115,7 +115,7 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Incident.objects.get(pk=incident_pk).level, 2)
 
-    def test_open_equals_true_returns_only_open_incidents(self):
+    def test_open_true_returns_only_open_incidents(self):
         open_pk = self.add_open_incident()
         self.add_closed_incident()
         self.add_stateless_incident()
@@ -123,7 +123,7 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], open_pk)
 
-    def test_open_equals_true_and_stateful_equals_true_returns_only_open_incidents(self):
+    def test_open_true_and_stateful_true_returns_only_open_incidents(self):
         open_pk = self.add_open_incident()
         self.add_closed_incident()
         self.add_stateless_incident()
@@ -131,7 +131,7 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], open_pk)
 
-    def test_open_equals_false_returns_only_closed_incidents(self):
+    def test_open_false_returns_only_closed_incidents(self):
         self.add_open_incident()
         closed_pk = self.add_closed_incident()
         self.add_stateless_incident()
@@ -139,7 +139,7 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], closed_pk)
 
-    def test_open_equals_false_and_stateful_equals_true_returns_only_closed_incidents(self):
+    def test_open_false_and_stateful_true_returns_only_closed_incidents(self):
         self.add_open_incident()
         closed_pk = self.add_closed_incident()
         self.add_stateless_incident()
@@ -147,7 +147,7 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], closed_pk)
 
-    def test_stateful_equals_false_returns_only_stateless_incidents(self):
+    def test_stateful_false_returns_only_stateless_incidents(self):
         self.add_open_incident()
         self.add_closed_incident()
         stateless_pk = self.add_stateless_incident()
@@ -155,14 +155,14 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], stateless_pk)
 
-    def test_stateful_equals_false_and_open_equals_true_returns_no_incidents(self):
+    def test_stateful_false_and_open_true_returns_no_incidents(self):
         self.add_open_incident()
         self.add_closed_incident()
         self.add_stateless_incident()
         response = self.client.get("/api/v1/incidents/?stateful=false&open=true")
         self.assertEqual(len(response.data["results"]), 0, msg=response.data)
 
-    def test_stateful_equals_false_and_open_equals_false_returns_no_incidents(self):
+    def test_stateful_false_and_open_false_returns_no_incidents(self):
         self.add_open_incident()
         self.add_closed_incident()
         self.add_stateless_incident()

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -14,7 +14,6 @@ from argus.incident.factories import (
 from argus.incident.models import Event, Incident, Tag
 from argus.incident.views import EventViewSet
 from argus.util.testing import disconnect_signals, connect_signals
-from argus.util.datetime_utils import INFINITY_REPR
 
 
 class EventViewSetTestCase(TestCase):

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -139,6 +139,16 @@ class IncidentViewSetV1TestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["pk"], stateless_pk)
 
+    def test_stateful_true_returns_only_stateful_incidents(self):
+        open_pk = self.add_open_incident()
+        closed_pk = self.add_closed_incident()
+        self.add_stateless_incident()
+        response = self.client.get("/api/v1/incidents/?stateful=true")
+        self.assertEqual(len(response.data["results"]), 2)
+        response_pks = [result["pk"] for result in response.data["results"]]
+        self.assertTrue(open_pk in response_pks)
+        self.assertTrue(closed_pk in response_pks)
+
     def test_open_true_and_stateful_true_returns_only_open_incidents(self):
         open_pk = self.add_open_incident()
         self.add_closed_incident()


### PR DESCRIPTION
Fixes #410 

Checks that API returns the correct incidents when filtering on `open` and `stateful`