### PR TITLE
Allow a source to delete its incidents in API

### DIFF
--- a/changelog.d/804.added.md
+++ b/changelog.d/804.added.md
@@ -1,0 +1,2 @@
+New in the API: Allow sources to delete their own incidents, as well as allow
+superusers to delete any incident.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -347,6 +347,9 @@ Incident endpoints
       -  ``ticket_url``
       -  ``tags``
 
+   - ``DELETE``: deletes an incident. Limited to the source of the incident or
+     superuser.
+
 
 -  ``/api/v1/incidents/<int:pk>/ticket_url/``:
 

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -190,6 +190,15 @@ A common value in development would be::
 
   DATABASE_URL=postgresql://argus_user:superSecretPassword@localhost:5432/argus_db
 
+Incident settings
+-----------------
+
+.. setting:: INDELIBLE_INCIDENTS
+
+* :setting:`INDELIBLE_INCIDENTS` protects incidents from being deleted. The
+  default is ``True``. This can also be set via the environment variable
+  ``ARGUS_INDELIBLE_INCIDENTS``.
+
 Notification settings
 ---------------------
 

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -23,6 +23,7 @@ from rest_framework.reverse import reverse
 
 from argus.auth.models import User
 from argus.drf.permissions import IsSuperuserOrReadOnly
+from argus.incident.models import Acknowledgement, Event
 from argus.incident.ticket.base import (
     TicketClientException,
     TicketCreationException,
@@ -314,6 +315,8 @@ class IncidentViewSet(
         source = getattr(self.request.user, "source_system", None)
         owns_instance = source and source == instance.source
         if self.request.user.is_superuser or owns_instance:
+            ack_events = instance.events.filter(type=Event.Type.ACKNOWLEDGE)
+            Acknowledgement.objects.filter(event__in=ack_events).delete()
             instance.events.all().delete()
             self.perform_destroy(instance)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -293,6 +293,7 @@ class IncidentViewSet(
         responses={
             204: OpenApiResponse(response=None),
             403: OpenApiResponse(response=None),
+            405: OpenApiResponse(response=None),
         }
     )
     def destroy(self, request, *args, **kwargs):

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -245,6 +245,8 @@ CHANNEL_LAYERS = {
 
 # Project specific settings
 
+INDELIBLE_INCIDENTS = get_bool_env("ARGUS_INDELIBLE_INCIDENTS", True)
+
 NOTIFICATION_SUBJECT_PREFIX = "[Argus] "
 
 SEND_NOTIFICATIONS = False  # Don't spam by accident

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.urls import reverse
 from django.utils.timezone import now
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, override_settings
 
 from rest_framework import serializers, status, versioning
 from rest_framework.test import APITestCase
@@ -296,6 +296,12 @@ class IncidentViewSetV1TestCase(IncidentAPITestCase):
         tag = Tag.objects.get(key=key, value=value)
         # Check that incident and tag are linked
         self.assertTrue(IncidentTagRelation.objects.filter(incident=incident).filter(tag=tag).exists())
+
+    @override_settings(INDELIBLE_INCIDENTS=False)
+    def test_cannot_delete_incident_if_indelible_is_true(self):
+        incident_pk = self.add_open_incident_with_start_event_and_tag().pk
+        response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class SourceSystemV1TestCase(IncidentAPITestCase):

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -337,6 +337,17 @@ class IncidentViewSetV1DeleteTestCase(IncidentAPITestCase):
         self.assertFalse(Incident.objects.filter(pk=incident_pk).exists())
 
     @override_settings(INDELIBLE_INCIDENTS=False)
+    def test_can_delete_acknowledged_incidente(self):
+        incident = add_open_incident_with_start_event_and_tag(self.source)
+        self.assertTrue(Incident.objects.filter(pk=incident.pk).exists())
+        ack = incident.create_ack(actor=self.user)
+        self.assertTrue(Acknowledgement.objects.filter(pk=ack.pk).exists())
+        response = self.client.delete(path=f"/api/v2/incidents/{incident.pk}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Incident.objects.filter(pk=incident.pk).exists())
+        self.assertFalse(Acknowledgement.objects.filter(pk=ack.pk).exists())
+
+    @override_settings(INDELIBLE_INCIDENTS=False)
     def test_source_cannot_delete_unowned_incident_if_indelible_is_False(self):
         incident_pk = add_open_incident_with_start_event_and_tag(self.source).pk
         self.assertTrue(Incident.objects.filter(pk=incident_pk).exists())

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -7,7 +7,12 @@ from django.test import TestCase, RequestFactory, override_settings
 from rest_framework import serializers, status, versioning
 from rest_framework.test import APITestCase
 
-from argus.auth.factories import AdminUserFactory, BaseUserFactory, SourceUserFactory
+from argus.auth.factories import (
+    AdminUserFactory,
+    BaseUserFactory,
+    PersonUserFactory,
+    SourceUserFactory,
+)
 from argus.incident.factories import (
     AcknowledgementFactory,
     EventFactory,
@@ -31,6 +36,14 @@ from argus.incident.views import EventViewSet
 from argus.notificationprofile.factories import FilterFactory
 from argus.notificationprofile.models import Filter
 from argus.util.testing import disconnect_signals, connect_signals
+
+
+def add_open_incident_with_start_event_and_tag(source, description="incident"):
+    incident = StatefulIncidentFactory(source=source, description=description)
+    tag = TagFactory(key="a", value="b")
+    IncidentTagRelationFactory(incident=incident, tag=tag)
+    incident.create_first_event()
+    return incident
 
 
 class EventViewSetTestCase(TestCase):
@@ -70,11 +83,7 @@ class IncidentAPITestCase(APITestCase):
 
 class IncidentViewSetV1TestCase(IncidentAPITestCase):
     def add_open_incident_with_start_event_and_tag(self, description="incident"):
-        incident = StatefulIncidentFactory(source=self.source, description=description)
-        tag = TagFactory(key="a", value="b")
-        IncidentTagRelationFactory(incident=incident, tag=tag)
-        incident.create_first_event()
-        return incident
+        return add_open_incident_with_start_event_and_tag(self.source, description)
 
     def add_acknowledgement_with_incident_and_event(self):
         return AcknowledgementFactory()
@@ -297,11 +306,53 @@ class IncidentViewSetV1TestCase(IncidentAPITestCase):
         # Check that incident and tag are linked
         self.assertTrue(IncidentTagRelation.objects.filter(incident=incident).filter(tag=tag).exists())
 
+
+class IncidentViewSetV1DeleteTestCase(IncidentAPITestCase):
     @override_settings(INDELIBLE_INCIDENTS=True)
-    def test_cannot_delete_incident_if_indelible_is_true(self):
-        incident_pk = self.add_open_incident_with_start_event_and_tag().pk
+    def test_cannot_delete_incident_if_indelible_is_True(self):
+        incident_pk = add_open_incident_with_start_event_and_tag(self.source).pk
+        # source
         response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        # superuser
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @override_settings(INDELIBLE_INCIDENTS=False)
+    def test_superuser_can_delete_incident_if_indelible_is_False(self):
+        incident_pk = add_open_incident_with_start_event_and_tag(self.source).pk
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @override_settings(INDELIBLE_INCIDENTS=False)
+    def test_source_can_delete_owned_incident_if_indelible_is_False(self):
+        incident_pk = add_open_incident_with_start_event_and_tag(self.source).pk
+        response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @override_settings(INDELIBLE_INCIDENTS=False)
+    def test_source_cannot_delete_unowned_incident_if_indelible_is_False(self):
+        incident_pk = add_open_incident_with_start_event_and_tag(self.source).pk
+
+        source_type = SourceSystemTypeFactory()
+        user = SourceUserFactory()
+        source = SourceSystemFactory(type=source_type, user=user)
+
+        self.client.force_authenticate(user=user)
+        response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @override_settings(INDELIBLE_INCIDENTS=False)
+    def test_nonsource_cannot_delete_incident(self):
+        incident_pk = add_open_incident_with_start_event_and_tag(self.source).pk
+
+        user = PersonUserFactory()
+
+        self.client.force_authenticate(user=user)
+        response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class SourceSystemV1TestCase(IncidentAPITestCase):

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -297,7 +297,7 @@ class IncidentViewSetV1TestCase(IncidentAPITestCase):
         # Check that incident and tag are linked
         self.assertTrue(IncidentTagRelation.objects.filter(incident=incident).filter(tag=tag).exists())
 
-    @override_settings(INDELIBLE_INCIDENTS=False)
+    @override_settings(INDELIBLE_INCIDENTS=True)
     def test_cannot_delete_incident_if_indelible_is_true(self):
         incident_pk = self.add_open_incident_with_start_event_and_tag().pk
         response = self.client.delete(path=f"/api/v2/incidents/{incident_pk}/")


### PR DESCRIPTION
Closes #804

Missing/will we need it/to decide:

1. Should there be an event to mark the deletion of an incident? It cannot be on the incident to be deleted.
2. Should there be a hard time window where deletion is allowed? What should the settings-name be to set the duration?
3. Should there be a field on the incident that says deletion is allowed? What should the field be named? What should the default be?
4. Depends on queue: If there is a field on the incident that allows deletion, should there be an agent that toggles this field after X seconds? (See no. 3 above)
5. Should there be a setting that toggles this on or off? If off, deletion is not allowed.