### PR TITLE
Fill filter_string with content of filter in API v1

### DIFF
--- a/src/argus/notificationprofile/V1/serializers.py
+++ b/src/argus/notificationprofile/V1/serializers.py
@@ -52,6 +52,17 @@ class FilterSerializerV1(serializers.ModelSerializer):
         validated_data = self._copy_content_from_filter_string_to_filter(validated_data=validated_data)
         return super().update(instance=instance, validated_data=validated_data)
 
+    def to_representation(self, obj):
+        filter_string_dict = {"sourceSystemIds": [], "tags": []}
+        filter_keys = obj.filter.keys()
+        if "sourceSystemIds" in filter_keys:
+            filter_string_dict["sourceSystemIds"] = obj.filter["sourceSystemIds"]
+        if "tags" in filter_keys:
+            filter_string_dict["tags"] = obj.filter["tags"]
+        obj.filter_string = json.dumps(filter_string_dict)
+
+        return super().to_representation(obj)
+
 
 class ResponseNotificationProfileSerializerV1(serializers.ModelSerializer):
     timeslot = TimeslotSerializer()

--- a/tests/notificationprofile/V1/test_views.py
+++ b/tests/notificationprofile/V1/test_views.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import tag
 
 from rest_framework import status
@@ -284,6 +286,20 @@ class ViewTests(APITestCase):
         response = self.user1_rest_client.get(f"/api/v1/notificationprofiles/filters/{filter_pk}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["pk"], filter_pk)
+
+    def test_specific_filter_has_filter_string_copied_from_filter(self):
+        filter_pk = self.filter1.pk
+        response = self.user1_rest_client.get(f"/api/v1/notificationprofiles/filters/{filter_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["pk"], filter_pk)
+        expected_filter_string_dict = dict()
+        expected_filter_string_dict["sourceSystemIds"] = (
+            self.filter1.filter["sourceSystemIds"] if "sourceSystemIds" in self.filter1.filter.keys() else []
+        )
+        expected_filter_string_dict["tags"] = (
+            self.filter1.filter["tags"] if "tags" in self.filter1.filter.keys() else []
+        )
+        self.assertEqual(response.data["filter_string"], json.dumps(expected_filter_string_dict))
 
     def test_can_update_filter_name_with_valid_values(self):
         filter_pk = self.filter1.pk


### PR DESCRIPTION
When sending a GET request to `api/notificationprofile/filters/` currently filter_string is empty, this will be fixed by this PR and some tests added for that exact case. 