### PR TITLE
Create change events on incident changes

### DIFF
--- a/src/argus/incident/apps.py
+++ b/src/argus/incident/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 
 
 class IncidentConfig(AppConfig):
@@ -7,9 +7,18 @@ class IncidentConfig(AppConfig):
     label = "argus_incident"
 
     def ready(self):
-        from .signals import delete_associated_user, delete_associated_event, create_first_event, send_notification
+        from .signals import (
+            create_change_events,
+            create_first_event,
+            delete_associated_user,
+            delete_associated_event,
+            detect_changes,
+            send_notification,
+        )
 
         post_delete.connect(delete_associated_user, "argus_incident.SourceSystem")
         post_delete.connect(delete_associated_event, "argus_incident.Acknowledgement")
         post_save.connect(create_first_event, "argus_incident.Incident")
         post_save.connect(send_notification, "argus_incident.Event", dispatch_uid="send_notification")
+        pre_save.connect(detect_changes, "argus_incident.Incident"),
+        post_save.connect(create_change_events, "argus_incident.Incident"),

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -12,6 +12,7 @@ from argus.util.datetime_utils import INFINITY_REPR
 from . import fields
 from .models import (
     Acknowledgement,
+    ChangeEvent,
     Event,
     Incident,
     IncidentTagRelation,
@@ -224,6 +225,11 @@ class IncidentPureDeserializer(serializers.ModelSerializer):
                     errors[str(tag_relation.tag)] = "Cannot remove this tag when you're not the one who added it."
             if errors:
                 raise serializers.ValidationError(errors)
+
+        # Post change events
+        if remove_tag_relations or add_tags:
+            description = f"Change: tags {[str(tag) for tag in existing_tags]} → {[str(tag) for tag in posted_tags]}"
+            ChangeEvent.objects.create(incident=instance, actor=user, timestamp=timezone.now(), description=description)
 
         for tag_relation in remove_tag_relations:
             tag_relation.delete()

--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -1,5 +1,7 @@
+from django.utils import timezone
+
 from argus.notificationprofile.media import background_send_notifications_to_users
-from .models import SourceSystem, Incident, Event, Acknowledgement
+from .models import Acknowledgement, ChangeEvent, Event, Incident, SourceSystem
 
 
 __all__ = [
@@ -36,3 +38,32 @@ def send_notification(sender, instance: Event, *args, **kwargs):
 def delete_associated_event(sender, instance: Acknowledgement, *args, **kwargs):
     if hasattr(instance, "event") and instance.event:
         instance.event.delete()
+
+
+def detect_changes(sender, instance: Incident, raw, *args, **kwargs):
+    if raw or not instance.id or not instance.end_time:
+        return
+    instance._changed = {}
+    previous = Incident.objects.get(id=instance.id)
+    if previous.level != instance.level:
+        instance._changed["level"] = previous.level
+    if previous.details_url != instance.details_url:
+        instance._changed["details_url"] = previous.details_url
+    if previous.ticket_url != instance.ticket_url:
+        instance._changed["ticket_url"] = previous.ticket_url
+
+
+def create_change_events(sender, instance: Incident, created, raw, *args, **kwargs):
+    if not instance or not getattr(instance, "_changed", None):
+        return
+
+    for attr in ("level", "details_url", "ticket_url"):
+        if attr not in instance._changed.keys():
+            continue
+
+        old_value = instance._changed[attr]
+        new_value = getattr(instance, attr)
+        description = f"Change: {attr} {old_value} → {new_value}"
+        ChangeEvent.objects.create(
+            incident=instance, actor=instance.source.user, timestamp=timezone.now(), description=description
+        )

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -240,7 +240,6 @@ class IncidentViewSet(
         if serializer.is_valid():
             incident.ticket_url = serializer.data["ticket_url"]
             incident.save()
-            # TODO: make argus stateless incident about the url being saved? event?
             return Response(serializer.data)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/incident/test_change_event.py
+++ b/tests/incident/test_change_event.py
@@ -1,0 +1,92 @@
+from django.test import tag
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+from argus.incident.factories import StatefulIncidentFactory
+from argus.incident.models import Event
+from argus.util.testing import disconnect_signals, connect_signals
+
+from . import IncidentBasedAPITestCaseHelper
+
+
+@tag("integration")
+class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+        super().init_test_objects()
+
+        self.url = "http://www.example.com/repository/issues/issue"
+        self.incident = StatefulIncidentFactory(level=1, ticket_url=self.url, details_url=self.url)
+
+    def teardown(self):
+        connect_signals()
+
+    def test_change_event_is_created_on_level_changes(self):
+        data = {
+            "level": 2,
+        }
+        response = self.user1_rest_client.patch(
+            path=f"/api/v2/incidents/{self.incident.pk}/",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
+        change_events_descriptions = [event.description for event in change_events]
+        self.assertTrue(change_events)
+        self.assertIn("Change: level 1 → 2", change_events_descriptions)
+
+    def test_change_event_is_created_on_ticket_url_changes(self):
+        new_ticket_url = "http://www.example.com/repository/issues/other-issue"
+        response = self.user1_rest_client.patch(
+            path=f"/api/v2/incidents/{self.incident.pk}/",
+            data={
+                "ticket_url": new_ticket_url,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
+        change_events_descriptions = [event.description for event in change_events]
+        self.assertTrue(change_events)
+        self.assertIn(f"Change: ticket_url {self.url} → {new_ticket_url}", change_events_descriptions)
+
+    def test_change_event_is_created_on_ticket_url_changes_for_ticket_url_endpoint(self):
+        new_ticket_url = "http://www.example.com/repository/issues/other-issue"
+        response = self.user1_rest_client.put(
+            path=f"/api/v2/incidents/{self.incident.pk}/ticket_url/",
+            data={
+                "ticket_url": new_ticket_url,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
+        change_events_descriptions = [event.description for event in change_events]
+        self.assertTrue(change_events)
+        self.assertIn(f"Change: ticket_url {self.url} → {new_ticket_url}", change_events_descriptions)
+
+    def test_change_event_is_created_on_details_url_changes(self):
+        new_details_url = "http://www.example.com/repository/issues/other-issue"
+        response = self.user1_rest_client.patch(
+            path=f"/api/v2/incidents/{self.incident.pk}/",
+            data={
+                "details_url": new_details_url,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
+        change_events_descriptions = [event.description for event in change_events]
+        self.assertTrue(change_events)
+        self.assertIn(f"Change: details_url {self.url} → {new_details_url}", change_events_descriptions)
+
+    def test_change_event_is_created_on_tag_changes(self):
+        new_tag = "a=b"
+        response = self.user1_rest_client.patch(
+            path=f"/api/v2/incidents/{self.incident.pk}/",
+            data={
+                "tags": [{"tag": new_tag}],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
+        change_events_descriptions = [event.description for event in change_events]
+        self.assertTrue(change_events)
+        self.assertIn(f"Change: tags [] → ['{new_tag}']", change_events_descriptions)


### PR DESCRIPTION
Closes #292

Change events for tags need to be created in the serializer since the changing of the tags also happens there and therefore can't be detected by signals.