### PR TITLE
Add username-password login to auth method list

### DIFF
--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from django.contrib.auth.backends import ModelBackend
 from django.utils.module_loading import import_string
 
+from rest_framework.reverse import reverse
 from social_core.backends.base import BaseAuth
 from social_core.backends.oauth import BaseOAuth2
 
@@ -20,12 +22,22 @@ def get_psa_authentication_names(backends=None):
     return sorted(psa_backends)
 
 
-def get_authentication_backend_name_and_type():
+def get_authentication_backend_name_and_type(request):
     backends = get_authentication_backend_classes()
     data = []
+    if ModelBackend in backends:
+        data.append(
+            {
+                "type": "username_password",
+                "url": reverse("v1:api-token-auth", request=request),
+                "name": "user_pw",
+            }
+        )
+
     data.extend(
         {
             "type": "OAuth2",
+            "url": reverse("social:begin", kwargs={"backend": backend.name}, request=request),
             "name": backend.name,
         }
         for backend in backends

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 from social_core.backends.base import BaseAuth
+from social_core.backends.oauth import BaseOAuth2
 
 
 def get_authentication_backend_classes():
@@ -17,3 +18,18 @@ def get_psa_authentication_names(backends=None):
         if issubclass(backend, BaseAuth):
             psa_backends.add(backend.name)
     return sorted(psa_backends)
+
+
+def get_authentication_backend_name_and_type():
+    backends = get_authentication_backend_classes()
+    data = []
+    data.extend(
+        {
+            "type": "OAuth2",
+            "name": backend.name,
+        }
+        for backend in backends
+        if issubclass(backend, BaseOAuth2)
+    )
+
+    return data

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -10,10 +10,10 @@ def get_authentication_backend_classes():
     return backends
 
 
-def get_psa_authentication_names(backends=None):
+def get_psa_authentication_classes(backends=None):
     backends = backends if backends else get_authentication_backend_classes()
     psa_backends = set()
     for backend in backends:
         if issubclass(backend, BaseAuth):
-            psa_backends.add(backend.name)
+            psa_backends.add(backend)
     return sorted(psa_backends)

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -10,10 +10,10 @@ def get_authentication_backend_classes():
     return backends
 
 
-def get_psa_authentication_classes(backends=None):
+def get_psa_authentication_names(backends=None):
     backends = backends if backends else get_authentication_backend_classes()
     psa_backends = set()
     for backend in backends:
         if issubclass(backend, BaseAuth):
-            psa_backends.add(backend)
+            psa_backends.add(backend.name)
     return sorted(psa_backends)

--- a/src/argus/auth/views.py
+++ b/src/argus/auth/views.py
@@ -9,9 +9,7 @@ from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 from rest_framework.views import APIView
-from social_core.backends.oauth import BaseOAuth2
 
 from .models import User
 from .serializers import BasicUserSerializer, EmptySerializer, RefreshTokenSerializer, UserSerializer
@@ -69,17 +67,7 @@ class AuthMethodListView(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, *args, **kwargs):
-        data = get_authentication_backend_name_and_type()
-        for backend in data:
-            backend["url"] = reverse("social:begin", kwargs={"backend": backend["name"]}, request=request)
-
-        data.append(
-            {
-                "type": "username_password",
-                "url": reverse("v1:api-token-auth", request=request),
-                "name": "user_pw",
-            }
-        )
+        data = get_authentication_backend_name_and_type(request=request)
 
         return Response(data)
 

--- a/tests/auth/test_utils.py
+++ b/tests/auth/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.contrib.auth.backends import ModelBackend
 from django.test import TestCase
 
-from argus.auth.utils import get_authentication_backend_name_and_type
+from argus.auth.utils import get_authentication_backend_name_and_type, get_psa_authentication_names
 from argus.dataporten.social import DataportenFeideOAuth2
 
 
@@ -33,3 +33,8 @@ class UtilsTests(TestCase):
                 "name": "dataporten_feide",
             }
         ]
+
+    @patch("argus.auth.utils.get_authentication_backend_classes")
+    def test_get_psa_authentication_names_returns_feide_name(self, mock_get_authentication_backend_classes):
+        mock_get_authentication_backend_classes.return_value = [DataportenFeideOAuth2]
+        assert get_psa_authentication_names() == ["dataporten_feide"]

--- a/tests/auth/test_utils.py
+++ b/tests/auth/test_utils.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from django.contrib.auth.backends import ModelBackend
+from django.test import TestCase
+
+from argus.auth.utils import get_authentication_backend_name_and_type
+from argus.dataporten.social import DataportenFeideOAuth2
+
+
+class UtilsTests(TestCase):
+    @patch("argus.auth.utils.get_authentication_backend_classes")
+    def test_get_authentication_backend_name_and_type_returns_user_name_password_login(
+        self, mock_get_authentication_backend_classes
+    ):
+        mock_get_authentication_backend_classes.return_value = [ModelBackend]
+        assert get_authentication_backend_name_and_type(request=None) == [
+            {
+                "type": "username_password",
+                "url": "/api/v1/token-auth/",
+                "name": "user_pw",
+            }
+        ]
+
+    @patch("argus.auth.utils.get_authentication_backend_classes")
+    def test_get_authentication_backend_name_and_type_returns_feide_login(
+        self, mock_get_authentication_backend_classes
+    ):
+        mock_get_authentication_backend_classes.return_value = [DataportenFeideOAuth2]
+        assert get_authentication_backend_name_and_type(request=None) == [
+            {
+                "type": "OAuth2",
+                "url": "/oidc/login/dataporten_feide/",
+                "name": "dataporten_feide",
+            }
+        ]


### PR DESCRIPTION
This will return the available login methods in the form 
```
[
  {
    "type": type,
    "url": url to endpoint,
    "name": name,
  },
  ...
]
```
as asked for by @podliashanyk.