### PR TITLE
Only show user's filters in profile admin change page

### DIFF
--- a/changelog.d/735.changed.md
+++ b/changelog.d/735.changed.md
@@ -1,0 +1,1 @@
+When editing a notification profile in the admin UI, only the profile owner's own filters are now listed as available for selection.

--- a/src/argus/notificationprofile/admin.py
+++ b/src/argus/notificationprofile/admin.py
@@ -140,6 +140,15 @@ class NotificationProfileAdmin(admin.ModelAdmin):
         # Reduce number of database calls
         return qs.prefetch_related("timeslot__user", "filters")
 
+    def get_form(self, request, obj=None, **kwargs):
+        self.instance = obj
+        return super(NotificationProfileAdmin, self).get_form(request, obj=obj, **kwargs)
+
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        if db_field.name == "filters" and self.instance:
+            kwargs["queryset"] = Filter.objects.filter(user=NotificationProfile.objects.get(pk=self.instance.pk).user)
+        return super(NotificationProfileAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
+
 
 admin.site.register(Timeslot, TimeslotAdmin)
 admin.site.register(Filter, FilterAdmin)


### PR DESCRIPTION
Closes #735.

It is quite hacky, but it works, so...

For reference: https://docs.djangoproject.com/en/4.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.formfield_for_manytomany