### PR TITLE
Fix setting of user of profile in factory

### DIFF
--- a/src/argus/notificationprofile/factories.py
+++ b/src/argus/notificationprofile/factories.py
@@ -76,7 +76,7 @@ class NotificationProfileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.NotificationProfile
 
-    user = factory.SubFactory(PersonUserFactory, user=factory.SelfAttribute("..timeslot"))
+    user = factory.LazyAttribute(lambda profile: profile.timeslot.user)
     timeslot = factory.SubFactory(TimeslotFactory)
     active = factory.Faker("boolean")
 


### PR DESCRIPTION
When trying to create a profile without a preset user (`NotificationprofileFactory()`) django complains, which I discovered when writing new tests:

```
Traceback (most recent call last):
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/django/db/models/query.py", line 929, in get_or_create
    return self.get(**kwargs), False
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/django/db/models/query.py", line 650, in get
    raise self.model.DoesNotExist(
argus.auth.models.User.DoesNotExist: User matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/johanna/Argus/tests/incident/test_filters.py", line 263, in test_notificationprofile_pk_returns_no_filtered_incidents_if_none_match
    profile = NotificationProfileFactory()
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/base.py", line 40, in __call__
    return cls.create(**kwargs)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/base.py", line 528, in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/django.py", line 121, in _generate
    return super()._generate(strategy, params)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/base.py", line 465, in _generate
    return step.build()
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/builder.py", line 270, in build
    step.resolve(pre)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/builder.py", line 211, in resolve
    self.attributes[field_name] = getattr(self.stub, field_name)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/builder.py", line 356, in __getattr__
    value = value.evaluate_pre(
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/declarations.py", line 67, in evaluate_pre
    return self.evaluate(instance, step, context)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/declarations.py", line 457, in evaluate
    return step.recurse(subfactory, extra, force_sequence=force_sequence)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/builder.py", line 228, in recurse
    return builder.build(parent_step=self, force_sequence=force_sequence)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/builder.py", line 274, in build
    instance = self.factory_meta.instantiate(
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/base.py", line 317, in instantiate
    return self.factory._create(model, *args, **kwargs)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/django.py", line 171, in _create
    return cls._get_or_create(model_class, *args, **kwargs)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/factory/django.py", line 144, in _get_or_create
    instance, _created = manager.get_or_create(*args, **key_fields)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/django/db/models/query.py", line 931, in get_or_create
    params = self._extract_model_params(defaults, **kwargs)
  File "/home/johanna/Argus/.tox/py310-django41/lib/python3.10/site-packages/django/db/models/query.py", line 994, in _extract_model_params
    raise exceptions.FieldError(
django.core.exceptions.FieldError: Invalid field name(s) for model User: 'user'.
```
 We always set a user in all other tests, which is why this was undiscovered so far.