### PR TITLE
Fix internal server error in timeslot admin due to removed method

### DIFF
--- a/changelog.d/797.fixed.md
+++ b/changelog.d/797.fixed.md
@@ -1,0 +1,1 @@
+Fix internal server error in timeslot admin due to removed method

--- a/src/argus/notificationprofile/models.py
+++ b/src/argus/notificationprofile/models.py
@@ -77,8 +77,7 @@ class TimeRecurrence(models.Model):
     """
 
     def __str__(self):
-        days_string = ", ".join(f"{day}s" for day in self.get_days_list())
-        return f"{self.start}-{self.end} on {days_string}"
+        return f"{self.start}-{self.end} on {self.get_days_display()}"
 
     @property
     def isoweekdays(self):


### PR DESCRIPTION
This is a leftover from moving from "Django MultiSelectField" to "ArrayField". The method `get_days_list()` was specific to "Django MultiSelectField".

Important PR, because currently the page `/admin/argus_notificationprofile/timeslot/` fails with an internal server error. 