### PR TITLE
Make it possible to plug in context processors included with apps

### DIFF
--- a/changelog.d/+810.added.md
+++ b/changelog.d/+810.added.md
@@ -1,0 +1,3 @@
+Extend the usefulness of `OVERRIDE_APPS` and `EXTRA_APPS` by adding support for
+Django template engine context processors. Any context processors are added to
+the end of the list.

--- a/docs/site-specific-settings.rst
+++ b/docs/site-specific-settings.rst
@@ -99,12 +99,18 @@ Settings for adding additional Django apps
 Format of the app settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+App
+...
+
 Both settings are a list of dicts. The minimal content of the dict is::
 
     { "app_name": "myapp" }
 
 "myapp" is the same string you would normally put into
 :setting:`INSTALLED_APPS`.
+
+Urls
+....
 
 There is an experimental way of also overriding or extending the root
 ``urls.py`` in ``argus.site``.
@@ -145,6 +151,23 @@ There are two possible formats:
 
 This assumes that ``myapp.urls`` contains a variable named ``urlpatterns`` with
 the defined urls of the app.
+
+Context processors
+..................
+
+Optionally, one or more context processors can be added to the end of the
+context processors list of the
+``django.template.backends.django.DjangoTemplates`` template backend.
+
+Format::
+
+    {
+        "app_name": "holiday_cheer",
+        "context_processors": [
+            "holiday_cheer.context_processors.date_context",
+            "holiday_cheer.context_processors.holidays"
+        ],
+    }
 
 Dataporten
 ----------

--- a/src/argus/site/settings/_serializers.py
+++ b/src/argus/site/settings/_serializers.py
@@ -12,7 +12,7 @@ class AppUrlSetting(BaseModel):
 class AppSetting(BaseModel):
     app_name: str
     urls: Optional[AppUrlSetting] = None
-    context_processors: Optional[List(str)] = None
+    context_processors: Optional[List[str]] = None
 
 
 class ListAppSetting(RootModel):

--- a/src/argus/site/settings/_serializers.py
+++ b/src/argus/site/settings/_serializers.py
@@ -12,6 +12,7 @@ class AppUrlSetting(BaseModel):
 class AppSetting(BaseModel):
     app_name: str
     urls: Optional[AppUrlSetting] = None
+    context_processors: Optional[List(str)] = None
 
 
 class ListAppSetting(RootModel):

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -15,6 +15,7 @@ import dj_database_url
 
 # Import some helpers
 from . import *
+from ..utils import update_context_processors_list
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -62,15 +63,6 @@ INSTALLED_APPS = [
 ]
 # fmt: on
 
-# override themes, urls
-if OVERRIDING_APPS:
-    _overriding_app_names = [app.app_name for app in OVERRIDING_APPS]
-    INSTALLED_APPS = _overriding_app_names + INSTALLED_APPS
-# add extra functionality without overrides
-if EXTRA_APPS:
-    _extra_app_names = [app.app_name for app in EXTRA_APPS]
-    INSTALLED_APPS += _extra_app_names
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -105,6 +97,17 @@ TEMPLATES = [
         },
     }
 ]
+
+# override themes, urls, context processors
+if OVERRIDING_APPS:
+    _overriding_app_names = [app.app_name for app in OVERRIDING_APPS]
+    INSTALLED_APPS = _overriding_app_names + INSTALLED_APPS
+    TEMPLATES = update_context_processors_list(TEMPLATES, OVERRIDING_APPS)
+# add extra functionality without overrides
+if EXTRA_APPS:
+    _extra_app_names = [app.app_name for app in EXTRA_APPS]
+    INSTALLED_APPS += _extra_app_names
+    TEMPLATES = update_context_processors_list(TEMPLATES, EXTRA_APPS)
 
 WSGI_APPLICATION = "argus.site.wsgi.application"
 

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -27,10 +27,10 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
-_overriding_apps_env = get_json_env("ARGUS_OVERRIDING_APPS", [])
+_overriding_apps_env = get_json_env("ARGUS_OVERRIDING_APPS", [], quiet=False)
 OVERRIDING_APPS = validate_app_setting(_overriding_apps_env)
 del _overriding_apps_env
-_extra_apps_env = get_json_env("ARGUS_EXTRA_APPS", [])
+_extra_apps_env = get_json_env("ARGUS_EXTRA_APPS", [], quiet=False)
 EXTRA_APPS = validate_app_setting(_extra_apps_env)
 del _extra_apps_env
 

--- a/src/argus/site/utils.py
+++ b/src/argus/site/utils.py
@@ -29,7 +29,7 @@ def update_context_processors_list(new_context_processors):
         return None
     correct_engine = None
     for engine in setting:
-        if setting["BACKEND"] == "django.template.backends.django.DjangoTemplates":
+        if engine["BACKEND"] == "django.template.backends.django.DjangoTemplates":
             correct_engine = engine
             break
     if not correct_engine:

--- a/src/argus/site/utils.py
+++ b/src/argus/site/utils.py
@@ -1,4 +1,5 @@
 # nothing that imports models here!
+from copy import deepcopy
 
 from django.conf import settings
 from django.urls import include, path
@@ -23,16 +24,19 @@ def get_urlpatterns_from_setting(setting):
     return urlpatterns
 
 
-def update_context_processors_list(new_context_processors):
-    setting = getattr(settings, "TEMPLATES", None)
-    if not setting:
-        return None
+def update_context_processors_list(templates_setting, app_settings):
+    if not templates_setting:
+        return templates_setting
+    safety_copy = deepcopy(templates_setting)
     correct_engine = None
-    for engine in setting:
+    for engine in safety_copy:
         if engine["BACKEND"] == "django.template.backends.django.DjangoTemplates":
             correct_engine = engine
             break
-    if not correct_engine:
-        return False
-    correct_engine["OPTIONS"]["context_processors"].extend(new_context_processors)
-    return True
+    else:
+        return templates_setting
+    for app in app_settings:
+        if not app.context_processors:
+            continue
+        correct_engine["OPTIONS"]["context_processors"].extend(app.context_processors)
+    return safety_copy

--- a/src/argus/site/utils.py
+++ b/src/argus/site/utils.py
@@ -1,5 +1,6 @@
 # nothing that imports models here!
 
+from django.conf import settings
 from django.urls import include, path
 
 
@@ -20,3 +21,18 @@ def get_urlpatterns_from_setting(setting):
         )
         # fmt: on
     return urlpatterns
+
+
+def update_context_processors_list(new_context_processors):
+    setting = getattr(settings, "TEMPLATES", None)
+    if not setting:
+        return None
+    correct_engine = None
+    for engine in setting:
+        if setting["BACKEND"] == "django.template.backends.django.DjangoTemplates":
+            correct_engine = engine
+            break
+    if not correct_engine:
+        return False
+    correct_engine["OPTIONS"]["context_processors"].extend(new_context_processors)
+    return True

--- a/tests/site/test_settings_helpers.py
+++ b/tests/site/test_settings_helpers.py
@@ -135,7 +135,9 @@ class UpdateContextProcessorsListTests(unittest.TestCase):
         result = update_context_processors_list(TEMPLATES, [app_setting])
         self.assertEqual(result, TEMPLATES)
 
-    def test_append_context_processors_in_setting_to_DjangoTemplates_context_processors_list(self):
+    def test_when_app_settings_contain_context_processors_it_should_append_them_to_DjangoTemplates_context_processors_list(
+        self,
+    ):
         raw_setting = {
             "app_name": "foo",
             "context_processors": ["omega"],

--- a/tests/site/test_settings_helpers.py
+++ b/tests/site/test_settings_helpers.py
@@ -49,7 +49,7 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
     def test_when_setting_is_falsey_return_empty_list(self):
         self.assertEqual(get_urlpatterns_from_setting(None), [])
 
-    def test_when_setting_contains_falsey_urls_should_return_empty_list(self):
+    def test_when_setting_urls_is_falsey_it_should_return_empty_list(self):
         class Obj:
             pass
 

--- a/tests/site/test_settings_helpers.py
+++ b/tests/site/test_settings_helpers.py
@@ -1,10 +1,16 @@
 import unittest
+from copy import deepcopy
+
+from django.conf import settings
+from django.urls.resolvers import URLResolver
+from django.test import override_settings
 
 from argus.site.settings import normalize_url, _add_missing_scheme_to_url
+from argus.site.settings._serializers import AppSetting
+from argus.site.utils import get_urlpatterns_from_setting, update_context_processors_list
 
 
 class NormalizeUrlTests(unittest.TestCase):
-
     def test_add_missing_scheme_if_recoverable(self):
         test_url_80 = "//localhost:80/fgh/ghj/?ghj=gh#fghj"
         fixed_url = _add_missing_scheme_to_url(test_url_80)
@@ -37,3 +43,80 @@ class NormalizeUrlTests(unittest.TestCase):
         test_url_unknown_port = "http://localhost:5431/fgh/ghj/?ghj=gh#fghj"
         fixed_url = normalize_url(test_url_unknown_port)
         self.assertEqual(fixed_url, test_url_unknown_port)
+
+
+class GetUrlPatternsFromSettingsTest(unittest.TestCase):
+    def test_if_falsey_setting_return_empty_list(self):
+        self.assertEqual(get_urlpatterns_from_setting(None), [])
+
+    def test_if_falsey_urls_return_empty_list(self):
+        class Obj:
+            pass
+
+        obj = Obj()
+        obj.urls = None
+
+        self.assertEqual(get_urlpatterns_from_setting([obj]), [])
+
+    def test_urls_without_namspace_return_list_of_paths_without_namespace(self):
+        raw_setting = {
+            "app_name": "foo",
+            "urls": {
+                "path": "fghfh",
+                "urlpatterns_module": "django",  # must be a dotted path to a module in python path!
+            },
+        }
+        setting = AppSetting(**raw_setting)
+        result = get_urlpatterns_from_setting([setting])
+        self.assertEqual(len(result), 1)
+        self.assertTrue(isinstance(result[0], URLResolver))
+        self.assertFalse(result[0].namespace)
+
+    def test_urls_with_namspace_return_list_of_paths_with_namespace(self):
+        raw_setting = {
+            "app_name": "foo",
+            "urls": {
+                "path": "fghfh",
+                "urlpatterns_module": "django",  # must be a dotted path to a module in python path!
+                "namespace": "blbl",
+            },
+        }
+        setting = AppSetting(**raw_setting)
+        result = get_urlpatterns_from_setting([setting])
+        self.assertEqual(len(result), 1)
+        self.assertTrue(isinstance(result[0], URLResolver))
+        self.assertEqual(result[0].namespace, "blbl")
+
+
+class UpdateContextProcessorsListTests(unittest.TestCase):
+    def test_do_nothing_if_empty_list(self):
+        old_setting = deepcopy(settings.TEMPLATES)
+        result = update_context_processors_list([])
+        self.assertTrue(result)
+        new_setting = deepcopy(settings.TEMPLATES)
+        self.assertEqual(old_setting, new_setting)
+
+    @override_settings(TEMPLATES=[{"BACKEND": "foo", "OPTIONS": {"context_processors": ["alpha"]}}])
+    def test_only_update_DjangoTemplates_section(self):
+        old_setting = deepcopy(settings.TEMPLATES)[0]
+        result = update_context_processors_list(["omega"])
+        self.assertFalse(result)
+        new_setting = deepcopy(settings.TEMPLATES[0])
+        self.assertEqual(old_setting, new_setting)
+
+    @override_settings(TEMPLATES=[])
+    def test_return_None_if_no_setting(self):
+        result = update_context_processors_list(["n"])
+        self.assertEqual(result, None)
+
+    def test_append_list_to_DjangoTemplates_context_processors(self):
+        old_setting = deepcopy(settings.TEMPLATES[0])
+        new_cps = ["a", "b"]
+        result = update_context_processors_list(new_cps)
+        self.assertTrue(result)
+        new_setting = deepcopy(settings.TEMPLATES[0])
+        self.assertNotEqual(old_setting, new_setting)
+        old_cps = old_setting["OPTIONS"].pop("context_processors")
+        new_cps = new_setting["OPTIONS"].pop("context_processors")
+        self.assertEqual(old_setting, new_setting)
+        self.assertNotEqual(old_cps, new_cps)

--- a/tests/site/test_settings_helpers.py
+++ b/tests/site/test_settings_helpers.py
@@ -46,10 +46,10 @@ class NormalizeUrlTests(unittest.TestCase):
 
 
 class GetUrlPatternsFromSettingsTest(unittest.TestCase):
-    def test_if_falsey_setting_return_empty_list(self):
+    def test_when_setting_is_falsey_return_empty_list(self):
         self.assertEqual(get_urlpatterns_from_setting(None), [])
 
-    def test_if_falsey_urls_return_empty_list(self):
+    def test_when_setting_contains_falsey_urls_should_return_empty_list(self):
         class Obj:
             pass
 
@@ -58,7 +58,12 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
 
         self.assertEqual(get_urlpatterns_from_setting([obj]), [])
 
-    def test_urls_without_namspace_return_list_of_paths_without_namespace(self):
+    def test_urls_without_namespace_return_list_of_paths_without_namespace(self):
+        # django.urls.include has one obligatory positional argument that is
+        # either an urlpatterns-list or a dotted path to a module that contains
+        # an urlpatterns list that is labeled "urlpatterns". It also has
+        # a keyword argument "namespace". This tests including urlpatterns that
+        # DOES NOT have namespace set.
         raw_setting = {
             "app_name": "foo",
             "urls": {
@@ -72,7 +77,12 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
         self.assertTrue(isinstance(result[0], URLResolver))
         self.assertFalse(result[0].namespace)
 
-    def test_urls_with_namspace_return_list_of_paths_with_namespace(self):
+    def test_urls_with_namespace_return_list_of_paths_with_namespace(self):
+        # django.urls.include has one obligatory positional argument that is
+        # either an urlpatterns-list or a dotted path to a module that contains
+        # an urlpatterns list that is labeled "urlpatterns". It also has
+        # a keyword argument "namespace". This tests including urlpatterns that
+        # DO have namespace set.
         raw_setting = {
             "app_name": "foo",
             "urls": {
@@ -89,7 +99,7 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
 
 
 class UpdateContextProcessorsListTests(unittest.TestCase):
-    def test_do_nothing_if_cp_setting_not_set(self):
+    def test_when_context_processor_setting_is_unset_it_should_do_nothing(self):
         raw_setting = {
             "app_name": "foo",
             "urls": {
@@ -103,7 +113,7 @@ class UpdateContextProcessorsListTests(unittest.TestCase):
         result = update_context_processors_list(TEMPLATES, None)
         self.assertEqual(result, TEMPLATES)
 
-    def test_do_nothing_if_template_setting_is_falsey(self):
+    def test_when_template_setting_is_falsey_it_should_do_nothing(self):
         TEMPLATES = []
         raw_setting = {
             "app_name": "foo",
@@ -113,7 +123,7 @@ class UpdateContextProcessorsListTests(unittest.TestCase):
         result = update_context_processors_list(TEMPLATES, [app_setting])
         self.assertEqual(result, TEMPLATES)
 
-    def test_only_update_DjangoTemplates_section(self):
+    def test_when_it_is_not_a_DjangoTemplates_section_it_should_do_nothing(self):
         raw_setting = {
             "app_name": "foo",
             "context_processors": ["omega"],
@@ -125,7 +135,7 @@ class UpdateContextProcessorsListTests(unittest.TestCase):
         result = update_context_processors_list(TEMPLATES, [app_setting])
         self.assertEqual(result, TEMPLATES)
 
-    def test_append_cp_in_app_settings_to_DjangoTemplates_context_processors(self):
+    def test_append_context_processors_in_setting_to_DjangoTemplates_context_processors_list(self):
         raw_setting = {
             "app_name": "foo",
             "context_processors": ["omega"],

--- a/tests/site/test_settings_validators.py
+++ b/tests/site/test_settings_validators.py
@@ -4,7 +4,7 @@ from argus.site.settings._serializers import AppSetting
 
 
 class AppSettingTests(unittest.TestCase):
-    def test_just_app_in_setting_should_validate(self):
+    def test_when_app_settings_only_contains_app_name_it_should_validate(self):
         setting = {"app_name": "foo"}
         result = AppSetting(**setting)
         self.assertTrue(result.app_name)

--- a/tests/site/test_settings_validators.py
+++ b/tests/site/test_settings_validators.py
@@ -1,0 +1,12 @@
+import unittest
+
+from argus.site.settings._serializers import AppSetting
+
+
+class AppSettingTests(unittest.TestCase):
+    def test_just_app_in_setting_should_validate(self):
+        setting = {"app_name": "foo"}
+        result = AppSetting(**setting)
+        self.assertTrue(result.app_name)
+        self.assertFalse(result.urls)
+        self.assertFalse(result.context_processors)


### PR DESCRIPTION
Bonus: halt setup with a traceback if the JSON in EXTRA_APPS/OVERRIDING_APPS is buggy!

How to use: 
 add a context processor in an app (for instance `argus_htmx.context_processors` in Uninett/argus-htmx-frontend#15) to the app, it's a list on the key `context_processors`.