### PR TITLE
Prevent internal server from trying to delete non-existent filter

### DIFF
--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -13,7 +13,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAuthenticated
@@ -246,12 +246,12 @@ class IncidentViewSet(
             try:
                 source = SourceSystem.objects.get(pk=source_pk)
             except SourceSystem.DoesNotExist:
-                raise serializers.ValidationError(f"SourceSystem with pk={source_pk} does not exist.")
+                raise ValidationError(f"SourceSystem with pk={source_pk} does not exist.")
         else:
             try:
                 source = user.source_system
             except SourceSystem.DoesNotExist:
-                raise serializers.ValidationError("The requesting user must have a connected source system.")
+                raise ValidationError("The requesting user must have a connected source system.")
 
         # TODO: send notifications to users
         try:
@@ -392,7 +392,7 @@ class IncidentTagViewSet(
         try:
             incident = Incident.objects.get(pk=incident_pk)
         except Incident.DoesNotExist:
-            raise NotFound("An incident with this id does not exist")
+            raise ValidationError(f"An incident with pk={incident_pk} does not exist")
         return incident
 
     def get_object(self):
@@ -407,7 +407,7 @@ class IncidentTagViewSet(
             key, value = Tag.split(self.kwargs[lookup_url_kwarg])
         except (ValueError, ValidationError) as e:
             # Not a valid tag. Misses the delimiter, or multiple delimiters
-            raise NotFound(str(e))
+            raise ValidationError(str(e))
         filter_kwargs = {"key": key, "value": value}
         obj = get_object_or_404(queryset, **filter_kwargs)
 

--- a/src/argus/notificationprofile/views.py
+++ b/src/argus/notificationprofile/views.py
@@ -1,6 +1,7 @@
 import json
 
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
@@ -169,10 +170,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         pk = self.kwargs["pk"]
-        try:
-            destination = self.get_queryset().get(pk=pk)
-        except DestinationConfig.DoesNotExist:
-            raise ValidationError(f"Destination with pk={pk} does not exist.")
+        destination = get_object_or_404(self.get_queryset(), pk=pk)
 
         try:
             medium = api_safely_get_medium_object(destination.media.slug)
@@ -230,7 +228,7 @@ class FilterViewSet(viewsets.ModelViewSet):
         serializer.save(user=self.request.user)
 
     def destroy(self, request, *args, **kwargs):
-        filter = self.get_queryset().get(pk=self.kwargs["pk"])
+        filter = get_object_or_404(self.get_queryset(), pk=self.kwargs["pk"])
         connected_profiles = filter.notification_profiles.all()
         if connected_profiles:
             profiles = ", ".join([str(profile) for profile in connected_profiles])


### PR DESCRIPTION
When trying to delete a filter at `api/notificationprofile/filter/{filter-pk}` for a non-existing pk currently an internal server error happens. This PR fixes that and also normalizes all error messages for trying to delete a non-existing element.