### PR TITLE
Factor out codecov upload

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -31,14 +31,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           tags: |
             type=semver,pattern={{version}}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push backend Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,4 +1,4 @@
-name: Publish test results
+name: Publish test and coverage results
 
 on:
   workflow_run:
@@ -8,11 +8,19 @@ on:
 
 jobs:
   publish-test-results:
-    name: "Publish test results"
+    name: "Publish test and coverage results"
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
+      # Checking out the repo is necessary codecov/codecov-action@v4 to work properly
+      # Codecov requires source code to process the coverage file and generate coverage
+      # reports
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -34,3 +42,9 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"
           files: artifacts/**/*-results.xml
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -29,7 +29,7 @@ jobs:
            done
 
       - name: "Publish test results"
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -10,7 +10,7 @@ jobs:
   publish-test-results:
     name: "Publish test and coverage results"
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:
       # Checking out the repo is necessary codecov/codecov-action@v4 to work properly

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -43,8 +43,31 @@ jobs:
           check_name: "Test results"
           files: artifacts/**/*-results.xml
 
+      - name: Read PR number file
+        if: ${{ hashFiles('artifacts/extra/pr_number') != '' }}
+        run: |
+          pr_number=$(cat artifacts/extra/pr_number)
+          re='^[0-9]+$'
+          if [[ $pr_number =~ $re ]] ; then
+            echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+          fi
+
+      - name: Read base SHA file
+        if: ${{ hashFiles('artifacts/extra/base_sha') != '' }}
+        run: |
+          base_sha=$(cat artifacts/extra/base_sha)
+          re='[0-9a-f]{40}'
+          if [[ $base_sha =~ $re ]] ; then
+            echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
+          fi
+
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          override_branch: ${{ github.event.workflow_run.head_branch}}
+          override_commit: ${{ github.event.workflow_run.head_sha}}
+          commit_parent: ${{ env.BASE_SHA }}
+          override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -93,3 +93,25 @@ jobs:
         name: test-reports-${{ matrix.python-version }}
         path: |
           test-reports/**/*
+
+
+  upload-pr-number-base-sha:
+    name: Save PR number and base SHA in artifact
+    runs-on: ubuntu-latest
+    if: ${{ github.event.number && always() }}
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - name: Make PR number file
+        run: |
+          mkdir -p ./extra
+          echo $PR_NUMBER > ./extra/pr_number
+      - name: Make base SHA file
+        run: |
+          echo $BASE_SHA > ./extra/base_sha
+      - name: Upload PR number file and base SHA file
+        uses: actions/upload-artifact@v4
+        with:
+          name: extra
+          path: extra/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,20 +86,6 @@ jobs:
       run: |
         python -m tox
 
-    - name: "Combine coverage"
-      if: "contains(env.USING_COVERAGE, matrix.python-version)"
-      run: |
-        set -xe
-        python -m coverage combine
-        python -m coverage xml
-
-    - name: Upload to Codecov
-      if: "github.repository_owner == 'Uninett' && contains(env.USING_COVERAGE, matrix.python-version)"
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true
-
     - name: Upload test reports (${{ matrix.python-version }})
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache
       with:
         path: ~/.cache/pip
@@ -18,7 +18,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
@@ -44,9 +44,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache
       with:
         path: ~/.cache/pip
@@ -55,7 +55,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -104,8 +104,8 @@ jobs:
 
     - name: Upload test reports (${{ matrix.python-version }})
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test-reports
+        name: test-reports-${{ matrix.python-version }}
         path: |
           test-reports/**/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,8 +35,6 @@ jobs:
 
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
-    env:
-      USING_COVERAGE: '3.8'
 
     strategy:
       max-parallel: 4

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Towncrier check
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Closes #801.

Since upgrading the codecov action to version 4 uploading coverage reports without a token (so when creating a PR from a fork) is severely rate limited, which resulted often enough in our tests seemingly failing, even though it was only the coverage upload failing. (Reference: https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)

Workflows that are triggered by other workflows are always run within the context of the main repository, instead of within the fork (except for workflows triggered by pushes to main in a fork, they are run within the context of the fork). This means that that way we can have access to the secret CODECOV_TOKEN and avoid the rate limitations.

Since we already upload our coverage results as artifacts in the Upload test reports step of the tests workflow, we decided to move the uploading coverage step to the same workflow where we publish the test results: publish-test-results. This workflow is triggered by the completion of the tests workflow, which means it is run within the context of the main repository.

Moving the uploading coverage step to the publish-test-results worked great in the way that we have access to the CODECOV_TOKEN, but due to the context switch codecov could not properly tell anymore which branch, commit and pull request that coverage information belongs to.

That is why we override the pull request, commit, base and branch information.

Getting the associated pull request number and base SHA is quite a bit more complicated and it involves saving them in a file, then uploading it as an artifact, then downloading that artifact and after validation using them in configuring codecov.

This also upgrades various actions used in these workflows.
Reference for why we need to rename the artifacts after upgrading the upload artifacts action: https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
