### PR TITLE
Trigger workflow in argus-docker on release

### DIFF
--- a/.github/workflows/trigger-argus-docker.yml
+++ b/.github/workflows/trigger-argus-docker.yml
@@ -1,0 +1,36 @@
+name: Trigger workflow in argus-docker on release
+
+on:
+  release:
+    types: ["released"]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate an installation access token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: "argus-docker"
+      - name: Trigger Workflow in argus-docker
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          repo_owner="Uninett"
+          repo_name="argus-docker"
+          event_type="trigger-release"
+          repository="${{ github.event.repository.name }}"
+          version="${{ github.event.release.tag_name }}"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\", \
+            \"client_payload\": {\"repository\": \"$repository\", \"version\": \"$version\"}}"


### PR DESCRIPTION
Will trigger the workflow added in Uninett/argus-docker#6.

Another part to close Uninett/argus-docker#4.

To get this to work we need to install a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow) that has the permissions to trigger workflows in Argus. This app will be used by the used GitHub action [create-github-app-token](https://github.com/actions/create-github-app-token/tree/v1/) to create a token with the necessary permissions. 