### PR TITLE
Add SMSNotification plugin to dev settings

### DIFF
--- a/src/argus/site/settings/dev.py
+++ b/src/argus/site/settings/dev.py
@@ -40,6 +40,7 @@ SEND_NOTIFICATIONS = get_bool_env("ARGUS_SEND_NOTIFICATIONS", default=False)
 # Paths to plugins
 MEDIA_PLUGINS = [
     "argus.notificationprofile.media.email.EmailNotification",
+    "argus.notificationprofile.media.sms_as_email.SMSNotification",
 ]
 
 # PSA for login


### PR DESCRIPTION
Not everything can be tested (and docker environment specifically crashes) without the SMSPlugin enabled. This only enables for development, not for production.