### PR TITLE
Fix broken /api/ endpoint in docker-compose environment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -xe
 
 cd /argus
+python3 -m pip install -e .
 python3 manage.py collectstatic --noinput
 python3 manage.py migrate --noinput
 exec daphne -b 0.0.0.0 -p 8000 argus.ws.asgi:application


### PR DESCRIPTION
The /api/ endpoint returns the version number of the argus server. In a development install, this is only available through the distribution information for `argus-server` - yet `argus-server` is not actually installed in the Docker image, it is only mounted as a source code directory. Thus, the /api/ endpoint crashes.

This mitigates the problem by ensuring an editable (symlinked) installation of the source code is made every time the container starts.