### PR TITLE
Add date drilldown to incident list in admin

### DIFF
--- a/changelog.d/739.added.md
+++ b/changelog.d/739.added.md
@@ -1,0 +1,1 @@
+Add a possibility to filter incidents by start time in incident admin list

--- a/src/argus/incident/admin.py
+++ b/src/argus/incident/admin.py
@@ -124,6 +124,7 @@ class IncidentAdmin(TextWidgetsOverrideModelAdmin):
         "incident_tag_relations__tag__key",
         "incident_tag_relations__tag__value",
     )
+    date_hierarchy = "start_time"
     list_filter = (
         list_filter_factory("stateful", lambda qs, yes_filter: qs.stateful() if yes_filter else qs.stateless()),
         list_filter_factory("open", lambda qs, yes_filter: qs.open() if yes_filter else qs.closed()),


### PR DESCRIPTION
Closes #739.

As far as it looks you cannot use two fields here, so I decided for `start_time` as the field to filter by.