### PR TITLE
Remove FilterBlobSerializer dependents from plugin

### DIFF
--- a/changelog.d/+simplify-filter-plugin.changed.md
+++ b/changelog.d/+simplify-filter-plugin.changed.md
@@ -1,0 +1,4 @@
+Removed `FilterSerializer` and `validate_jsonfilter` from the filter plugin
+mechanism since they just wrap `FilterBlobSerializer`. (This also means
+`FilterBlobSerializer` can no longer be in the same file as
+`FilterSerializer`.)

--- a/src/argus/dev/management/commands/list_filters.py
+++ b/src/argus/dev/management/commands/list_filters.py
@@ -1,11 +1,8 @@
 from django.contrib.auth.hashers import check_password
 from django.core.management.base import BaseCommand
 
-from argus.filter import get_filter_backend
+from argus.filter.serializers import FilterSerializer
 from argus.notificationprofile.models import Filter
-
-filter_backend = get_filter_backend()
-FilterSerializer = filter_backend.FilterSerializer
 
 
 class Command(BaseCommand):

--- a/src/argus/filter/checks.py
+++ b/src/argus/filter/checks.py
@@ -1,10 +1,7 @@
 from django.conf import settings
 from django.core.checks import Warning
 
-from argus.filter import get_filter_backend
-
-filter_backend = get_filter_backend()
-validate_jsonfilter = filter_backend.validate_jsonfilter
+from argus.filter.validators import validate_jsonfilter
 
 
 __all__ = ["fallback_filter_check"]

--- a/src/argus/filter/default.py
+++ b/src/argus/filter/default.py
@@ -11,8 +11,4 @@ from .filters import (  # noqa: F401
     INCIDENT_OPENAPI_PARAMETER_DESCRIPTIONS,
     SOURCE_LOCKED_INCIDENT_OPENAPI_PARAMETER_DESCRIPTIONS,
 )
-from .serializers import (  # noqa: F401
-    FilterSerializer,
-    FilterBlobSerializer,
-)
-from .validators import validate_jsonfilter  # noqa: F401
+from .swappable.serializers import FilterBlobSerializer  # noqa: F401

--- a/src/argus/filter/serializers.py
+++ b/src/argus/filter/serializers.py
@@ -1,38 +1,15 @@
-from rest_framework import fields, serializers
+from rest_framework import serializers
 
-from argus.incident.constants import INCIDENT_LEVELS
-from argus.incident.models import Event
 from argus.notificationprofile.models import Filter
-from .primitive_serializers import CustomMultipleChoiceField
+from argus.filter import get_filter_backend
+
+filter_backend = get_filter_backend()
+FilterBlobSerializer = filter_backend.FilterBlobSerializer
 
 
 __all__ = [
-    "FilterBlobSerializer",
     "FilterSerializer",
 ]
-
-
-class FilterBlobSerializer(serializers.Serializer):
-    sourceSystemIds = serializers.ListField(
-        child=serializers.IntegerField(min_value=1),
-        allow_empty=True,
-        required=False,
-    )
-    tags = serializers.ListField(
-        child=serializers.CharField(min_length=3),
-        allow_empty=True,
-        required=False,
-    )
-    open = serializers.BooleanField(required=False, allow_null=True)
-    acked = serializers.BooleanField(required=False, allow_null=True)
-    stateful = serializers.BooleanField(required=False, allow_null=True)
-    maxlevel = serializers.IntegerField(
-        required=False, allow_null=True, max_value=max(INCIDENT_LEVELS), min_value=min(INCIDENT_LEVELS)
-    )
-    event_types = CustomMultipleChoiceField(
-        choices=Event.Type.choices,
-        required=False,
-    )
 
 
 class FilterSerializer(serializers.ModelSerializer):

--- a/src/argus/filter/swappable/serializers.py
+++ b/src/argus/filter/swappable/serializers.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+
+from argus.incident.constants import INCIDENT_LEVELS
+from argus.incident.models import Event
+from ..primitive_serializers import CustomMultipleChoiceField
+
+
+__all__ = [
+    "FilterBlobSerializer",
+]
+
+
+class FilterBlobSerializer(serializers.Serializer):
+    sourceSystemIds = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=True,
+        required=False,
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(min_length=3),
+        allow_empty=True,
+        required=False,
+    )
+    open = serializers.BooleanField(required=False, allow_null=True)
+    acked = serializers.BooleanField(required=False, allow_null=True)
+    stateful = serializers.BooleanField(required=False, allow_null=True)
+    maxlevel = serializers.IntegerField(
+        required=False, allow_null=True, max_value=max(INCIDENT_LEVELS), min_value=min(INCIDENT_LEVELS)
+    )
+    event_types = CustomMultipleChoiceField(
+        choices=Event.Type.choices,
+        required=False,
+    )

--- a/src/argus/filter/validators.py
+++ b/src/argus/filter/validators.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 
-from argus.filter.serializers import FilterBlobSerializer
+from argus.filter import get_filter_backend
+
+filter_backend = get_filter_backend()
+FilterBlobSerializer = filter_backend.FilterBlobSerializer
 
 
 __all__ = [

--- a/src/argus/notificationprofile/checks.py
+++ b/src/argus/notificationprofile/checks.py
@@ -1,11 +1,7 @@
 from django.conf import settings
 from django.core.checks import Warning
 
-from argus.filter import get_filter_backend
-
-
-filter_backend = get_filter_backend()
-validate_jsonfilter = filter_backend.validate_jsonfilter
+from argus.filter.validators import validate_jsonfilter
 
 
 __all__ = ["fallback_filter_check"]

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -1,14 +1,10 @@
 from rest_framework import fields, serializers
 
-from argus.filter import get_filter_backend
-from argus.filter.primitive_serializers import CustomMultipleChoiceField
+from argus.filter.serializers import FilterSerializer
 from argus.incident.constants import INCIDENT_LEVELS
 from argus.incident.models import Event
 from .media import api_safely_get_medium_object
 from .models import DestinationConfig, Media, NotificationProfile, TimeRecurrence, Timeslot
-
-filter_backend = get_filter_backend()
-FilterSerializer = filter_backend.FilterSerializer
 
 
 class TimeRecurrenceSerializer(serializers.ModelSerializer):

--- a/src/argus/notificationprofile/views.py
+++ b/src/argus/notificationprofile/views.py
@@ -15,6 +15,7 @@ from drf_rw_serializers import viewsets as rw_viewsets
 
 from argus.drf.permissions import IsOwner
 from argus.filter import get_filter_backend
+from argus.filter.serializers import FilterSerializer
 from argus.incident.serializers import IncidentSerializer
 from argus.notificationprofile.media import api_safely_get_medium_object
 from argus.notificationprofile.media.base import NotificationMedium
@@ -33,7 +34,6 @@ from .serializers import (
 
 filter_backend = get_filter_backend()
 QuerySetFilter = filter_backend.QuerySetFilter
-FilterSerializer = filter_backend.FilterSerializer
 FilterBlobSerializer = filter_backend.FilterBlobSerializer
 
 


### PR DESCRIPTION
Closes #861

FilterSerializer and validate_jsonfilter depend on FilterBlobSerializer and need not themselves be pluginable.