### PR TITLE
Improve ticket url handling

### DIFF
--- a/changelog.d/+improve-ticket-url-handling.changed.md
+++ b/changelog.d/+improve-ticket-url-handling.changed.md
@@ -1,0 +1,6 @@
+Refactored ticket creation code so the actual changing of the incident happens
+only in one place. Also moved the actual autocreation magic to utility
+functions (sans error-handling since that is response-type dependent). Made
+bulk changes of tickets actually create the ChangeEvents so that it behaves
+like other bulk actions and make it possible to get notified of changed ticket
+urls.

--- a/src/argus/dev/management/commands/bulk_incidents.py
+++ b/src/argus/dev/management/commands/bulk_incidents.py
@@ -123,16 +123,20 @@ class Command(BaseCommand):
 
         incident_qs = Incident.objects.filter(pk__in=incident_pks)
 
+        timestamp = options.get("timestamp") or None
+        description = options.get("description") or ""
+
         if action == "ticket_url":
             url = options.get("url") or None
             if not url:
                 self.stderr.write(self.style.WARNING("A ticket url is needed."))
                 return
 
-            incident_qs.update_ticket_url(url=url)
-
-        timestamp = options.get("timestamp") or None
-        description = options.get("description") or ""
+            incident_qs.update_ticket_url(
+                actor=actor,
+                url=url,
+                timestamp=timestamp,
+            )
 
         if action == "ack":
             expiration = options.get("expiration") or None

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -555,6 +555,14 @@ class Incident(models.Model):
         event = ChangeEvent.change_level(self, actor, new_level, timestamp)
         return event
 
+    # @transaction.atomic
+    def change_ticket_url(self, actor, url="", timestamp=None):
+        old_ticket_url = self.ticket_url
+        self.ticket_url = url
+        self.save(update_fields=["ticket_url"])
+        event = ChangeEvent.change_ticket_url(self, actor, old_ticket_url, url, timestamp)
+        return event
+
     def pp_details_url(self):
         "Merge Incident.details_url with Source.base_url"
         path = self.details_url.strip()
@@ -614,6 +622,14 @@ class ChangeEvent(Event):
     def change_level(cls, incident, actor, new_level, timestamp=None):
         timestamp = timestamp if timestamp else timezone.now()
         description = cls.format_description("level", incident.level, new_level)
+        event = cls(incident=incident, actor=actor, timestamp=timestamp, description=description)
+        event.save()
+        return event
+
+    @classmethod
+    def change_ticket_url(cls, incident, actor, old_ticket="", new_ticket="", timestamp=None):
+        timestamp = timestamp if timestamp else timezone.now()
+        description = cls.format_description("ticket_url", old_ticket, new_ticket)
         event = cls(incident=incident, actor=actor, timestamp=timestamp, description=description)
         event.save()
         return event

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -349,9 +349,12 @@ class IncidentQuerySet(models.QuerySet):
         events = qs.create_events(actor, event_type, timestamp, description)
         return events
 
-    def update_ticket_url(self, url: str):
-        self.update(ticket_url=url)
-        return self.all()  # Return updated qs
+    def update_ticket_url(self, actor: User, url: str, timestamp=None):
+        events = set()
+        for incident in self:
+            event = incident.change_ticket_url(actor, url, timestamp)
+            events.add(event.pk)
+        return self.all()
 
 
 # TODO: review whether fields should be nullable, and on_delete modes

--- a/src/argus/incident/ticket/utils.py
+++ b/src/argus/incident/ticket/utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin
+
+from django.conf import settings
+
+from argus.incident.ticket.base import (
+    TicketSettingsException,
+)
+from argus.util.utils import import_class_from_dotted_path
+
+from ..serializers import IncidentSerializer
+
+if TYPE_CHECKING:
+    from argus.incident.models import Incident
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+
+
+LOG = logging.getLogger(__name__)
+SETTING_NAME = "TICKET_PLUGIN"
+
+
+__all__ = [
+    "SETTING_NAME",
+    "get_autocreate_ticket_plugin",
+    "serialize_incident_for_ticket_autocreation",
+]
+
+
+def get_autocreate_ticket_plugin():
+    plugin = getattr(settings, SETTING_NAME, None)
+
+    if not plugin:
+        raise TicketSettingsException(
+            f'No path to ticket plugin can be found in the settings. Please update the setting "{SETTING_NAME}".'
+        )
+
+    try:
+        ticket_class = import_class_from_dotted_path(plugin)
+    except Exception as e:
+        LOG.exception("Could not import ticket plugin from path %s", plugin)
+        raise TicketSettingsException(f"Ticket plugin is incorrectly configured: {e}")
+    else:
+        return ticket_class
+
+
+def serialize_incident_for_ticket_autocreation(incident: Incident, actor: User):
+    serialized_incident = IncidentSerializer(incident).data
+    # TODO: ensure argus_url ends with "/" on HTMx frontend
+    serialized_incident["argus_url"] = urljoin(
+        getattr(settings, "FRONTEND_URL", ""),
+        f"incidents/{incident.pk}",
+    )
+    serialized_incident["user"] = actor.get_full_name()
+    return serialized_incident

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -722,7 +722,7 @@ class BulkTicketUrlViewSet(BulkHelper, viewsets.ViewSet):
 
         qs, changes, status_codes_seen = self.bulk_setup(incident_ids)
 
-        incidents = qs.update_ticket_url(ticket_url)
+        incidents = qs.update_ticket_url(request.user, ticket_url, timestamp=timezone.now())
         for incident in incidents:
             changes[str(incident.id)] = {
                 "ticket_url": ticket_url,

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -339,12 +339,7 @@ class TicketPluginViewSet(viewsets.ViewSet):
             )
 
         if url:
-            description = ChangeEvent.format_description("ticket_url", "", url)
-            ChangeEvent.objects.create(
-                incident=incident, actor=request.user, timestamp=timezone.now(), description=description
-            )
-            incident.ticket_url = url
-            incident.save(update_fields=["ticket_url"])
+            incident.change_ticket_url(request.user, url, timezone.now())
             serializer = self.serializer_class(data={"ticket_url": incident.ticket_url})
             if serializer.is_valid():
                 return Response(serializer.data, status=status.HTTP_200_OK)

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -1,6 +1,5 @@
 import logging
 import secrets
-from urllib.parse import urljoin
 
 from django.conf import settings
 from django.db import IntegrityError
@@ -29,6 +28,10 @@ from argus.incident.ticket.base import (
     TicketCreationException,
     TicketPluginException,
     TicketSettingsException,
+)
+from argus.incident.ticket.utils import (
+    get_autocreate_ticket_plugin,
+    serialize_incident_for_ticket_autocreation,
 )
 from argus.notificationprofile.media import (
     send_notifications_to_users,
@@ -285,38 +288,23 @@ class TicketPluginViewSet(viewsets.ViewSet):
     def update(self, request, incident_pk=None):
         incident = get_object_or_404(self.queryset, pk=incident_pk)
 
+        # never overwrite existing url
         if incident.ticket_url:
             serializer = self.serializer_class(data={"ticket_url": incident.ticket_url})
             if serializer.is_valid():
                 return Response(serializer.data, status=status.HTTP_200_OK)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        plugin = getattr(settings, "TICKET_PLUGIN", None)
+        try:
+            ticket_plugin = get_autocreate_ticket_plugin()
+        except TicketSettingsException as e:
+            # shouldn't this be a 500 Server Error?
+            return Response(data=str(e), status=status.HTTP_400_BAD_REQUEST)
 
-        if not plugin:
-            return Response(
-                data="No path to ticket plugin can be found in the settings. Please update the setting 'TICKET_PLUGIN'.",
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        serialized_incident = serialize_incident_for_ticket_autocreation(incident, request.user)
 
         try:
-            ticket_class = import_class_from_dotted_path(plugin)
-        except Exception:
-            LOG.exception("Could not import ticket plugin from path %s", plugin)
-            return Response(
-                data="Ticket plugins are incorrectly configured.",
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        serialized_incident = IncidentSerializer(incident).data
-        serialized_incident["argus_url"] = urljoin(
-            getattr(settings, "FRONTEND_URL", ""),
-            f"incidents/{incident_pk}",
-        )
-        serialized_incident["user"] = request.user.get_full_name()
-
-        try:
-            url = ticket_class.create_ticket(serialized_incident)
+            url = ticket_plugin.create_ticket(serialized_incident)
         except TicketSettingsException as e:
             return Response(
                 data=str(e),

--- a/tests/incident/test_queryset.py
+++ b/tests/incident/test_queryset.py
@@ -100,7 +100,7 @@ class IncidentQuerySetUpdatingTestCase(TestCase):
     @tag("bulk")
     def test_update_ticket_url(self):
         qs = Incident.objects.filter(id__in=(self.incident1.id, self.incident2.id))
-        qs.update_ticket_url("http://vg.no")
+        qs.update_ticket_url(self.user, "http://vg.no")
         result = qs.has_ticket()
         self.assertEqual(set(result), set(qs.all()))
 

--- a/tests/incident/test_queryset.py
+++ b/tests/incident/test_queryset.py
@@ -92,9 +92,7 @@ class IncidentQuerySetUpdatingTestCase(TestCase):
     def test_create_events(self):
         qs = Incident.objects.filter(id__in=(self.incident3.id, self.incident4.id))
         qs.create_events(self.user, Event.Type.OTHER, description="foo")
-        result = set(
-            e.incident for e in Event.objects.filter(type=Event.Type.OTHER)
-        )
+        result = set(e.incident for e in Event.objects.filter(type=Event.Type.OTHER))
         self.assertEqual(result, set(qs.all()))
 
     @tag("bulk")
@@ -108,9 +106,7 @@ class IncidentQuerySetUpdatingTestCase(TestCase):
     def test_close_incidents(self):
         qs = Incident.objects.filter(id__in=(self.incident2.id, self.incident3.id))
         qs.close(self.user, description="Boo")
-        result = set(
-            e.incident for e in Event.objects.filter(type=Event.Type.CLOSE, description="Boo")
-        )
+        result = set(e.incident for e in Event.objects.filter(type=Event.Type.CLOSE, description="Boo"))
         self.assertEqual(result, set(qs.all()))
 
     @tag("bulk")
@@ -119,7 +115,5 @@ class IncidentQuerySetUpdatingTestCase(TestCase):
         self.incident3.set_closed(self.user)
         qs = Incident.objects.filter(id__in=(self.incident2.id, self.incident3.id))
         qs.reopen(self.user, description="Bar")
-        result = set(
-            e.incident for e in Event.objects.filter(type=Event.Type.REOPEN, description="Bar")
-        )
+        result = set(e.incident for e in Event.objects.filter(type=Event.Type.REOPEN, description="Bar"))
         self.assertEqual(result, set(qs.all()))


### PR DESCRIPTION
Refactor the hardcoded ticket creation logic in the API views so they can also be used for HTML views.

One change in functionality: make a bulk update of tickets create the proper ChangeEvent per incident so that this behaves like any other bulk update.