### PR TITLE
Link two first columns in Incident admin

### DIFF
--- a/changelog.d/+fix-incident-admin-list-link.changed.md
+++ b/changelog.d/+fix-incident-admin-list-link.changed.md
@@ -1,0 +1,3 @@
+Linked up the second column in the admin incident list to the details view in
+addition to the default first column because the first column is currently an
+optional field. If the field has no value there can also not be a link.

--- a/src/argus/incident/admin.py
+++ b/src/argus/incident/admin.py
@@ -112,6 +112,10 @@ class IncidentAdmin(TextWidgetsOverrideModelAdmin):
         "get_open",
         "get_shown",
     )
+    list_display_links = (
+        "source_incident_id",
+        "start_time",
+    )
     search_fields = (
         "description",
         "source_incident_id",


### PR DESCRIPTION
By default, the first displayed field is linked to the details page. The first field we show is `source_incident_id` which is optional. When it is not set there will be no link. Therefore, also link up the second field (`start_time`) so that we can always easily get to the details page.