### PR TITLE
Replace wildcard imports

### DIFF
--- a/src/argus/auth/factories.py
+++ b/src/argus/auth/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from .models import *
+from .models import User
 
 __all__ = [
     "PersonUserFactory",

--- a/tests/incident/test_filters.py
+++ b/tests/incident/test_filters.py
@@ -7,7 +7,13 @@ from django.utils.timezone import is_aware, make_aware
 
 from argus.auth.factories import SourceUserFactory
 from argus.util.testing import disconnect_signals, connect_signals
-from argus.incident.factories import *
+from argus.incident.factories import (
+    SourceSystemFactory,
+    SourceSystemTypeFactory,
+    StatefulIncidentFactory,
+    StatelessIncidentFactory,
+    TagFactory,
+)
 from argus.incident.models import Incident, IncidentTagRelation
 from argus.incident.views import IncidentFilter
 


### PR DESCRIPTION
In the Argus Security Code Audit Report it was suggested to not use wildcard imports. 
This commit replaces some of the occurring wildcard imports. 
The wildcard imports in the settings were not touched.