### PR TITLE
Do not allow deletion of used destinations

### DIFF
--- a/changelog.d/753.fixed.md
+++ b/changelog.d/753.fixed.md
@@ -1,0 +1,1 @@
+Do not allow used destinations to be deleted

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -68,12 +68,17 @@ class NotificationMedium(ABC):
         pass
 
     @classmethod
-    def raise_if_not_deletable(cls, destination: DestinationConfig):
+    def raise_if_not_deletable(cls, destination: DestinationConfig) -> NoneType:
         """
-        Returns None if the given destination is deletable and raises an
-        NotDeletableError if not
+        Raises a NotDeletableError if the given destination is not able to be deleted
+        (if it is in use by any notification profiles)
         """
-        return None
+        connected_profiles = destination.notification_profiles.all()
+        if connected_profiles:
+            profiles = ", ".join([str(profile) for profile in connected_profiles])
+            raise cls.NotDeletableError(
+                f"Cannot delete this destination since it is in use in the notification profile(s): {profiles}."
+            )
 
     @staticmethod
     def update(destination: DestinationConfig, validated_data: dict) -> Union[DestinationConfig, NoneType]:

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -41,7 +41,7 @@ class NotificationMedium(ABC):
 
     @classmethod
     @abstractmethod
-    def has_duplicate(self, queryset: QuerySet, settings: dict) -> bool:
+    def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
         """
         Returns True if a destination with the given settings already exists
         in the given queryset

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -93,22 +93,17 @@ class EmailNotification(NotificationMedium):
         return form.cleaned_data
 
     @classmethod
-    def raise_if_not_deletable(cls, destination: DestinationConfig) -> Union[str, NoneType]:
+    def raise_if_not_deletable(cls, destination: DestinationConfig) -> NoneType:
         """
         Raises a NotDeletableError if the given email destination is not able
         to be deleted (if it was defined by an outside source or is in use by
         any notification profiles)
         """
+        super().raise_if_not_deletable(destination=destination)
+
         if destination.settings["synced"]:
             raise cls.NotDeletableError(
                 "Cannot delete this email destination since it was defined by an outside source."
-            )
-
-        connected_profiles = destination.notification_profiles.all()
-        if connected_profiles:
-            profiles = ", ".join([str(profile) for profile in connected_profiles])
-            raise cls.NotDeletableError(
-                f"Cannot delete this destination since it is in use in the notification profile(s): {profiles}."
             )
 
     @staticmethod

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -135,7 +135,7 @@ class EmailNotification(NotificationMedium):
         return destination.settings.get("email_address")
 
     @classmethod
-    def has_duplicate(self, queryset: QuerySet, settings: dict) -> bool:
+    def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
         """
         Returns True if an email destination with the same email address
         already exists in the given queryset

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -82,7 +82,7 @@ class SMSNotification(NotificationMedium):
         return destination.settings.get("phone_number")
 
     @classmethod
-    def has_duplicate(self, queryset: QuerySet, settings: dict) -> bool:
+    def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
         """
         Returns True if a sms destination with the same phone number
         already exists in the given queryset

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -3,6 +3,7 @@
 This SMS gateway has an email specific interface. The email subject must contain the
 recipient's phone number. The email body must contain the message text.
 """
+
 from __future__ import annotations
 
 import logging
@@ -26,7 +27,8 @@ if TYPE_CHECKING:
     else:
         from collections.abc import Iterable
 
-    from typing import List
+    from typing import List, Union
+    from types import NoneType
     from django.db.models.query import QuerySet
     from argus.auth.models import User
     from ..models import DestinationConfig


### PR DESCRIPTION
After @podliashanyk reported that it is possible to delete sms destinations that were in use by a notification profile, but not such email destinations, I added that check into the base class.