### PR TITLE
Create argus default user before admin user

### DIFF
--- a/src/argus/dev/management/commands/initial_setup.py
+++ b/src/argus/dev/management/commands/initial_setup.py
@@ -21,8 +21,11 @@ class Command(BaseCommand):
         parser.add_argument("-u", "--username", type=str, help="Set admin username. Default: admin")
 
     def handle(self, *args, **options):
-        # Create default superuser first
+        # Create source for argus, also creates a user
+        get_or_create_default_instances()
+        self.stdout.write('Ensured the existence of the source, source type and user "argus"')
 
+        # Create default superuser
         email = options.get("email") or ""
         options_password = options.get("password", None)
         password = options_password or generate_password_string()
@@ -49,8 +52,3 @@ class Command(BaseCommand):
         else:
             msg = f"Argus superuser {username} already exists!"
             self.stderr.write(self.style.WARNING(msg))
-
-        # Create source for argus, also creates a user
-        get_or_create_default_instances()
-
-        self.stdout.write('Ensured the existence of the source, source type and user "argus"')


### PR DESCRIPTION
When using inital-setup script:
If you used parameter -u "argus" to create an admin user called argus, this user would then be accepted as the default instance is not created yet, then it would be overridden at the end by the call to get_or_create_default_instances(), but it would now have a password so you could log into it. No error message is given so for the user of the script it seems like there are no issues.
Caused quite some errors using a source system user in the frontend.