### PR TITLE
Update timeslot with empty time recurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ read by developers.
 
 ## [Unreleased]
 
+
+
+## bugfix/updating-timeslot-empty-time-recurrence
+
+### Fixed
+- Allow updating of a timeslot with an empty time recurrence list, which
+  results in all time recurrences to be removed from the timeslot
+
+
 ## [1.11.1] - 2023-02-16
 
 ### Added

--- a/NOTES.md
+++ b/NOTES.md
@@ -3,6 +3,15 @@ This file documents changes to Argus that are relevant for the users to know.
 
 ## [Unreleased]
 
+
+
+## bugfix/updating-timeslot-empty-time-recurrence
+
+### Fixed
+- Allow updating of a timeslot with an empty time recurrence list, which
+  results in all time recurrences to be removed from the timeslot
+
+
 ## [1.11.1] - 2023-02-16
 
 ### Fixed

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -86,7 +86,7 @@ class TimeslotSerializer(serializers.ModelSerializer):
             timeslot.save()
 
         # Replace existing time recurrences with posted time recurrences
-        if time_recurrences_data:
+        if time_recurrences_data is not None:
             timeslot.time_recurrences.all().delete()
             for time_recurrence_data in time_recurrences_data:
                 TimeRecurrence.objects.create(timeslot=timeslot, **time_recurrence_data)


### PR DESCRIPTION
When investigating #502 I realized that when updating a time slot with the field time recurrence being an empty list no changes were made, even though I would expect all linked time recurrences to be unlinked from that time slot. This PR fixes that and also adds tests for that and a similar case.  