### PR TITLE
Make API acking in V2 behave as it should

### DIFF
--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -359,6 +359,7 @@ class UpdateAcknowledgementSerializer(serializers.ModelSerializer):
 
 
 class RequestAcknowledgementSerializer(serializers.ModelSerializer):
+    timestamp = serializers.DateTimeField()
     description = serializers.CharField(required=False, allow_blank=True)
     expiration = serializers.DateTimeField(required=False, allow_null=True)
 
@@ -366,6 +367,7 @@ class RequestAcknowledgementSerializer(serializers.ModelSerializer):
         model = Acknowledgement
         fields = [
             "pk",
+            "timestamp",
             "description",
             "expiration",
         ]
@@ -378,10 +380,11 @@ class RequestAcknowledgementSerializer(serializers.ModelSerializer):
         incident = validated_data.pop("incident")
         actor = validated_data.pop("actor")
         expiration = validated_data.get("expiration", None)
+        timestamp = validated_data.pop("timestamp")
         description = validated_data.get("description", "")
         ack = incident.create_ack(
             actor,
-            timestamp=timezone.now(),
+            timestamp=timestamp,
             description=description,
             expiration=expiration,
         )

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -359,14 +359,13 @@ class UpdateAcknowledgementSerializer(serializers.ModelSerializer):
 
 
 class RequestAcknowledgementSerializer(serializers.ModelSerializer):
-    timestamp = serializers.DateTimeField()
-    description = serializers.CharField(allow_blank=True)
+    description = serializers.CharField(required=False, allow_blank=True)
+    expiration = serializers.DateTimeField(required=False, allow_null=True)
 
     class Meta:
         model = Acknowledgement
         fields = [
             "pk",
-            "timestamp",
             "description",
             "expiration",
         ]
@@ -379,18 +378,17 @@ class RequestAcknowledgementSerializer(serializers.ModelSerializer):
         incident = validated_data.pop("incident")
         actor = validated_data.pop("actor")
         expiration = validated_data.get("expiration", None)
-        timestamp = validated_data.pop("timestamp")
         description = validated_data.get("description", "")
         ack = incident.create_ack(
             actor,
-            timestamp=timestamp,
+            timestamp=timezone.now(),
             description=description,
             expiration=expiration,
         )
         return ack
 
     def validate(self, attrs: dict):
-        expiration = attrs.get("expiration")
+        expiration = attrs.get("expiration", None)
         if expiration and expiration <= attrs["timestamp"]:
             raise serializers.ValidationError("'expiration' is earlier than creation timestamp.")
         return attrs

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -585,6 +585,7 @@ class BulkAcknowledgementViewSet(viewsets.ViewSet):
         changes = {}
         status_codes_seen = set()
 
+        timestamp = timezone.now()
         for incident_id in incident_ids:
             incident = incidents.get(incident_id)
 
@@ -599,9 +600,9 @@ class BulkAcknowledgementViewSet(viewsets.ViewSet):
 
             ack = incident.create_ack(
                 actor=actor,
-                timestamp=ack_data["timestamp"],
-                description=ack_data["description"],
-                expiration=ack_data["expiration"],
+                timestamp=timestamp,
+                description=ack_data.get("description", ""),
+                expiration=ack_data.get("expiration", None),
             )
             changes[str(incident_id)] = {
                 "ack": ResponseAcknowledgementSerializer(instance=ack).to_representation(instance=ack),

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -585,7 +585,6 @@ class BulkAcknowledgementViewSet(viewsets.ViewSet):
         changes = {}
         status_codes_seen = set()
 
-        timestamp = timezone.now()
         for incident_id in incident_ids:
             incident = incidents.get(incident_id)
 
@@ -600,7 +599,7 @@ class BulkAcknowledgementViewSet(viewsets.ViewSet):
 
             ack = incident.create_ack(
                 actor=actor,
-                timestamp=timestamp,
+                timestamp=ack_data["timestamp"],
                 description=ack_data.get("description", ""),
                 expiration=ack_data.get("expiration", None),
             )


### PR DESCRIPTION
For both bulk acks and single acks:

- Hide the timestamp from the client
- Make description and expiration optional