### PR TITLE
Check destinations before forking

### DIFF
--- a/src/argus/incident/apps.py
+++ b/src/argus/incident/apps.py
@@ -13,6 +13,7 @@ class IncidentConfig(AppConfig):
             delete_associated_user,
             delete_associated_event,
             send_notification,
+            background_send_notification,
         )
 
         post_delete.connect(delete_associated_user, "argus_incident.SourceSystem")
@@ -20,4 +21,4 @@ class IncidentConfig(AppConfig):
         post_delete.connect(close_token_incident, "authtoken.Token")
         post_save.connect(close_token_incident, "authtoken.Token")
         post_save.connect(create_first_event, "argus_incident.Incident")
-        post_save.connect(send_notification, "argus_incident.Event", dispatch_uid="send_notification")
+        post_save.connect(background_send_notification, "argus_incident.Event", dispatch_uid="send_notification")

--- a/src/argus/incident/apps.py
+++ b/src/argus/incident/apps.py
@@ -12,8 +12,8 @@ class IncidentConfig(AppConfig):
             create_first_event,
             delete_associated_user,
             delete_associated_event,
-            send_notification,
-            background_send_notification,
+            task_send_notification,  # noqa
+            task_background_send_notification,
         )
 
         post_delete.connect(delete_associated_user, "argus_incident.SourceSystem")
@@ -21,4 +21,4 @@ class IncidentConfig(AppConfig):
         post_delete.connect(close_token_incident, "authtoken.Token")
         post_save.connect(close_token_incident, "authtoken.Token")
         post_save.connect(create_first_event, "argus_incident.Incident")
-        post_save.connect(background_send_notification, "argus_incident.Event", dispatch_uid="send_notification")
+        post_save.connect(task_background_send_notification, "argus_incident.Event", dispatch_uid="send_notification")

--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -37,11 +37,11 @@ def create_first_event(sender, instance: Incident, created, raw, *args, **kwargs
         )
 
 
-def send_notification(sender, instance: Event, *args, **kwargs):
+def task_send_notification(sender, instance: Event, *args, **kwargs):
     send_notifications_to_users(instance)
 
 
-def background_send_notification(sender, instance: Event, *args, **kwargs):
+def task_background_send_notification(sender, instance: Event, *args, **kwargs):
     send_notifications_to_users(instance, background_send_notification)
 
 

--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -3,7 +3,9 @@ from django.utils import timezone
 from rest_framework.authtoken.models import Token
 
 from argus.incident.models import get_or_create_default_instances, Incident
-from argus.notificationprofile.media import background_send_notifications_to_users
+from argus.notificationprofile.media import send_notifications_to_users
+from argus.notificationprofile.media import background_send_notification
+from argus.notificationprofile.media import send_notification
 from .models import Acknowledgement, ChangeEvent, Event, Incident, SourceSystem, Tag
 
 
@@ -36,7 +38,11 @@ def create_first_event(sender, instance: Incident, created, raw, *args, **kwargs
 
 
 def send_notification(sender, instance: Event, *args, **kwargs):
-    background_send_notifications_to_users(instance)
+    send_notifications_to_users(instance)
+
+
+def background_send_notification(sender, instance: Event, *args, **kwargs):
+    send_notifications_to_users(instance, background_send_notification)
 
 
 def delete_associated_event(sender, instance: Acknowledgement, *args, **kwargs):

--- a/src/argus/util/testing.py
+++ b/src/argus/util/testing.py
@@ -1,6 +1,7 @@
 from django.db.models.signals import post_save
 
 from argus.incident.signals import send_notification
+from argus.incident.signals import background_send_notification
 from argus.incident.models import Event
 
 
@@ -15,7 +16,9 @@ __all__ = [
 
 def disconnect_signals():
     post_save.disconnect(send_notification, Event, dispatch_uid="send_notification")
+    post_save.disconnect(background_send_notification, Event, dispatch_uid="send_notification")
 
 
 def connect_signals():
     post_save.connect(send_notification, Event, dispatch_uid="send_notification")
+    post_save.connect(background_send_notification, Event, dispatch_uid="send_notification")

--- a/tests/notificationprofile/test_media.py
+++ b/tests/notificationprofile/test_media.py
@@ -24,6 +24,7 @@ class FindDestinationsTest(TestCase):
 
         # Create two separate timeslots
         user = PersonUserFactory()
+        self.user = user
         timeslot1 = factories.TimeslotFactory(user=user)
         factories.MaximalTimeRecurrenceFactory(timeslot=timeslot1)
         timeslot2 = factories.TimeslotFactory(user=user)
@@ -54,5 +55,6 @@ class FindDestinationsTest(TestCase):
         incident = create_fake_incident()
         event = incident.events.get(type="STA")
         destinations = find_destinations_for_event(event)
-        self.assertTrue(len(destinations), 1)
+        for destination in self.user.destinations.all():
+            self.assertIn(destination, destinations)
 

--- a/tests/notificationprofile/test_media.py
+++ b/tests/notificationprofile/test_media.py
@@ -1,13 +1,58 @@
 from django.test import TestCase
+import json
 
-from argus.notificationprofile.factories import TimeslotFactory
+from argus.auth.factories import PersonUserFactory
+from argus.incident.models import create_fake_incident, get_or_create_default_instances
+from argus.notificationprofile import factories
+from argus.notificationprofile.media import find_destinations_for_event
 from argus.notificationprofile.media.email import modelinstance_to_dict
+from argus.util.testing import disconnect_signals, connect_signals
 
 
 class SerializeModelTest(TestCase):
     def test_modelinstance_to_dict_should_not_change_modelinstance(self):
-        instance = TimeslotFactory()
+        instance = factories.TimeslotFactory()
         attributes1 = vars(instance)
         modelinstance_to_dict(instance)
         attributes2 = vars(instance)
         self.assertEqual(attributes1, attributes2)
+
+
+class FindDestinationsTest(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+        # Create two separate timeslots
+        user = PersonUserFactory()
+        timeslot1 = factories.TimeslotFactory(user=user)
+        factories.MaximalTimeRecurrenceFactory(timeslot=timeslot1)
+        timeslot2 = factories.TimeslotFactory(user=user)
+        factories.MinimalTimeRecurrenceFactory(timeslot=timeslot2)
+
+        # Create a filter that matches your test incident
+        (_, _, argus_source) = get_or_create_default_instances()
+        filter_dict = {"sourceSystemIds": [argus_source.id], "tags": []}
+        filter_string = json.dumps(filter_dict)
+        filter = factories.FilterFactory(user=user, filter_string=filter_string)
+
+        # Get user related destinations
+        destinations = user.destinations.all()
+
+        # Create two notification profiles that match this filter,
+        # but attached to different timeslots
+        self.np1 = factories.NotificationProfileFactory(user=user, timeslot=timeslot1, active=True)
+        self.np1.filters.add(filter)
+        self.np1.destinations.set(destinations)
+        self.np2 = factories.NotificationProfileFactory(user=user, timeslot=timeslot2, active=True)
+        self.np2.filters.add(filter)
+        self.np2.destinations.set(destinations)
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_find_destinations_for_event(self):
+        incident = create_fake_incident()
+        event = incident.events.get(type="STA")
+        destinations = find_destinations_for_event(event)
+        self.assertTrue(len(destinations), 1)
+


### PR DESCRIPTION
The code now only forks a new process if there is anything to send.

Note: The functions in `argus/notificationprofile/media/__init__.py` has been sorted differently since the actual sending functions are parameters to the filter-function and therefore must come before it.

Other problems I found:

1. the sending apparatus expects a list of destinations while the plugins themselves expects a queryset
2. the filtering done inside each `plugin.send` should be on the base-class and not overriden. Then the base class controls whether it wants a queryset or a list of destinations.