### PR TITLE
Except ValidationError when calling Tag.split()

### DIFF
--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -55,7 +55,7 @@ def create_fake_incident(tags=None, description=None, stateful=True, level=None)
     if tags:
         try:
             tags = [Tag.split(tag) for tag in tags]
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             raise ValidationError(str(e))
         taglist.extend(tags)
     for k, v in taglist:

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from typing import List
 
+from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.utils import timezone
 
@@ -43,7 +44,7 @@ class TagSerializer(serializers.Serializer):
     def validate_tag(self, value: str):
         try:
             [key, value] = Tag.split(value)
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             raise serializers.ValidationError(str(e))
 
         return Tag.join(key, value)
@@ -54,7 +55,7 @@ class TagSerializer(serializers.Serializer):
 
         try:
             [key, value] = Tag.split(data.pop("tag"))
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             raise serializers.ValidationError({"tag": str(e)})
 
         return {"key": key, "value": value}
@@ -79,7 +80,7 @@ class IncidentTagRelationSerializer(serializers.ModelSerializer):
     def validate_tag(self, value: str):
         try:
             [key, value] = Tag.split(value)
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             raise serializers.ValidationError(str(e))
 
         return Tag.join(key, value)
@@ -88,7 +89,7 @@ class IncidentTagRelationSerializer(serializers.ModelSerializer):
         tag = validated_data.pop("tag")
         try:
             [key, value] = Tag.split(tag)
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             raise serializers.ValidationError(str(e))
 
         return Tag.objects.create(key=key, value=value, **validated_data)
@@ -99,7 +100,7 @@ class IncidentTagRelationSerializer(serializers.ModelSerializer):
 
         try:
             [key, value] = Tag.split(data.pop("tag"))
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             raise serializers.ValidationError({"tag": str(e)})
 
         return {"key": key, "value": value}

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -8,7 +8,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 from rest_framework import generics, mixins, serializers, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
@@ -278,7 +278,7 @@ class IncidentTagViewSet(
         )
         try:
             key, value = Tag.split(self.kwargs[lookup_url_kwarg])
-        except ValueError as e:
+        except (ValueError, ValidationError) as e:
             # Not a valid tag. Misses the delimiter, or multiple delimiters
             raise NotFound(str(e))
         filter_kwargs = {"key": key, "value": value}

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -627,6 +627,18 @@ class IncidentViewSetTestCase(APITestCase):
         incident_tags = [str(relation.tag) for relation in IncidentTagRelation.objects.filter(incident=incident)]
         self.assertIn(data["tag"], incident_tags)
 
+    def test_cannot_create_tag_of_incident_with_invalid_key(self):
+        incident = self.add_open_incident_with_start_event_and_tag()
+        data = {
+            "tag": "???=d",
+        }
+
+        response = self.client.post(path=f"/api/v2/incidents/{incident.pk}/tags/", data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        incident_tags = [str(relation.tag) for relation in IncidentTagRelation.objects.filter(incident=incident)]
+        self.assertNotIn(data["tag"], incident_tags)
+
     def test_can_delete_tag_of_incident(self):
         incident = self.add_open_incident_with_start_event_and_tag()
         tag = incident.incident_tag_relations.first().tag


### PR DESCRIPTION
Trying to post `{"tag": "???=world"}` to the endpoint `/api/v1/incidents/{incident_pk}/tags/` results currently in an internal server error. 

Before adding the validation of the tag to `Tag.split()` it was possible to post tags with invalid key to this endpoint.

Currently we only catch a ValueError when using `Tag.split()`, which happens when the tag does not contain a delimiter or the key is empty, but in case the key is not empty, but consists of other character than lowercase letters, numbers and underscores a `ValidationError` is raised, but not caught. 

This PR catches this error in all uses of the `Tag.split()` function and adds a test for this specific case. 