### PR TITLE
Fix sending sms by accessing correct key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ read by developers.
 
 ## [Unreleased]
 
+## bugfix/sms-sending
+
+### Fixed
+- Fix typo that prevented SMS messages from being sent.
+
 ### Added
 
 - Added an endpoint to get a refreshed auth token.

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -90,7 +90,7 @@ class SMSNotification(NotificationMedium):
         sms_destinations = destinations.filter(media_id=SMSNotification.MEDIA_SLUG)
         if not sms_destinations:
             return False
-        phone_numbers = [destination.settings["phone_numbers"] for destination in sms_destinations]
+        phone_numbers = [destination.settings["phone_number"] for destination in sms_destinations]
         title = f"{event.description}"
         for phone_number in phone_numbers:
             send_email_safely(


### PR DESCRIPTION
As reported by @vidarstokke Argus did not send a SMS as expected. 

The error trace back was the following:
```
2022-10-27 20:29:02,295 argus.notificationprofile.media send_notifications_to_users DEBUG    Notification: checking profile "Beredskapsvakt: Beredskapsvakt [{"sourceSystemIds":[],"tags":["alert_type=boxDown","organization=uninett","kundetjeneste=Campus_CNaaS"]}]"
Process Process-10:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/app/Argus/src/argus/notificationprofile/media/__init__.py", line 55, in send_notifications_to_users
    send_notification(profile.destinations.all(), event)
  File "/app/Argus/src/argus/notificationprofile/media/__init__.py", line 76, in send_notification
    sent = medium.send(event, destinations) or sent
  File "/app/Argus/src/argus/notificationprofile/media/sms_as_email.py", line 93, in send
    phone_numbers = [destination.settings["phone_numbers"] for destination in sms_destinations]
  File "/app/Argus/src/argus/notificationprofile/media/sms_as_email.py", line 93, in <listcomp>
    phone_numbers = [destination.settings["phone_numbers"] for destination in sms_destinations]
KeyError: 'phone_numbers'
``` 

The problem is that there is a typo in the key (`phone_numbers` instead of `phone_number`). 