### PR TITLE
Allow disabling redis

### DIFF
--- a/changelog.d/+disable-redis-setting.added.md
+++ b/changelog.d/+disable-redis-setting.added.md
@@ -1,0 +1,2 @@
+Added ARGUS_DISABLE_REDIS setting as an environment variable to disable redis during development
+and testing

--- a/docs/reference/site-specific-settings.rst
+++ b/docs/reference/site-specific-settings.rst
@@ -323,7 +323,7 @@ Ticket system settings
 ``TICKET_PLUGIN``, ``TICKET_ENDPOINT``, ``TICKET_AUTHENTICATION_SECRET``,
 ``TICKET_INFORMATION`` are all described in :ref:`ticket-systems-settings`.
 
-Debugging settings
+Development settings
 ------------------
 
 .. setting:: DEBUG
@@ -334,6 +334,14 @@ Debugging settings
 
 * :setting:`TEMPLATE_DEBUG` (optional) provides a convenient way to turn debugging on and off
   for templates. If undefined it will default to the value of :setting:`DEBUG`.
+
+.. setting:: ARGUS_DISABLE_REDIS
+
+* :setting:`ARGUS_DISABLE_REDIS` When given as an environment variable, this switches out the
+  depencendy of django channels on Redis with an InMemoryChannelLayer. This can only be done
+  in development (using the dev.py settings). Overriding this setting in a custom settings file has
+  no effect.
+
 
 Other settings
 --------------

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -226,14 +226,22 @@ AUTH_TOKEN_EXPIRES_AFTER_DAYS = 14
 ASGI_APPLICATION = "argus.ws.asgi.application"
 
 # fmt: off
-_REDIS = urlsplit("//" + get_str_env("ARGUS_REDIS_SERVER", "127.0.0.1:6379"))
-CHANNEL_LAYERS = {
+ARGUS_DISABLE_REDIS = get_bool_env("ARGUS_DISABLE_REDIS", False)
+if ARGUS_DISABLE_REDIS:
+    CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": [(_REDIS.hostname, _REDIS.port or 6379)],
+        "BACKEND": "channels.layers.InMemoryChannelLayer"
+    }
+}
+else:
+    _REDIS = urlsplit("//" + get_str_env("ARGUS_REDIS_SERVER", "127.0.0.1:6379"))
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {
+                "hosts": [(_REDIS.hostname, _REDIS.port or 6379)],
+            },
         },
-    },
 }
 # fmt: on
 

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -229,10 +229,10 @@ ASGI_APPLICATION = "argus.ws.asgi.application"
 ARGUS_DISABLE_REDIS = get_bool_env("ARGUS_DISABLE_REDIS", False)
 if ARGUS_DISABLE_REDIS:
     CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "channels.layers.InMemoryChannelLayer"
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        },
     }
-}
 else:
     _REDIS = urlsplit("//" + get_str_env("ARGUS_REDIS_SERVER", "127.0.0.1:6379"))
     CHANNEL_LAYERS = {
@@ -242,7 +242,7 @@ else:
                 "hosts": [(_REDIS.hostname, _REDIS.port or 6379)],
             },
         },
-}
+    }
 # fmt: on
 
 # Project specific settings

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -225,29 +225,6 @@ AUTH_TOKEN_EXPIRES_AFTER_DAYS = 14
 
 ASGI_APPLICATION = "argus.ws.asgi.application"
 
-# Disable using Redis in Channels and fall back to an InMemoryChannel
-# WARNING: This should only ever be used during development/testing and never
-# in production. To enforce this it is only ever activated when DEBUG is also set
-# fmt: off
-ARGUS_DISABLE_REDIS = get_bool_env("ARGUS_DISABLE_REDIS", False)
-if ARGUS_DISABLE_REDIS and DEBUG:
-    CHANNEL_LAYERS = {
-        "default": {
-            "BACKEND": "channels.layers.InMemoryChannelLayer",
-        },
-    }
-else:
-    _REDIS = urlsplit("//" + get_str_env("ARGUS_REDIS_SERVER", "127.0.0.1:6379"))
-    CHANNEL_LAYERS = {
-        "default": {
-            "BACKEND": "channels_redis.core.RedisChannelLayer",
-            "CONFIG": {
-                "hosts": [(_REDIS.hostname, _REDIS.port or 6379)],
-            },
-        },
-    }
-# fmt: on
-
 # Project specific settings
 
 # Set this to be able to send notifications

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -225,9 +225,12 @@ AUTH_TOKEN_EXPIRES_AFTER_DAYS = 14
 
 ASGI_APPLICATION = "argus.ws.asgi.application"
 
+# Disable using Redis in Channels and fall back to an InMemoryChannel
+# WARNING: This should only ever be used during development/testing and never
+# in production. To enforce this it is only ever activated when DEBUG is also set
 # fmt: off
 ARGUS_DISABLE_REDIS = get_bool_env("ARGUS_DISABLE_REDIS", False)
-if ARGUS_DISABLE_REDIS:
+if ARGUS_DISABLE_REDIS and DEBUG:
     CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",


### PR DESCRIPTION
Add a boolean environment variable "ARGUS_DISABLE_REDIS" that, when set, will tell channels to use an InMemoryChannel instead of Redis so that we may run the backend without having a redis server running