### PR TITLE
Add gitkeep file to ignored towncrier files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ underlines = ["", "", ""]
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/Uninett/Argus/issues/{issue})"
 wrap = true
+ignore = [".gitkeep"]
 
 [[tool.towncrier.type]]
 directory = "security"


### PR DESCRIPTION
Release 24.7.0 made this necessary by scanning for invalid filenames

References: https://github.com/twisted/towncrier/pull/622, https://towncrier.readthedocs.io/en/stable/release-notes.html#towncrier-24-7-0-2024-07-31