### PR TITLE
Properly map notification destinations to events

### DIFF
--- a/src/argus/notificationprofile/media/__init__.py
+++ b/src/argus/notificationprofile/media/__init__.py
@@ -81,14 +81,16 @@ def find_destinations_for_event(event: Event):
         LOG.debug('Notification: checking profile "%s" for event "%s"', profile, event)
         if profile.incident_fits(incident) and profile.event_fits(event):
             destinations.update(profile.destinations.all())
+    LOG.info('Notification: found %i listeners for "%s"', len(destinations), event)
     return destinations
 
 
 def find_destinations_for_many_events(events: Iterable[Event]):
-    destinations = set()
+    destinations = dict()
     for event in events:
-        destinations.update(find_destinations_for_event(event))
-    LOG.info('Notification: found %i listeners for "%s"', len(destinations), event)
+        found = find_destinations_for_event(event)
+        if found:
+            destinations[event] = found
     return destinations
 
 
@@ -101,10 +103,11 @@ def send_notifications_to_users(*events: Iterable[Event], send=send_notification
         return
     # TODO: only send one notification per medium per user
     LOG.debug('Fallback filter set to "%s"', getattr(settings, "ARGUS_FALLBACK_FILTER", {}))
-    destinations = find_destinations_for_many_events(events)
-    if not destinations:
+    all_destinations = find_destinations_for_many_events(events)
+    if not all_destinations:
         return
-    send(destinations, *events)
+    for event, destinations in all_destinations.items():
+        send(destinations, event)
     LOG.info("Notification: %i events sent! %i copies", len(events), len(destinations))
 
 

--- a/tests/notificationprofile/test_media.py
+++ b/tests/notificationprofile/test_media.py
@@ -64,15 +64,18 @@ class FindDestinationsTest(TestCase):
         for destination in self.destinations:
             self.assertIn(destination, destinations)
 
-    def test_test_find_destinations_for_many_events(self):
+    def test_find_destinations_for_many_events(self):
         incident = create_fake_incident()
         event1 = incident.events.get(type=Event.Type.INCIDENT_START)
         incident.set_closed(self.user)
         event2 = incident.events.get(type=Event.Type.CLOSE)
-        destinations = find_destinations_for_many_events((event1, event2))
-        self.assertEqual(len(destinations), 1, "No destinations found")
+        found_destinations = find_destinations_for_many_events((event1, event2))
+        self.assertEqual(len(found_destinations), 2, "No destinations found")
+        found_destination_set = set()
+        for fd in found_destinations.values():
+            found_destination_set.update(fd)
         for destination in self.destinations:
-            self.assertIn(destination, destinations)
+            self.assertIn(destination, found_destination_set)
 
 
 class GetNotificationMediaTests(TestCase):

--- a/tests/notificationprofile/test_media.py
+++ b/tests/notificationprofile/test_media.py
@@ -25,33 +25,49 @@ class FindDestinationsTest(TestCase):
     def setUp(self):
         disconnect_signals()
 
-        # Create two separate timeslots
-        self.user = PersonUserFactory()
-        timeslot1 = factories.TimeslotFactory(user=self.user)
-        factories.MaximalTimeRecurrenceFactory(timeslot=timeslot1)
-        timeslot2 = factories.TimeslotFactory(user=self.user)
-        factories.MinimalTimeRecurrenceFactory(timeslot=timeslot2)
+        self.user1 = PersonUserFactory()
+        self.user1_destination = self.user1.destinations.get()  # default email
+        self.extra_destination1 = factories.DestinationConfigFactory(
+            user=self.user1,
+            media=Media.objects.get(slug="email"),
+            settings={"email": "a@b.ca", "synced": False},
+        )
+
+        self.user2 = PersonUserFactory()
+        self.user2_destination = self.user2.destinations.get()  # default email
+        self.extra_destination2 = factories.DestinationConfigFactory(
+            user=self.user2,
+            media=Media.objects.get(slug="email"),
+            settings={"email": "b@c.de", "synced": False},
+        )
 
         # Create a filter that matches your test incident
         (_, _, argus_source) = get_or_create_default_instances()
-        filter_dict = {"sourceSystemIds": [argus_source.id], "tags": []}
-        filter = factories.FilterFactory(
-            user=self.user,
-            filter=filter_dict,
+        filter_dict1 = {"sourceSystemIds": [argus_source.id]}
+        filter1 = factories.FilterFactory(
+            user=self.user1,
+            filter=filter_dict1,
+        )
+        filter_dict2 = {"tags": ["foo=bar"]}
+        filter2 = factories.FilterFactory(
+            user=self.user2,
+            filter=filter_dict2,
         )
 
-        # Get user related destinations
-        # if user.email_address is set then at least one
-        self.destinations = self.user.destinations.all()
+        # Make a timeslot
+        timeslot = factories.TimeslotFactory(user=self.user1)
+        factories.MaximalTimeRecurrenceFactory(timeslot=timeslot)
 
         # Create two notification profiles that match this filter,
-        # but attached to different timeslots
-        self.np1 = factories.NotificationProfileFactory(user=self.user, timeslot=timeslot1, active=True)
-        self.np1.filters.add(filter)
-        self.np1.destinations.set(self.destinations)
-        self.np2 = factories.NotificationProfileFactory(user=self.user, timeslot=timeslot2, active=True)
-        self.np2.filters.add(filter)
-        self.np2.destinations.set(self.destinations)
+        # with different destinations
+        self.np1 = factories.NotificationProfileFactory(user=self.user1, timeslot=timeslot, active=True)
+        self.np1.filters.add(filter1)
+        self.np1.destinations.add(self.user1_destination)
+
+        self.np2 = factories.NotificationProfileFactory(user=self.user2, timeslot=timeslot, active=True)
+        self.np2.filters.add(filter2)
+        self.np2.destinations.add(self.user2_destination)
+        self.np2.destinations.add(self.extra_destination2)
 
     def tearDown(self):
         connect_signals()
@@ -60,22 +76,39 @@ class FindDestinationsTest(TestCase):
         incident = create_fake_incident()
         event = incident.events.get(type=Event.Type.INCIDENT_START)
         destinations = find_destinations_for_event(event)
-        self.assertEqual(len(destinations), 1, "No destinations found")
-        for destination in self.destinations:
-            self.assertIn(destination, destinations)
+        self.assertEqual(len(destinations), 1)
+        self.assertIn(self.user1_destination, destinations)
+        self.assertNotIn(self.extra_destination1, destinations)
+        self.assertNotIn(self.extra_destination2, destinations)
 
     def test_find_destinations_for_many_events(self):
-        incident = create_fake_incident()
-        event1 = incident.events.get(type=Event.Type.INCIDENT_START)
-        incident.set_closed(self.user)
-        event2 = incident.events.get(type=Event.Type.CLOSE)
-        found_destinations = find_destinations_for_many_events((event1, event2))
-        self.assertEqual(len(found_destinations), 2, "No destinations found")
-        found_destination_set = set()
-        for fd in found_destinations.values():
-            found_destination_set.update(fd)
-        for destination in self.destinations:
-            self.assertIn(destination, found_destination_set)
+        incident1 = create_fake_incident()
+        event1 = incident1.events.get(type=Event.Type.INCIDENT_START)
+        incident1.set_closed(self.user1)
+        event2 = incident1.events.get(type=Event.Type.CLOSE)
+        incident2 = create_fake_incident(tags=["foo=bar"])
+        event3 = incident2.events.get(type=Event.Type.INCIDENT_START)
+
+        destinations = find_destinations_for_many_events((event1, event2, event3))
+        self.assertEqual(len(destinations), 3)
+
+        self.assertIn(event1, destinations)
+        self.assertIn(self.user1_destination, destinations[event1])
+        self.assertNotIn(self.user2_destination, destinations[event1])
+        self.assertNotIn(self.extra_destination1, destinations[event1])
+        self.assertNotIn(self.extra_destination2, destinations[event1])
+
+        self.assertIn(event2, destinations)
+        self.assertIn(self.user1_destination, destinations[event2])
+        self.assertNotIn(self.user2_destination, destinations[event2])
+        self.assertNotIn(self.extra_destination1, destinations[event2])
+        self.assertNotIn(self.extra_destination2, destinations[event2])
+
+        self.assertIn(event3, destinations)
+        self.assertIn(self.user1_destination, destinations[event3])
+        self.assertIn(self.user2_destination, destinations[event3])
+        self.assertNotIn(self.extra_destination1, destinations[event3])
+        self.assertIn(self.extra_destination2, destinations[event3])
 
 
 class GetNotificationMediaTests(TestCase):


### PR DESCRIPTION
Previously if sending more than one event at a time, all events would be sent to all found destinations instead of destinations specific to that event.