### PR TITLE
Ensure unique factory values

### DIFF
--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -30,7 +30,7 @@ class SourceSystemFactory(factory.django.DjangoModelFactory):
         model = models.SourceSystem
         django_get_or_create = ("name", "user")
 
-    name = factory.Faker("word")
+    name = factory.Sequence(lambda s: "SourceSystem %s" % s)
     type = factory.SubFactory(SourceSystemTypeFactory)
     user = factory.SubFactory(SourceUserFactory)
     base_url = factory.Faker("url")

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -41,8 +41,8 @@ class TagFactory(factory.django.DjangoModelFactory):
         model = models.Tag
         django_get_or_create = ("key", "value")
 
-    key = factory.Faker("word")
-    value = factory.Faker("word")
+    key = factory.Sequence(lambda s: "key_%s" % s)
+    value = factory.Sequence(lambda s: "value_%s" % s)
 
 
 class IncidentFactory(factory.django.DjangoModelFactory):

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -52,7 +52,7 @@ class IncidentFactory(factory.django.DjangoModelFactory):
     start_time = factory.Faker("date_time_between", start_date="-1d", end_date="+1d", tzinfo=pytz.UTC)
     end_time = INFINITY_REPR
     source = factory.SubFactory(SourceSystemFactory)
-    source_incident_id = factory.Faker("md5")
+    source_incident_id = factory.Sequence(lambda s: s)
     details_url = factory.Faker("uri")
     description = factory.Faker("sentence")
     level = factory.fuzzy.FuzzyChoice(models.Incident.LEVELS)  # Random valid level

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -22,7 +22,7 @@ class SourceSystemTypeFactory(factory.django.DjangoModelFactory):
         model = models.SourceSystemType
         django_get_or_create = ("name",)
 
-    name = factory.Faker("word")
+    name = factory.Sequence(lambda s: "SourceSystemType %s" % s)
 
 
 class SourceSystemFactory(factory.django.DjangoModelFactory):

--- a/src/argus/notificationprofile/factories.py
+++ b/src/argus/notificationprofile/factories.py
@@ -60,7 +60,7 @@ class MediaFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Media
 
-    slug = factory.Faker("word")
+    slug = factory.Sequence(lambda s: "Media %s" % s)
     name = factory.LazyAttribute(lambda obj: obj.slug.capitalize())
 
 

--- a/src/argus/notificationprofile/factories.py
+++ b/src/argus/notificationprofile/factories.py
@@ -22,7 +22,7 @@ class TimeslotFactory(factory.django.DjangoModelFactory):
         model = models.Timeslot
 
     user = factory.SubFactory(PersonUserFactory)
-    name = factory.Faker("word")
+    name = factory.Sequence(lambda s: "Timeslot %s" % s)
 
 
 class TimeRecurrenceFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Ensures unique values for certain fields that are PKs or have constraints that require them to be unique in some way.
Makes the value globally unique. a little "overkill" in situations where 2 fields need to be unique together and such situations, but it gets the job done. Expands on change done in #510. 

The errors from #499 seem to have been fixed by #510, so these changes aim to avoid similar errors popping up in the future