### PR TITLE
Add command for spamming incident creation API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "wheel",
     "channels[daphne]>=4.0.0,<5",
     "channels-redis>=4",
+    "httpx",
 ]
 dynamic = ["version"]
 

--- a/requirements-django32.txt
+++ b/requirements-django32.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements-django32.txt pyproject.toml requirements/django32.txt requirements/forced-upgrade.txt
 #
+anyio==3.6.2
+    # via httpcore
 asgiref==3.6.0
     # via
     #   channels
@@ -26,7 +28,10 @@ autobahn==23.1.2
 automat==20.2.0
     # via twisted
 certifi==2022.12.7
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==1.14.5
     # via cryptography
 channels[daphne]==4.0.0
@@ -85,12 +90,20 @@ factory-boy==3.2.1
     # via argus-server (pyproject.toml)
 faker==8.0.0
     # via factory-boy
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.0
+    # via httpx
+httpx==0.24.0
+    # via argus-server (pyproject.toml)
 hyperlink==21.0.0
     # via
     #   autobahn
     #   twisted
 idna==2.10
     # via
+    #   anyio
+    #   httpx
     #   hyperlink
     #   requests
     #   twisted
@@ -153,6 +166,11 @@ six==1.15.0
     #   automat
     #   jsonschema
     #   python-dateutil
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
 social-auth-app-django==5.0.0
     # via argus-server (pyproject.toml)
 social-auth-core==4.2.0

--- a/requirements-django41.txt
+++ b/requirements-django41.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements-django41.txt pyproject.toml requirements/django41.txt requirements/forced-upgrade.txt
 #
+anyio==3.6.2
+    # via httpcore
 asgiref==3.6.0
     # via
     #   channels
@@ -26,7 +28,10 @@ autobahn==22.7.1
 automat==22.10.0
     # via twisted
 certifi==2022.12.7
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==1.15.1
     # via cryptography
 channels[daphne]==4.0.0
@@ -86,12 +91,20 @@ factory-boy==3.2.1
     # via argus-server (pyproject.toml)
 faker==15.3.1
     # via factory-boy
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.0
+    # via httpx
+httpx==0.24.0
+    # via argus-server (pyproject.toml)
 hyperlink==21.0.0
     # via
     #   autobahn
     #   twisted
 idna==3.4
     # via
+    #   anyio
+    #   httpx
     #   hyperlink
     #   requests
     #   twisted
@@ -152,6 +165,11 @@ six==1.16.0
     #   automat
     #   python-dateutil
     #   service-identity
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
 social-auth-app-django==5.0.0
     # via argus-server (pyproject.toml)
 social-auth-core==4.3.0

--- a/requirements-django42.txt
+++ b/requirements-django42.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements-django42.txt pyproject.toml requirements/django42.txt requirements/forced-upgrade.txt
 #
+anyio==3.6.2
+    # via httpcore
 asgiref==3.6.0
     # via
     #   channels
@@ -26,7 +28,10 @@ autobahn==23.1.2
 automat==22.10.0
     # via twisted
 certifi==2022.12.7
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==1.15.1
     # via cryptography
 channels[daphne]==4.0.0
@@ -87,12 +92,20 @@ factory-boy==3.2.1
     # via argus-server (pyproject.toml)
 faker==18.4.0
     # via factory-boy
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.0
+    # via httpx
+httpx==0.24.0
+    # via argus-server (pyproject.toml)
 hyperlink==21.0.0
     # via
     #   autobahn
     #   twisted
 idna==3.4
     # via
+    #   anyio
+    #   httpx
     #   hyperlink
     #   requests
     #   twisted
@@ -153,6 +166,11 @@ six==1.16.0
     #   automat
     #   python-dateutil
     #   service-identity
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
 social-auth-app-django==5.2.0
     # via argus-server (pyproject.toml)
 social-auth-core==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements-django32.txt pyproject.toml requirements/django32.txt requirements/forced-upgrade.txt
 #
+anyio==3.6.2
+    # via httpcore
 asgiref==3.6.0
     # via
     #   channels
@@ -26,7 +28,10 @@ autobahn==23.1.2
 automat==20.2.0
     # via twisted
 certifi==2022.12.7
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==1.14.5
     # via cryptography
 channels[daphne]==4.0.0
@@ -85,12 +90,20 @@ factory-boy==3.2.1
     # via argus-server (pyproject.toml)
 faker==8.0.0
     # via factory-boy
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.0
+    # via httpx
+httpx==0.24.0
+    # via argus-server (pyproject.toml)
 hyperlink==21.0.0
     # via
     #   autobahn
     #   twisted
 idna==2.10
     # via
+    #   anyio
+    #   httpx
     #   hyperlink
     #   requests
     #   twisted
@@ -153,6 +166,11 @@ six==1.15.0
     #   automat
     #   jsonschema
     #   python-dateutil
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
 social-auth-app-django==5.0.0
     # via argus-server (pyproject.toml)
 social-auth-core==4.2.0

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             "-s",
             "--seconds",
             type=int,
-            help="Number of seconds to run. The total runtime might be longer if workers are waiting for a response for a long time",
+            help="Number of seconds to send http requests. After this no more requests will be sent but responses will be waited for",
             default=100,
         )
         parser.add_argument(

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -12,25 +12,21 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "url",
+            type=str,
+            help="URL for target argus host including port, ex https://argushost.no:443",
+        )
+        parser.add_argument(
+            "token",
+            type=str,
+            help="Token for authenticating against target API. The token must belong to a user that is associated with a source system",
+        )
+        parser.add_argument(
             "-s",
             "--seconds",
             type=int,
             help="Number of seconds to send http requests. After this no more requests will be sent but responses will be waited for",
             default=100,
-        )
-        parser.add_argument(
-            "-u",
-            "--url",
-            type=str,
-            help="URL for target argus host including port, ex https://argushost.no:443",
-            required=True,
-        )
-        parser.add_argument(
-            "-t",
-            "--token",
-            type=str,
-            help="Token for authenticating against target API. The token must belong to a user that is associated with a source system",
-            required=True,
         )
         parser.add_argument("-n", type=int, help="Number of workers", default=1)
 

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             help="Number of seconds to send http requests. After this no more requests will be sent but responses will be waited for",
             default=100,
         )
-        parser.add_argument("-n", type=int, help="Number of workers", default=1)
+        parser.add_argument("-w", "--workers", type=int, help="Number of workers", default=1)
 
     def get_incident_data(self):
         return {
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         test_duration = options.get("seconds")
         url = urljoin(options.get("url"), "/api/v1/incidents/")
         token = options.get("token")
-        worker_count = options.get("n")
+        worker_count = options.get("workers")
         loop = asyncio.get_event_loop()
         start_time = datetime.now()
         end_time = start_time + timedelta(seconds=test_duration)

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -2,8 +2,7 @@ from datetime import datetime
 from urllib.parse import urljoin
 import asyncio
 
-import httpx
-from httpx import HTTPError
+from httpx import HTTPError, AsyncClient
 
 from django.core.management.base import BaseCommand
 
@@ -52,7 +51,7 @@ class Command(BaseCommand):
         return request_counter
 
     async def run_spam_workers(self, url, duration, token, worker_count):
-        async with httpx.AsyncClient() as client:
+        async with AsyncClient() as client:
             return await asyncio.gather(
                 *(self.spam_post_incident(url, duration, token, client) for _ in range(worker_count))
             )

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
     help = "Stresstests incident creation API"
 
     INCIDENT_DATA = {
-        "start_time": "2023-04-18T15:44:00+02:00",
+        "start_time": datetime.now().isoformat(),
         "description": "Stresstest",
         "tags": [],
     }
@@ -40,13 +40,21 @@ class Command(BaseCommand):
         )
         parser.add_argument("-n", type=int, help="Number of workers", default=1)
 
+    def get_incident_data(self):
+        return {
+            "start_time": datetime.now().isoformat(),
+            "description": "Stresstest",
+            "tags": [],
+        }
+
     async def post_incidents_until_end_time(self, url, end_time, token, client):
         request_counter = 0
+        incident_data = self.get_incident_data()
         while True:
             if datetime.now() >= end_time:
                 break
             # Can raise HTTPError but does not need to be handled here
-            response = await client.post(url, json=self.INCIDENT_DATA, headers={"Authorization": f"Token {token}"})
+            response = await client.post(url, json=incident_data, headers={"Authorization": f"Token {token}"})
             try:
                 response.raise_for_status()
             except HTTPError:

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -10,12 +10,6 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = "Stresstests incident creation API"
 
-    INCIDENT_DATA = {
-        "start_time": datetime.now().isoformat(),
-        "description": "Stresstest",
-        "tags": [],
-    }
-
     def add_arguments(self, parser):
         parser.add_argument(
             "-s",

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -19,7 +19,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "-s", "--seconds", type=int, help="Number of seconds the stresstest should last", default=100
+            "-s",
+            "--seconds",
+            type=int,
+            help="Number of seconds to run. The total runtime might be longer if workers are waiting for a response for a long time",
+            default=100,
         )
         parser.add_argument(
             "-u",
@@ -31,7 +35,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "-t", "--token", type=str, help="Token for authenticating against target API", required=True
         )
-        parser.add_argument("-n", type=int, help="Number of parallel connections", default=1)
+        parser.add_argument("-n", type=int, help="Number of workers", default=1)
 
     async def spam_post_incident(self, url, duration, token, client):
         request_counter = 0

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from urllib.parse import urljoin
+import asyncio
+
+import httpx
+from httpx import HTTPError
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Stresstests incident creation API"
+
+    INCIDENT_DATA = {
+        "source": "1",
+        "start_time": "2023-04-18T15:44:00+02:00",
+        "description": "Stresstest",
+        "tags": [],
+    }
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-s", "--seconds", type=int, help="Number of seconds the stresstest should last", default=100
+        )
+        parser.add_argument(
+            "-u",
+            "--url",
+            type=str,
+            help="URL for target argus host including port, ex https://argushost.no:443",
+            required=True,
+        )
+        parser.add_argument(
+            "-t", "--token", type=str, help="Token for authenticating against target API", required=True
+        )
+        parser.add_argument("-n", type=int, help="Number of parallel connections", default=1)
+
+    async def spam_post_incident(self, url, duration, token, client):
+        request_counter = 0
+        stresstest_start = datetime.now()
+        while True:
+            # Can raise HTTPError but does not need to be handled here
+            response = await client.post(url, json=self.INCIDENT_DATA, headers={"Authorization": f"Token {token}"})
+            try:
+                response.raise_for_status()
+            except HTTPError:
+                msg = f"HTTP error {response.status_code}: {response.content.decode('utf-8')}"
+                raise HTTPError(msg)
+            request_counter += 1
+            current_duration = (datetime.now() - stresstest_start).seconds
+            if current_duration >= duration:
+                break
+        return request_counter
+
+    async def run_spam_workers(self, url, duration, token, worker_count):
+        async with httpx.AsyncClient() as client:
+            return await asyncio.gather(
+                *(self.spam_post_incident(url, duration, token, client) for _ in range(worker_count))
+            )
+
+    def handle(self, *args, **options):
+        test_duration = options.get("seconds")
+        url = urljoin(options.get("url"), "/api/v1/incidents/")
+        token = options.get("token")
+        worker_count = options.get("n")
+        loop = asyncio.get_event_loop()
+        try:
+            result = loop.run_until_complete(self.run_spam_workers(url, test_duration, token, worker_count))
+        except HTTPError as e:
+            self.stderr.write(self.style.ERROR(e))
+        else:
+            total_requests = sum(result)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Stresstest complete with no errors. {total_requests} requests were sent in {test_duration} seconds."
+                )
+            )

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("-n", type=int, help="Number of workers", default=1)
 
-    async def spam_post_incident(self, url, end_time, token, client):
+    async def post_incidents_until_end_time(self, url, end_time, token, client):
         request_counter = 0
         while True:
             if datetime.now() >= end_time:
@@ -52,10 +52,10 @@ class Command(BaseCommand):
             request_counter += 1
         return request_counter
 
-    async def run_spam_workers(self, url, end_time, token, worker_count):
+    async def run_workers(self, url, end_time, token, worker_count):
         async with AsyncClient() as client:
             return await asyncio.gather(
-                *(self.spam_post_incident(url, end_time, token, client) for _ in range(worker_count))
+                *(self.post_incidents_until_end_time(url, end_time, token, client) for _ in range(worker_count))
             )
 
     def handle(self, *args, **options):
@@ -67,7 +67,7 @@ class Command(BaseCommand):
         start_time = datetime.now()
         end_time = start_time + timedelta(seconds=test_duration)
         try:
-            result = loop.run_until_complete(self.run_spam_workers(url, end_time, token, worker_count))
+            result = loop.run_until_complete(self.run_workers(url, end_time, token, worker_count))
         except HTTPError as e:
             self.stderr.write(self.style.ERROR(e))
         else:

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -11,7 +11,6 @@ class Command(BaseCommand):
     help = "Stresstests incident creation API"
 
     INCIDENT_DATA = {
-        "source": "1",
         "start_time": "2023-04-18T15:44:00+02:00",
         "description": "Stresstest",
         "tags": [],
@@ -33,7 +32,11 @@ class Command(BaseCommand):
             required=True,
         )
         parser.add_argument(
-            "-t", "--token", type=str, help="Token for authenticating against target API", required=True
+            "-t",
+            "--token",
+            type=str,
+            help="Token for authenticating against target API. The token must belong to a user that is associated with a source system",
+            required=True,
         )
         parser.add_argument("-n", type=int, help="Number of workers", default=1)
 

--- a/src/argus/dev/management/commands/stresstest.py
+++ b/src/argus/dev/management/commands/stresstest.py
@@ -40,6 +40,9 @@ class Command(BaseCommand):
     async def spam_post_incident(self, url, duration, token, client, start_time):
         request_counter = 0
         while True:
+            current_duration = (datetime.now() - start_time).seconds
+            if current_duration >= duration:
+                break
             # Can raise HTTPError but does not need to be handled here
             response = await client.post(url, json=self.INCIDENT_DATA, headers={"Authorization": f"Token {token}"})
             try:
@@ -48,9 +51,6 @@ class Command(BaseCommand):
                 msg = f"HTTP error {response.status_code}: {response.content.decode('utf-8')}"
                 raise HTTPError(msg)
             request_counter += 1
-            current_duration = (datetime.now() - start_time).seconds
-            if current_duration >= duration:
-                break
         return request_counter
 
     async def run_spam_workers(self, url, duration, token, worker_count, start_time):


### PR DESCRIPTION
Command for #567 

Adds a management command that you can use to spam POST requests to /api/v1/incidents/.
You supply the base url and a token for authorization, so this can be used against any argus instance, not just
a local one.

This just checks that no error messages are returned from the Argus API, it does not check if things are stored correctly (missing tags and such as mentioned in #567)