### PR TITLE
Save profile in v1 after setting destinations in create

### DIFF
--- a/src/argus/notificationprofile/V1/serializers.py
+++ b/src/argus/notificationprofile/V1/serializers.py
@@ -79,6 +79,7 @@ class RequestNotificationProfileSerializerV1(serializers.ModelSerializer):
 
         profile = super().create(validated_data)
         profile.destinations.set(destinations)
+        profile.save()
         return profile
 
     def update(self, instance: NotificationProfile, validated_data: dict):


### PR DESCRIPTION
When trying out backend 1.8.0 with frontend 1.5.4 we noticed that when trying to create a new notification profile an internal server error happened. This PR fixes this error. 