### PR TITLE
Prefetch related data in incidents endpoint

### DIFF
--- a/changelog.d/837.fixed.md
+++ b/changelog.d/837.fixed.md
@@ -1,0 +1,1 @@
+Improve `/incident` endpoint response time by roughly 36% by pre-fetching incident tag data

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -243,7 +243,7 @@ class IncidentViewSet(
 
     pagination_class = IncidentPagination
     permission_classes = [IsAuthenticated]
-    queryset = Incident.objects.all()
+    queryset = Incident.objects.prefetch_default_related()
     filter_backends = [filters.DjangoFilterBackend, SearchFilter]
     filterset_class = IncidentFilter
     search_fields = ["description", "search_text"]


### PR DESCRIPTION
The incidents endpoint does not appear to prefetch tag data when querying incidents.  This may cause the response to be magnitudes slower that it needs to be.

For context, fetching 2.5K incidents is 99% faster if tag data is prefetched:

```pycon
>>> timeit.timeit("""
... for i in x:
...     i.deprecated_tags
... """, setup="x = Incident.objects.all()[:2500]", number=2, globals=locals())
69.45030555600533
>>> timeit.timeit("""
... for i in x:
...    i.deprecated_tags
... """, setup="x = Incident.objects.prefetch_default_related()[:2500]", number=2, globals=locals())
0.4965064429998165
>>>
```

The difference may not be as stark in the API endpoint itself, as most of the time there is spent serializing the data to JSON (DRF's ModelSerializer is reaally slow).  Simply testing the API before and after applying this change seems to indicate only a 36% speedup (which is still significant).
