### PR TITLE
Improve old notificationprofile tests

### DIFF
--- a/tests/notificationprofile/V1/test_switch_phone_numbers.py
+++ b/tests/notificationprofile/V1/test_switch_phone_numbers.py
@@ -24,9 +24,6 @@ class SwitchPhoneNumberTests(TestCase):
         self.new_phone_number = PhoneNumber.from_string("+4747474747")
 
     def test_switch_phone_number(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
-
         _switch_phone_numbers(self.destination, self.new_phone_number, self.profile)
 
         self.assertEqual(

--- a/tests/notificationprofile/test_serializers.py
+++ b/tests/notificationprofile/test_serializers.py
@@ -262,8 +262,6 @@ class DestinationConfigSerializerTests(TestCase):
         self.assertEqual(obj.settings["email_address"], "new.email@example.com")
 
     def test_validate_new_sms_destination(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         request = self.request_factory.post("/")
         request.user = self.user
         data = {
@@ -279,8 +277,6 @@ class DestinationConfigSerializerTests(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
     def test_validate_new_sms_destination_with_empty_settings(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         request = self.request_factory.post("/")
         request.user = self.user
         data = {
@@ -295,8 +291,6 @@ class DestinationConfigSerializerTests(TestCase):
         self.assertTrue(serializer.errors)
 
     def test_validate_new_sms_destination_with_invalid_settings(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         request = self.request_factory.post("/")
         request.user = self.user
         data = {
@@ -311,8 +305,6 @@ class DestinationConfigSerializerTests(TestCase):
         self.assertTrue(serializer.errors)
 
     def test_validate_new_sms_destination_with_invalid_phone_number(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         request = self.request_factory.post("/")
         request.user = self.user
         data = {
@@ -327,8 +319,6 @@ class DestinationConfigSerializerTests(TestCase):
         self.assertTrue(serializer.errors)
 
     def test_validate_new_sms_destination_with_additional_settings(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         request = self.request_factory.post("/")
         request.user = self.user
         data = {
@@ -351,8 +341,6 @@ class DestinationConfigSerializerTests(TestCase):
         )
 
     def test_create_new_sms_destination(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         request = self.request_factory.post("/")
         request.user = self.user
         validated_data = {
@@ -374,8 +362,6 @@ class DestinationConfigSerializerTests(TestCase):
         )
 
     def test_update_existing_sms_destination(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
         destination = DestinationConfigFactory(
             user=self.user,
             media_id="sms",

--- a/tests/notificationprofile/test_views.py
+++ b/tests/notificationprofile/test_views.py
@@ -29,9 +29,6 @@ class ViewTests(APITestCase, IncidentAPITestCaseHelper):
         disconnect_signals()
         super().init_test_objects()
 
-        incident1_json = IncidentSerializer([self.incident1], many=True).data
-        self.incident1_json = JSONRenderer().render(incident1_json)
-
         self.timeslot1 = TimeslotFactory(user=self.user1, name="Never")
         self.timeslot2 = TimeslotFactory(user=self.user1, name="Never 2: Ever-expanding Void")
         filter1 = FilterFactory(
@@ -58,12 +55,13 @@ class ViewTests(APITestCase, IncidentAPITestCaseHelper):
     def teardown(self):
         connect_signals()
 
-    def test_incidents_filtered_by_notification_profile_view(self):
+    def test_can_get_all_incidents_of_notification_profile(self):
         response = self.user1_rest_client.get(
-            reverse("v2:notification-profile:notificationprofile-incidents", args=[self.notification_profile1.pk])
+            path=f"/api/v2/notificationprofiles/{self.notification_profile1.pk}/incidents/"
         )
-        response.render()
-        self.assertEqual(response.content, self.incident1_json)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["pk"], self.incident1.pk)
 
     def test_notification_profile_can_properly_change_timeslot(self):
         profile1_pk = self.notification_profile1.pk

--- a/tests/notificationprofile/test_views.py
+++ b/tests/notificationprofile/test_views.py
@@ -90,9 +90,6 @@ class ViewTests(APITestCase, IncidentAPITestCaseHelper):
         self.assertEqual(self.user1_rest_client.get(new_profile1_path).status_code, status.HTTP_200_OK)
 
     def test_can_delete_sms_destination(self):
-        if not "sms" in MEDIA_CLASSES_DICT.keys():
-            self.skipTest("No sms plugin available")
-
         self.assertTrue(DestinationConfig.objects.filter(media_id="sms").exists())
         response = self.user1_rest_client.delete(
             path=f"/api/v2/notificationprofiles/destinations/{self.sms_destination.pk}/"


### PR DESCRIPTION
I noticed that #439 changed a lot of the existing tests and thought it might be better to split it up into two PRs.

- simplify incidents of notification profile test
- move destination creation to setup
- simplify deletion tests