### PR TITLE
Convert Django's ValidationError to drf

### DIFF
--- a/changelog.d/+convert-exceptions.changed.md
+++ b/changelog.d/+convert-exceptions.changed.md
@@ -1,0 +1,4 @@
+Convert Django ValidationErrors to DRF ValidationErrors. This makes it possible
+to move some validation from API model serializers to the actual model, which
+means validating only once and the API and future Django frontend seeing the
+same errors.

--- a/src/argus/drf/__init__.py
+++ b/src/argus/drf/__init__.py
@@ -15,8 +15,7 @@ def exception_handler(exc, context):
     if isinstance(exc, DjangoValidationError):
         data = exc.message_dict
         if DJANGO_NON_FIELD_ERRORS in data:
-            data[DRF_NON_FIELD_ERRORS] = data[DJANGO_NON_FIELD_ERRORS]
-            del data[DJANGO_NON_FIELD_ERRORS]
+            data[DRF_NON_FIELD_ERRORS] = data.pop(DJANGO_NON_FIELD_ERRORS)
 
         exc = DRFValidationError(detail=data)
 

--- a/src/argus/drf/__init__.py
+++ b/src/argus/drf/__init__.py
@@ -1,0 +1,23 @@
+from django.core.exceptions import NON_FIELD_ERRORS as DJANGO_NON_FIELD_ERRORS
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.views import api_settings
+from rest_framework.views import exception_handler as drf_exception_handler
+
+DRF_NON_FIELD_ERRORS = api_settings.NON_FIELD_ERRORS_KEY
+
+
+__all__ = ["exception_handler"]
+
+
+def exception_handler(exc, context):
+    if isinstance(exc, DjangoValidationError):
+        data = exc.message_dict
+        if DJANGO_NON_FIELD_ERRORS in data:
+            data[DRF_NON_FIELD_ERRORS] = data[DJANGO_NON_FIELD_ERRORS]
+            del data[DJANGO_NON_FIELD_ERRORS]
+
+        exc = DRFValidationError(detail=data)
+
+    return drf_exception_handler(exc, context)

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -233,6 +233,7 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_VERSION": "v1",
+    "EXCEPTION_HANDLER": "argus.drf.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "PAGE_SIZE": 100,
 }


### PR DESCRIPTION
As we add more validation to the models and out of drf serializers and api views, we need to be able to convert Django's ValidationError to drf's ValidationError. Otherwise the api will raise a lot of unnecessary "500 Server Error"s