### PR TITLE
Force override ZIP files from artifacts

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -33,7 +33,7 @@ jobs:
            do
              IFS=$'\t' read name url <<< "$artifact"
              gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
+             unzip -o -d "$name" "$name.zip"
            done
 
       - name: "Publish test results"


### PR DESCRIPTION
This can happen when for multiple python versions tests fail only on some.

When rerunning only these failing tests it leads to these files already existing and it waits for confirmation to override these files.

So we force this override so that this action doesn't fail.

Example for this happening: https://github.com/Uninett/Argus/actions/runs/9659202194/job/26642852840

I don't think we need this for any other repo, since only in Argus the tests sometimes fail, which is fixed by rerunning them. 