### PR TITLE
Upgrade codecov-action to v4

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Upload to Codecov
       if: "github.repository_owner == 'Uninett' && contains(env.USING_COVERAGE, matrix.python-version)"
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true


### PR DESCRIPTION
In an attempt to get rid of spurious CodeCov issues, v4 seems to be better in that regard.

Also, I don't think we need a changelog entry for this one, it's not really relevant for Argus users.