### PR TITLE
Set acting user as actor of change events

### DIFF
--- a/src/argus/incident/apps.py
+++ b/src/argus/incident/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import post_delete, post_save
 
 
 class IncidentConfig(AppConfig):
@@ -9,11 +9,9 @@ class IncidentConfig(AppConfig):
     def ready(self):
         from .signals import (
             close_token_incident,
-            create_change_events,
             create_first_event,
             delete_associated_user,
             delete_associated_event,
-            detect_changes,
             send_notification,
         )
 
@@ -23,5 +21,3 @@ class IncidentConfig(AppConfig):
         post_save.connect(close_token_incident, "authtoken.Token")
         post_save.connect(create_first_event, "argus_incident.Incident")
         post_save.connect(send_notification, "argus_incident.Event", dispatch_uid="send_notification")
-        pre_save.connect(detect_changes, "argus_incident.Incident"),
-        post_save.connect(create_change_events, "argus_incident.Incident"),

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -187,6 +187,8 @@ class IncidentSerializer(serializers.ModelSerializer):
 
 
 class IncidentPureDeserializer(serializers.ModelSerializer):
+    EDITABLE_FIELDS = set(["ticket_url", "details_url", "level"])
+
     tags = IncidentTagRelationSerializer(many=True, write_only=True)
 
     class Meta:
@@ -206,7 +208,20 @@ class IncidentPureDeserializer(serializers.ModelSerializer):
             tags_data = validated_data.pop("tags")
             self.add_and_remove_tags(instance, user, tags_data)
 
+        if self.EDITABLE_FIELDS.intersection(validated_data):
+            self.post_change_events(instance, user, validated_data)
+
         return super().update(instance, validated_data)
+
+    def post_change_events(self, instance: Incident, user: User, validated_data: dict):
+        for attr in self.EDITABLE_FIELDS:
+            if attr in validated_data and validated_data[attr] != getattr(instance, attr):
+                old_value = getattr(instance, attr)
+                new_value = validated_data[attr]
+                description = f"Change: {attr} {old_value} → {new_value}"
+                ChangeEvent.objects.create(
+                    incident=instance, actor=user, timestamp=timezone.now(), description=description
+                )
 
     @staticmethod
     def add_and_remove_tags(instance: Incident, user: User, tags_data: List[dict]):

--- a/tests/incident/test_change_event.py
+++ b/tests/incident/test_change_event.py
@@ -25,6 +25,7 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
         data = {
             "level": 2,
         }
+        description = "Change: level 1 → 2"
         response = self.user1_rest_client.patch(
             path=f"/api/v2/incidents/{self.incident.pk}/",
             data=data,
@@ -33,10 +34,13 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
         change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
         change_events_descriptions = [event.description for event in change_events]
         self.assertTrue(change_events)
-        self.assertIn("Change: level 1 → 2", change_events_descriptions)
+        self.assertIn(description, change_events_descriptions)
+        self.assertEqual(change_events.get(description=description).actor, self.user1)
 
     def test_change_event_is_created_on_ticket_url_changes(self):
         new_ticket_url = "http://www.example.com/repository/issues/other-issue"
+        description = f"Change: ticket_url {self.url} → {new_ticket_url}"
+
         response = self.user1_rest_client.patch(
             path=f"/api/v2/incidents/{self.incident.pk}/",
             data={
@@ -47,10 +51,13 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
         change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
         change_events_descriptions = [event.description for event in change_events]
         self.assertTrue(change_events)
-        self.assertIn(f"Change: ticket_url {self.url} → {new_ticket_url}", change_events_descriptions)
+        self.assertIn(description, change_events_descriptions)
+        self.assertEqual(change_events.get(description=description).actor, self.user1)
 
     def test_change_event_is_created_on_ticket_url_changes_for_ticket_url_endpoint(self):
         new_ticket_url = "http://www.example.com/repository/issues/other-issue"
+        description = f"Change: ticket_url {self.url} → {new_ticket_url}"
+
         response = self.user1_rest_client.put(
             path=f"/api/v2/incidents/{self.incident.pk}/ticket_url/",
             data={
@@ -61,10 +68,13 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
         change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
         change_events_descriptions = [event.description for event in change_events]
         self.assertTrue(change_events)
-        self.assertIn(f"Change: ticket_url {self.url} → {new_ticket_url}", change_events_descriptions)
+        self.assertIn(description, change_events_descriptions)
+        self.assertEqual(change_events.get(description=description).actor, self.user1)
 
     def test_change_event_is_created_on_details_url_changes(self):
         new_details_url = "http://www.example.com/repository/issues/other-issue"
+        description = f"Change: details_url {self.url} → {new_details_url}"
+
         response = self.user1_rest_client.patch(
             path=f"/api/v2/incidents/{self.incident.pk}/",
             data={
@@ -75,10 +85,13 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
         change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
         change_events_descriptions = [event.description for event in change_events]
         self.assertTrue(change_events)
-        self.assertIn(f"Change: details_url {self.url} → {new_details_url}", change_events_descriptions)
+        self.assertIn(description, change_events_descriptions)
+        self.assertEqual(change_events.get(description=description).actor, self.user1)
 
     def test_change_event_is_created_on_tag_changes(self):
         new_tag = "a=b"
+        description = f"Change: tags [] → ['{new_tag}']"
+
         response = self.user1_rest_client.patch(
             path=f"/api/v2/incidents/{self.incident.pk}/",
             data={
@@ -89,4 +102,5 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
         change_events = self.incident.events.filter(type=Event.Type.INCIDENT_CHANGE)
         change_events_descriptions = [event.description for event in change_events]
         self.assertTrue(change_events)
-        self.assertIn(f"Change: tags [] → ['{new_tag}']", change_events_descriptions)
+        self.assertIn(description, change_events_descriptions)
+        self.assertEqual(change_events.get(description=description).actor, self.user1)


### PR DESCRIPTION
Closes #549.

It is not possible AFAIK to tell the signals who the acting user is (correct me if I'm wrong), so I had to remove the signals and do it by hand. 

It is a bit awkward since the `ticket_url` has it's own endpoint, which is why the change events are in one instance created in the views and in another in the serializer, if you have any idea on how to make this more elegant, please lmk.