### PR TITLE
Change end time for bulk close/reopen events

### DIFF
--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -668,6 +668,13 @@ class BulkEventViewSet(viewsets.ViewSet):
                 status_codes_seen.add(status.HTTP_400_BAD_REQUEST)
                 continue
 
+            if event_data["type"] == "CLO":
+                incident.end_time = event_data["timestamp"]
+                incident.save(update_fields=["end_time"])
+            if event_data["type"] == "REO":
+                incident.end_time = INFINITY_REPR
+                incident.save(update_fields=["end_time"])
+
             event = Event.objects.create(
                 incident=incident,
                 actor=actor,


### PR DESCRIPTION
@podliashanyk noticed that when trying to integrate the frontend with the new bulk endpoint that bulk posting reopening/closing events returned success, but the incidents in question would be still showing up as open/closed (so no changes there). 

This is because even though the bulk event endpoint posts the events, it doesn't change the end time of the incident.

This PR fixes that and also adds tests for these specific cases.