### PR TITLE
Add configuration file for readthedocs and fix builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: requirements-django42.txt

--- a/docs/django_settings.py
+++ b/docs/django_settings.py
@@ -23,3 +23,5 @@ INSTALLED_APPS = [
 ]
 
 MEDIA_PLUGINS = []
+# This is just to get the documentation to work
+SECRET_KEY = "secret-secret!"

--- a/docs/notifications/writing-notification-plugins.rst
+++ b/docs/notifications/writing-notification-plugins.rst
@@ -10,7 +10,7 @@ and
 can be used as guides.
 
 To create a project for a new plugin easily it is recommended to use the
-`Argus Notification Cookiecutter Template <https://github.com/Uninett/argus-notification-cookiecutter>_`.
+`Argus Notification Cookiecutter Template <https://github.com/Uninett/argus-notification-cookiecutter>`_.
 
 If a Python library that speaks the protocol of the medium already exists, we
 recommend that you use it. This helps keep the plugin itself short and simple.


### PR DESCRIPTION
Since adding some more django into the docs build in #604 the readthedocs builds fail. I think adding a fake secret key to the django settings will fix this. The fact that after enabling builds on pull requests this build passes is promising.

I also added a configuration file for readthedocs since that will be required starting in September 2023 (more information here: https://blog.readthedocs.com/migrate-configuration-v2/).