### PR TITLE
Clean notification profile signal tests

### DIFF
--- a/tests/notificationprofile/test_signals.py
+++ b/tests/notificationprofile/test_signals.py
@@ -23,7 +23,7 @@ class SignalTests(APITestCase):
         self.assertTrue(default_destination.settings["synced"])
 
     def test_default_email_destination_should_not_be_created_if_user_has_no_email(self):
-        self.assertFalse(self.user2.destinations.first())
+        self.assertFalse(self.user2.destinations.exists())
 
     def test_default_email_destination_should_be_added_if_email_is_added_to_user(self):
         self.user2.email = self.user2.username

--- a/tests/notificationprofile/test_signals.py
+++ b/tests/notificationprofile/test_signals.py
@@ -17,6 +17,7 @@ class SignalTests(APITestCase):
         connect_signals()
 
     def test_default_email_destination_should_be_created_if_user_has_email(self):
+        # PersonUserFactory creates user with email address
         default_destination = self.user1.destinations.first()
         self.assertTrue(default_destination)
         self.assertTrue(default_destination.settings["synced"])


### PR DESCRIPTION
Replace `first` with `exists` in query and add clarifying comment.