### PR TITLE
Fix generating coverage reports

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,9 @@
 name: Test django site
 
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,6 +35,8 @@ jobs:
 
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
+    env:
+      USING_COVERAGE: '3.8'
 
     strategy:
       max-parallel: 4
@@ -85,6 +87,13 @@ jobs:
         DATABASE_URL: "postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost/${{ env.POSTGRES_DB }}"
       run: |
         python -m tox
+
+    - name: "Combine coverage"
+      if: contains(env.USING_COVERAGE, matrix.python-version)
+      run: |
+        set -xe
+        python -m coverage combine
+        python -m coverage xml
 
     - name: Upload test reports (${{ matrix.python-version }})
       if: always()

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,8 +35,6 @@ jobs:
 
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
-    env:
-      USING_COVERAGE: '3.8'
 
     strategy:
       max-parallel: 4
@@ -89,7 +87,6 @@ jobs:
         python -m tox
 
     - name: "Combine coverage"
-      if: contains(env.USING_COVERAGE, matrix.python-version)
       run: |
         set -xe
         python -m coverage combine

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         set -xe
         python -m coverage combine
-        python -m coverage xml
+        python -m coverage xml -o test-reports/${{ matrix.python-version }}/coverage.xml
 
     - name: Upload test reports (${{ matrix.python-version }})
       if: always()


### PR DESCRIPTION
When working on #830 I incorrectly removed the part that takes the `.coverage` file(s) and generated the necessary `coverage.xml` file. 

This PR adds it back and puts it in the same folder as the test results to be uploaded as an artifact together.

And we change this workflow to only run on all PRs and pushes to master - to avoid running all the tests twice when creating PRs - once on push and once on PR. 