### PR TITLE
Upgrade pre-commit to towncrier 24.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     -   id: black
         exclude: migrations/
 -   repo: https://github.com/twisted/towncrier
-    rev: 24.7.1
+    rev: 24.8.0
     hooks:
       - id: towncrier-check
         files: $changelog\.d/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ underlines = ["", "", ""]
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/Uninett/Argus/issues/{issue})"
 wrap = true
-ignore = [".gitkeep"]
 
 [[tool.towncrier.type]]
 directory = "security"


### PR DESCRIPTION
This version automatically ignores .gitkeep files. Reverts #853.