### PR TITLE
Add two development dependencies

### DIFF
--- a/changelog.d/+two-optional-dependencies.added.md
+++ b/changelog.d/+two-optional-dependencies.added.md
@@ -1,0 +1,15 @@
+Add two development dependencies
+
+While `tox` doesn't need to be in the venv, it DOES need to be less than
+version 4 so we document that like this.
+
+`build` is useful for debugging pip-trouble and pip-compile trouble.
+Whenever pip-compile (via `tox -e upgrade-deps` for instance) fails with
+
+```
+Backend subprocess exited when trying to invoke get_requires_for_build_wheel
+Failed to parse /PATH/pyproject.toml
+```
+
+run `python -m build -w` to se what build is actually complaining about.
+See also https://github.com/pypa/build/issues/553

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dev = [
     "pre-commit",
     "python-dotenv",
     "werkzeug",
+    "tox<4",  # does not work on tox 4 for some reason
+    "build",  # for debugging builds/installs
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
While `tox` doesn't need to be in the venv, it DOES currently need to be less than version 4.

`build` is useful for debugging pip errors and pip-compile trouble. Whenever pip-compile (via `tox -e upgrade-deps` for instance) fails with

```
Backend subprocess exited when trying to invoke get_requires_for_build_wheel
Failed to parse /PATH/pyproject.toml
```

run `python -m build -w` to se what `build` is actually complaining about.

See also https://github.com/pypa/build/issues/553