### PR TITLE
Use API v2 incident serializer instead of v1

### DIFF
--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -69,7 +69,6 @@ from .serializers import (
     TagSerializer,
     IncidentTagRelation,
 )
-from .V1.serializers import IncidentSerializerV1
 
 LOG = logging.getLogger(__name__)
 
@@ -304,7 +303,7 @@ class TicketPluginViewSet(viewsets.ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        serialized_incident = IncidentSerializerV1(incident).data
+        serialized_incident = IncidentSerializer(incident).data
         serialized_incident["argus_url"] = urljoin(
             getattr(settings, "FRONTEND_URL", ""),
             f"incidents/{incident_pk}",


### PR DESCRIPTION
The only outwards change is metadata and I tested this by adding it to `src/argus/incident/templates/incident/ticket/default_ticket_body.html` and it works as expected, but no fancy formatting, that we would need to add later if it is desired. 