### PR TITLE
Allow multiple notificiation profiles with empty names

### DIFF
--- a/changelog.d/+profile-without-name.fixed.md
+++ b/changelog.d/+profile-without-name.fixed.md
@@ -1,0 +1,1 @@
+Fixed posting/updating notification profiles without name

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -211,6 +211,7 @@ class RequestNotificationProfileSerializer(serializers.ModelSerializer):
         if (
             "name" in attrs.keys()
             and NotificationProfile.objects.exclude(pk=getattr(self.instance, "pk", None))
+            .exclude(name=None)
             .filter(name=attrs["name"])
             .exists()
         ):


### PR DESCRIPTION
After introducing the fields `name` to notification profiles the constraint was added that a user needs to have unique names for their notification profiles. This incorrectly also applies to profiles without names (aka name = None), which is what this PR fixes.
Now it is possible to post a notification profile without a name if another profile without a name already exists or also to remove the name of an existing profile.
I also added tests for that case to clarify the problem before.

Was able to replicate the bug with the current frontend from master and tested against this branch and everything now works as expected.  