### PR TITLE
Remove unnecessary exists assertions in tests

### DIFF
--- a/tests/notificationprofile/test_signals.py
+++ b/tests/notificationprofile/test_signals.py
@@ -23,7 +23,7 @@ class SignalTests(APITestCase):
         self.assertTrue(default_destination.settings["synced"])
 
     def test_default_email_destination_should_not_be_created_if_user_has_no_email(self):
-        self.assertFalse(self.user2.destinations.exists())
+        self.assertFalse(self.user2.destinations.filter(media_id="email", settings__synced=True).exists())
 
     def test_default_email_destination_should_be_added_if_email_is_added_to_user(self):
         self.user2.email = self.user2.username

--- a/tests/notificationprofile/test_views.py
+++ b/tests/notificationprofile/test_views.py
@@ -172,38 +172,33 @@ class ViewTests(APITestCase, IncidentAPITestCaseHelper):
         )
 
     def test_can_delete_sms_destination(self):
-        self.assertTrue(DestinationConfig.objects.filter(media_id="sms").exists())
         response = self.user1_rest_client.delete(
             path=f"/api/v2/notificationprofiles/destinations/{self.sms_destination.pk}/"
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(DestinationConfig.objects.filter(media_id="sms").exists())
+        self.assertFalse(DestinationConfig.objects.filter(id=self.sms_destination.pk).exists())
 
     def test_can_delete_unsynced_unconnected_email_destination(self):
-        self.assertTrue(DestinationConfig.objects.filter(media_id="email").filter(settings__synced=False).exists())
         response = self.user1_rest_client.delete(
             path=f"/api/v2/notificationprofiles/destinations/{self.non_synced_email_destination.pk}/"
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(DestinationConfig.objects.filter(media_id="email").filter(settings__synced=False).exists())
+        self.assertFalse(DestinationConfig.objects.filter(id=self.non_synced_email_destination.pk).exists())
 
     def test_cannot_delete_synced_email_destination(self):
-        self.assertTrue(DestinationConfig.objects.filter(media_id="email").filter(settings__synced=True).exists())
         response = self.user1_rest_client.delete(
             path=f"/api/v2/notificationprofiles/destinations/{self.synced_email_destination.pk}/"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue(DestinationConfig.objects.filter(media_id="email").filter(settings__synced=True).exists())
+        self.assertTrue(DestinationConfig.objects.filter(id=self.synced_email_destination.pk).exists())
 
     def test_cannot_delete_connected_email_destination(self):
         self.notification_profile1.destinations.add(self.non_synced_email_destination)
-
-        self.assertTrue(DestinationConfig.objects.filter(media_id="email").filter(settings__synced=False).exists())
         response = self.user1_rest_client.delete(
             path=f"/api/v2/notificationprofiles/destinations/{self.non_synced_email_destination.pk}/"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue(DestinationConfig.objects.filter(media_id="email").filter(settings__synced=False).exists())
+        self.assertTrue(DestinationConfig.objects.filter(id=self.non_synced_email_destination.pk).exists())
 
     def test_can_get_all_media(self):
         response = self.user1_rest_client.get(path=f"/api/v2/notificationprofiles/media/")


### PR DESCRIPTION
As mentioned in #494 there are too many unnecessary test assertions. This PR removes some of them. 