### PR TITLE
Add test for bulk event without description

### DIFF
--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -915,11 +915,13 @@ class BulkEventViewSetTestCase(APITestCase):
         incident_1_changes = response.data["changes"][str(incident_1.pk)]
         self.assertEqual(incident_1_changes["status"], status.HTTP_201_CREATED)
         self.assertEqual(incident_1_changes["event"]["type"]["value"], "OTH")
+        self.assertEqual(incident_1_changes["event"]["description"], "")
         self.assertEqual(incident_1_changes["errors"], None)
 
         incident_2_changes = response.data["changes"][str(incident_2.pk)]
         self.assertEqual(incident_2_changes["status"], status.HTTP_201_CREATED)
         self.assertEqual(incident_2_changes["event"]["type"]["value"], "OTH")
+        self.assertEqual(incident_2_changes["event"]["description"], "")
         self.assertEqual(incident_2_changes["errors"], None)
 
         self.assertTrue(incident_1.events.filter(type="OTH").exists())

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -927,6 +927,37 @@ class BulkEventViewSetTestCase(APITestCase):
         self.assertTrue(incident_1.events.filter(type="OTH").exists())
         self.assertTrue(incident_2.events.filter(type="OTH").exists())
 
+    def test_can_bulk_create_events_with_description_empty_string_for_incidents_with_valid_ids(self):
+        incident_1 = StatefulIncidentFactory()
+        incident_2 = StatefulIncidentFactory()
+        data = {
+            "ids": [incident_1.pk, incident_2.pk],
+            "event": {
+                "timestamp": "2022-08-02T13:04:03.529Z",
+                "type": "OTH",
+                "description": "",
+            },
+        }
+
+        response = self.client.post(path=f"/api/v2/incidents/events/bulk/", data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        incident_1_changes = response.data["changes"][str(incident_1.pk)]
+        self.assertEqual(incident_1_changes["status"], status.HTTP_201_CREATED)
+        self.assertEqual(incident_1_changes["event"]["type"]["value"], "OTH")
+        self.assertEqual(incident_1_changes["event"]["description"], "")
+        self.assertEqual(incident_1_changes["errors"], None)
+
+        incident_2_changes = response.data["changes"][str(incident_2.pk)]
+        self.assertEqual(incident_2_changes["status"], status.HTTP_201_CREATED)
+        self.assertEqual(incident_2_changes["event"]["type"]["value"], "OTH")
+        self.assertEqual(incident_2_changes["event"]["description"], "")
+        self.assertEqual(incident_2_changes["errors"], None)
+
+        self.assertTrue(incident_1.events.filter(type="OTH").exists())
+        self.assertTrue(incident_2.events.filter(type="OTH").exists())
+
     def test_cannot_bulk_create_events_for_incidents_with_all_invalid_ids(self):
         highest_incident_pk = Incident.objects.last().id if Incident.objects.exists() else 0
         invalid_incident_1_pk = highest_incident_pk + 1

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -897,6 +897,34 @@ class BulkEventViewSetTestCase(APITestCase):
         self.assertTrue(incident_1.events.filter(type="OTH").exists())
         self.assertTrue(incident_2.events.filter(type="OTH").exists())
 
+    def test_can_bulk_create_events_without_description_for_incidents_with_valid_ids(self):
+        incident_1 = StatefulIncidentFactory()
+        incident_2 = StatefulIncidentFactory()
+        data = {
+            "ids": [incident_1.pk, incident_2.pk],
+            "event": {
+                "timestamp": "2022-08-02T13:04:03.529Z",
+                "type": "OTH",
+            },
+        }
+
+        response = self.client.post(path=f"/api/v2/incidents/events/bulk/", data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        incident_1_changes = response.data["changes"][str(incident_1.pk)]
+        self.assertEqual(incident_1_changes["status"], status.HTTP_201_CREATED)
+        self.assertEqual(incident_1_changes["event"]["type"]["value"], "OTH")
+        self.assertEqual(incident_1_changes["errors"], None)
+
+        incident_2_changes = response.data["changes"][str(incident_2.pk)]
+        self.assertEqual(incident_2_changes["status"], status.HTTP_201_CREATED)
+        self.assertEqual(incident_2_changes["event"]["type"]["value"], "OTH")
+        self.assertEqual(incident_2_changes["errors"], None)
+
+        self.assertTrue(incident_1.events.filter(type="OTH").exists())
+        self.assertTrue(incident_2.events.filter(type="OTH").exists())
+
     def test_cannot_bulk_create_events_for_incidents_with_all_invalid_ids(self):
         highest_incident_pk = Incident.objects.last().id if Incident.objects.exists() else 0
         invalid_incident_1_pk = highest_incident_pk + 1


### PR DESCRIPTION
Additional to #570 to make sure that we can bulk post events without a description.