### PR TITLE
Base docker tests settings on test_CI

### DIFF
--- a/src/argus/site/settings/dockerdev.py
+++ b/src/argus/site/settings/dockerdev.py
@@ -1,5 +1,5 @@
 """Settings specific for Docker-based development environments"""
-from .dev import *
+from .test_CI import *
 
 # Allow all hosts, since all requests will typically come from outside the container
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
Fixes #468 

Instead of basing settings for docker tests on the dev settings file, instead base it on test_CI, as this is the file used for testing in all other environments.