### PR TITLE
Fix sync_media()

### DIFF
--- a/src/argus/notificationprofile/apps.py
+++ b/src/argus/notificationprofile/apps.py
@@ -1,34 +1,7 @@
 from django.apps import AppConfig
 from django.contrib.auth.signals import user_logged_in
 from django.core.checks import register
-from django.db.models.signals import post_save, pre_save
-from django.db.utils import ProgrammingError
-from rest_framework.exceptions import APIException
-
-
-def sync_media():
-    from .media import MEDIA_CLASSES, MEDIA_CLASSES_DICT
-
-    try:
-        from .models import Media
-    except ImportError:
-        return
-
-    try:
-        for medium in Media.objects.all():
-            if not medium.slug in MEDIA_CLASSES_DICT.keys():
-                raise APIException("".join([medium.name, " plugin is not registered in MEDIA_PLUGINS"]))
-    except ProgrammingError:
-        return
-
-    # Check if all media plugins are also saved in Media
-    new_media = [
-        Media(slug=media_class.MEDIA_SLUG, name=media_class.MEDIA_NAME)
-        for media_class in MEDIA_CLASSES
-        if not Media.objects.filter(slug=media_class.MEDIA_SLUG)
-    ]
-    if new_media:
-        Media.objects.bulk_create(new_media)
+from django.db.models.signals import post_save, pre_save, post_migrate
 
 
 class NotificationprofileConfig(AppConfig):
@@ -40,15 +13,14 @@ class NotificationprofileConfig(AppConfig):
         from .signals import (
             create_default_timeslot,
             sync_email_destination,
+            sync_media,
         )
 
         post_save.connect(create_default_timeslot, "argus_auth.User")
         post_save.connect(sync_email_destination, "argus_auth.User")
+        post_migrate.connect(sync_media, sender=self)
 
         # Settings validation
         from .checks import fallback_filter_check
 
         register(fallback_filter_check)
-
-        # Check if all media in Media has a respective class
-        sync_media()

--- a/src/argus/notificationprofile/signals.py
+++ b/src/argus/notificationprofile/signals.py
@@ -28,7 +28,7 @@ def sync_media(sender, **kwargs):
     try:
         for medium in Media.objects.all():
             if medium.slug not in MEDIA_CLASSES_DICT.keys():
-                raise APIException("".join([medium.name, " plugin is not registered in MEDIA_PLUGINS"]))
+                raise APIException(f"{medium.name} plugin is not registered in MEDIA_PLUGINS")
     except ProgrammingError:
         return
 

--- a/src/argus/notificationprofile/signals.py
+++ b/src/argus/notificationprofile/signals.py
@@ -27,7 +27,7 @@ def sync_media(sender, **kwargs):
 
     try:
         for medium in Media.objects.all():
-            if not medium.slug in MEDIA_CLASSES_DICT.keys():
+            if medium.slug not in MEDIA_CLASSES_DICT.keys():
                 raise APIException("".join([medium.name, " plugin is not registered in MEDIA_PLUGINS"]))
     except ProgrammingError:
         return

--- a/src/argus/notificationprofile/signals.py
+++ b/src/argus/notificationprofile/signals.py
@@ -1,10 +1,45 @@
+from django.db.utils import ProgrammingError
+
+from rest_framework.exceptions import APIException
+
 from argus.auth.models import User
 from .models import DestinationConfig, TimeRecurrence, Timeslot
 
 __all__ = [
+    "sync_media",
     "create_default_timeslot",
     "sync_email_destination",
 ]
+
+
+def sync_media(sender, **kwargs):
+    """Sync MEDIA_PLUGINS with the Media table
+
+    Check if all media in Media has a respective class"""
+
+    from .media import MEDIA_CLASSES, MEDIA_CLASSES_DICT
+
+    apps = kwargs['apps']
+    try:
+        Media = apps.get_model('argus_notificationprofile', 'Media')
+    except ImportError:
+        return
+
+    try:
+        for medium in Media.objects.all():
+            if not medium.slug in MEDIA_CLASSES_DICT.keys():
+                raise APIException("".join([medium.name, " plugin is not registered in MEDIA_PLUGINS"]))
+    except ProgrammingError:
+        return
+
+    # Check if all media plugins are also saved in Media
+    new_media = [
+        Media(slug=media_class.MEDIA_SLUG, name=media_class.MEDIA_NAME)
+        for media_class in MEDIA_CLASSES
+        if not Media.objects.filter(slug=media_class.MEDIA_SLUG)
+    ]
+    if new_media:
+        Media.objects.bulk_create(new_media)
 
 
 # Create default immediate Timeslot when a user is created


### PR DESCRIPTION
Closes #529.

Move sync_media() to a signal (post_migrate) prevents the dev/prod/settings and database from leaking into the test-settings and database so that tests run with the tests' MEDIA_PLUGINS, not a mix of the dev/prod MEDIA_PLUGINS and test MEDIA_PLUGINS.

This can be verified by dumping out the contents of the Media-table prior to checking it inside `sync_media`; before this patch, the dump would show the Media configured in the dev/prod-settings, after this patch it will show the media configured in the test-settings.  