### PR TITLE
Change view permission of media

### DIFF
--- a/src/argus/notificationprofile/views.py
+++ b/src/argus/notificationprofile/views.py
@@ -113,7 +113,7 @@ class SchemaView(DetailView):
 
 
 class MediaViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated, IsOwner]
+    permission_classes = [IsAuthenticated]
     serializer_class = MediaSerializer
     queryset = Media.objects.none()
     http_method_names = ["get", "head"]


### PR DESCRIPTION
When writing tests I realized that it is impossible to get a specific medium by its slug since the permission was `IsOwner`, which resulted in an error since media has no owner. 

This PR resolves that problem.