### PR TITLE
Rename missing_fields variable

### DIFF
--- a/src/argus/incident/templates/incident/ticket/default_ticket_body.html
+++ b/src/argus/incident/templates/incident/ticket/default_ticket_body.html
@@ -36,9 +36,9 @@
     <h2>Argus User</h2>
     {{ user }}
 
-    {% if __missing_fields__ %}
+    {% if missing_fields %}
     <h2>Missing fields/tags</h2>
-    {% for field in __missing_fields__ %}
+    {% for field in missing_fields %}
     <p>{{ field }}</p>
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
Variables in django templates may not begin with an underscore