### PR TITLE
Add keywords to arguments in SerializerMethodField construction

### DIFF
--- a/src/argus/auth/V1/serializers.py
+++ b/src/argus/auth/V1/serializers.py
@@ -10,9 +10,9 @@ class RequestPhoneNumberSerializerV1(serializers.Serializer):
 
 
 class ResponsePhoneNumberSerializerV1(serializers.Serializer):
-    pk = serializers.SerializerMethodField("get_pk")
-    user = serializers.SerializerMethodField("get_user")
-    phone_number = serializers.SerializerMethodField("get_phone_number")
+    pk = serializers.SerializerMethodField(method_name="get_pk")
+    user = serializers.SerializerMethodField(method_name="get_user")
+    phone_number = serializers.SerializerMethodField(method_name="get_phone_number")
 
     def get_pk(self, destination: DestinationConfig) -> int:
         return destination.pk
@@ -25,7 +25,7 @@ class ResponsePhoneNumberSerializerV1(serializers.Serializer):
 
 
 class UserSerializerV1(serializers.ModelSerializer):
-    phone_numbers = serializers.SerializerMethodField("get_phone_numbers")
+    phone_numbers = serializers.SerializerMethodField(method_name="get_phone_numbers")
 
     class Meta:
         model = User

--- a/src/argus/notificationprofile/V1/serializers.py
+++ b/src/argus/notificationprofile/V1/serializers.py
@@ -9,8 +9,8 @@ from ..serializers import FilterSerializer, TimeslotSerializer
 class ResponseNotificationProfileSerializerV1(serializers.ModelSerializer):
     timeslot = TimeslotSerializer()
     filters = FilterSerializer(many=True)
-    media = serializers.SerializerMethodField("get_media")
-    phone_number = serializers.SerializerMethodField("get_phone_number")
+    media = serializers.SerializerMethodField(method_name="get_media")
+    phone_number = serializers.SerializerMethodField(method_name="get_phone_number")
 
     class Meta:
         model = NotificationProfile

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -126,7 +126,7 @@ class JSONSchemaSerializer(serializers.Serializer):
 
 class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
     media = MediaSerializer()
-    suggested_label = serializers.SerializerMethodField("get_suggested_label")
+    suggested_label = serializers.SerializerMethodField(method_name="get_suggested_label")
 
     class Meta:
         model = DestinationConfig


### PR DESCRIPTION
When reviewing #588 I checked if all fields that inherit from `Field` supply their arguments by keyword since the djangorestframework release of 3.13.0 made Field constructors keyword-only. `SerializerMethodField` adds the `method_name` argument, so upgrading djangorestframework doesn't break anything in that regard, but I thought adding the keywords would be a good initiative. 