### PR TITLE
Prefer filter over filter_string for creating/updating filter in api v1

### DIFF
--- a/src/argus/notificationprofile/V1/serializers.py
+++ b/src/argus/notificationprofile/V1/serializers.py
@@ -34,13 +34,11 @@ class FilterSerializerV1(serializers.ModelSerializer):
             else:
                 filter_dict = validated_data["filter"]
                 source_system_ids = filter_string_dict["sourceSystemIds"]
-                if source_system_ids and (
-                    "sourceSystemIds" not in filter_dict.keys() or filter_dict["sourceSystemIds"] != source_system_ids
-                ):
+                if source_system_ids and ("sourceSystemIds" not in filter_dict.keys()):
                     validated_data["filter"]["sourceSystemIds"] = source_system_ids
 
                 tags = filter_string_dict["tags"]
-                if tags and ("tags" not in filter_dict.keys() or filter_dict["tags"] != tags):
+                if tags and "tags" not in filter_dict.keys():
                     validated_data["filter"]["tags"] = tags
         return validated_data
 

--- a/tests/notificationprofile/V1/test_views.py
+++ b/tests/notificationprofile/V1/test_views.py
@@ -264,7 +264,7 @@ class ViewTests(APITestCase):
         self.assertTrue(created_filter)
         self.assertIn("sourceSystemIds", created_filter.filter.keys())
 
-    def test_create_filter_with_filter_string_copies_to_filter_with_conflicting_source_system_ids(self):
+    def test_create_filter_with_filter_string_with_conflicting_source_system_ids_prefers_filter_content(self):
         response = self.user1_rest_client.post(
             "/api/v1/notificationprofiles/filters/",
             {
@@ -277,7 +277,7 @@ class ViewTests(APITestCase):
         created_filter = Filter.objects.filter(pk=response.data["pk"]).first()
         self.assertTrue(created_filter)
         self.assertIn("sourceSystemIds", created_filter.filter.keys())
-        self.assertEqual(created_filter.filter["sourceSystemIds"], [self.source1.pk])
+        self.assertEqual(created_filter.filter["sourceSystemIds"], [self.source2.pk])
 
     def test_can_get_specific_filter(self):
         filter_pk = self.filter1.pk
@@ -311,7 +311,7 @@ class ViewTests(APITestCase):
         self.assertTrue(created_filter)
         self.assertIn("sourceSystemIds", created_filter.filter.keys())
 
-    def test_update_filter_with_filter_string_copies_to_filter_with_conflicting_source_system_ids(self):
+    def test_update_filter_with_filter_string_with_conflicting_source_system_ids_prefers_filter_content(self):
         filter_pk = self.filter1.pk
         response = self.user1_rest_client.patch(
             f"/api/v1/notificationprofiles/filters/{filter_pk}/",
@@ -324,7 +324,7 @@ class ViewTests(APITestCase):
         created_filter = Filter.objects.filter(pk=response.data["pk"]).first()
         self.assertTrue(created_filter)
         self.assertIn("sourceSystemIds", created_filter.filter.keys())
-        self.assertEqual(created_filter.filter["sourceSystemIds"], [self.source1.pk])
+        self.assertEqual(created_filter.filter["sourceSystemIds"], [self.source2.pk])
 
     def test_can_delete_unused_filter(self):
         filter = FilterFactory(


### PR DESCRIPTION
When discussing with @hmpf we decided that when posting a filter in API v1 with conflicting information in `filter` and `filter_string` the information in `filter` should always be preferred. 