### PR TITLE
Improve docs about integrations

### DIFF
--- a/docs/integrations/_note.rst
+++ b/docs/integrations/_note.rst
@@ -1,5 +1,5 @@
 .. note::
    Open an issue on `Github <https://github.com/Uninett/Argus/issues>`_ to have
-   a glue service added to this list. It needs to be publicly accessible (and
+   your integration added to this list. It needs to be publicly accessible (and
    preferably available on PyPI) so we can check the code. We will link up both
    the source code repo (or homepage otherwise) and the PyPI-entry.

--- a/docs/integrations/_note.rst
+++ b/docs/integrations/_note.rst
@@ -1,0 +1,5 @@
+.. note::
+   Open an issue on `Github <https://github.com/Uninett/Argus/issues>`_ to have
+   a glue service added to this list. It needs to be publicly accessible (and
+   preferably available on PyPI) so we can check the code. We will link up both
+   the source code repo (or homepage otherwise) and the PyPI-entry.

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -27,7 +27,7 @@ Network Administration Visualized
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 | Source: https://github.com/Uninett/nav-argus-glue.
-| Pypi: `nav-argus-glue <https://pypi.org/project/nav-argus-glue/>`_
+| PyPI: `nav-argus-glue <https://pypi.org/project/nav-argus-glue/>`_
 
 This is an extension of NAV, runs on the same server, and uses the NAV config
 files.
@@ -37,7 +37,7 @@ Mist Systems Administration (Juniper)
 
 | Source: https://gitlab.sikt.no/cnaas/mist-argus
 
-This will be available on Pypi after more polish is done.
+This will be available on PyPI after more polish is done.
 
 Other glue services
 -------------------

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -1,23 +1,18 @@
-==========================================
-Integrating monitoring software with Argus
-==========================================
+.. index::
+   integration; glue service
+   glue service
+
+=========================================================
+Glue services: Integrating monitoring software with Argus
+=========================================================
+
+A *glue service* is the name we've given to any piece of software capable of
+receiving alerts from your monitoring system and translating these into
+incident state changes that are communicated to the Argus API server.
 
 In essence, to integrate your existing monitoring systems with Argus means to
 ensure your Argus incident database is synchronized with the alerts stemming
 from your monitoring systems.
-
-To ensure this, you will need what is termed a **glue service**.
-
-Glue services
-=============
-
-
-What is a glue service?
------------------------
-
-A *glue service* is any piece of software capable of receiving alerts from your
-monitoring system and translating these into incident state changes that are
-communicated to the Argus API server.
 
 A glue service for your particular monitoring system may already exist, or you
 may need to write your own.

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -52,11 +52,7 @@ NAGIOS
     https://github.com/SUNET/nglue-api, designed to run in a container. The
     nglue-api pre-filters what to send to argus.
 
-.. note::
-   Open an issue (`Github <https://github.com/Uninett/Argus/issues>`_) to have
-   a glue service added to this list. It needs to be publicly accessible (and
-   preferably available on PyPI) so we can check the code. We will link up both
-   the source code repo (or homepage otherwise) and the PyPI-entry.
+.. include:: ../_note.rst
 
 Integrating an existing monitoring system
 =========================================

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -20,8 +20,8 @@ may need to write your own.
 Existing glue services
 ======================
 
-1st party glue services
------------------------
+Glue services maintained by Argus developers
+--------------------------------------------
 
 Network Administration Visualized
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -45,7 +45,7 @@ Other glue services
 NAGIOS
 ~~~~~~
 
-  * There is a python script at https://github.com/SUNET/nagios-argus-glue. It
+  * There is a Python script at https://github.com/SUNET/nagios-argus-glue. It
     didn't scale to SUNET's needs.
   * There is code for a tiny rust binary at https://github.com/SUNET/nglue
     that is run by NAGIOS. It sends alerts to

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -53,10 +53,10 @@ NAGIOS
     nglue-api pre-filters what to send to argus.
 
 .. note::
-   Open an issue to have a glue service added to this list. It needs to be
-   publicly accessible (and preferably available on PyPI) so we can check the
-   code. We will link up both the source code repo (or homepage otherwise) and
-   the PyPI-entry.
+   Open an issue (`Github <https://github.com/Uninett/Argus/issues>`_) to have
+   a glue service added to this list. It needs to be publicly accessible (and
+   preferably available on PyPI) so we can check the code. We will link up both
+   the source code repo (or homepage otherwise) and the PyPI-entry.
 
 Integrating an existing monitoring system
 =========================================

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -45,12 +45,12 @@ Other glue services
 NAGIOS
 ~~~~~~
 
-  * There's a python script at https://github.com/SUNET/nagios-argus-glue. It
+  * There is a python script at https://github.com/SUNET/nagios-argus-glue. It
     didn't scale to SUNET's needs.
-  * There's the code for a tiny rust binary at https://github.com/SUNET/nglue
+  * There is code for a tiny rust binary at https://github.com/SUNET/nglue
     that is run by NAGIOS. It sends alerts to
     https://github.com/SUNET/nglue-api, designed to run in a container. The
-    nglue-api pre-filters what to send to argus.
+    ``nglue-api`` pre-filters what to send to Argus.
 
 .. include:: ../_note.rst
 

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -18,12 +18,27 @@ A glue service for your particular monitoring system may already exist, or you
 may need to write your own.
 
 Existing glue services
-----------------------
+======================
 
-* Network Administration Visualized: https://github.com/Uninett/nav-argus-glue.
-  This is an extension of nav, runs on the same server, and uses the NAV config
-  files.
-* NAGIOS:
+1st party glue services
+-----------------------
+
+Network Administration Visualized
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Source: https://github.com/Uninett/nav-argus-glue.
+
+This is an extension of NAV, runs on the same server, and uses the NAV config
+files.
+
+Mist Systems Administration (Juniper)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Source: https://gitlab.sikt.no/cnaas/mist-argus
+
+Other glue services
+-------------------
+
+NAGIOS
+~~~~~~
 
   * There's a python script at https://github.com/SUNET/nagios-argus-glue. It
     didn't scale to SUNET's needs.
@@ -31,7 +46,12 @@ Existing glue services
     that is run by NAGIOS. It sends alerts to
     https://github.com/SUNET/nglue-api, designed to run in a container. The
     nglue-api pre-filters what to send to argus.
-* Mist Systems Administration (Juniper): https://gitlab.sikt.no/cnaas/mist-argus
+
+.. note::
+   Open an issue to have a glue service added to this list. It needs to be
+   publicly accessible (and preferably available on PyPI) so we can check the
+   code. We will link up both the source code repo (or homepage otherwise) and
+   the PyPI-entry.
 
 Integrating an existing monitoring system
 =========================================

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -25,14 +25,19 @@ Existing glue services
 
 Network Administration Visualized
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Source: https://github.com/Uninett/nav-argus-glue.
+
+| Source: https://github.com/Uninett/nav-argus-glue.
+| Pypi: `nav-argus-glue <https://pypi.org/project/nav-argus-glue/>`_
 
 This is an extension of NAV, runs on the same server, and uses the NAV config
 files.
 
 Mist Systems Administration (Juniper)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Source: https://gitlab.sikt.no/cnaas/mist-argus
+
+| Source: https://gitlab.sikt.no/cnaas/mist-argus
+
+This will be available on Pypi after more polish is done.
 
 Other glue services
 -------------------

--- a/docs/integrations/notifications/email-plugin.rst
+++ b/docs/integrations/notifications/email-plugin.rst
@@ -1,7 +1,7 @@
 Email via Django's email support
 ================================
 
-| Class: argus.notificationprofile.media.email.EmailNotification
+| Class: ``argus.notificationprofile.media.email.EmailNotification``
 
 This plugin is enabled by default.
 

--- a/docs/integrations/notifications/email-plugin.rst
+++ b/docs/integrations/notifications/email-plugin.rst
@@ -1,5 +1,7 @@
-argus.notificationprofile.media.email.EmailNotification
-=======================================================
+Email via Django's email support
+================================
+
+| Class: argus.notificationprofile.media.email.EmailNotification
 
 This plugin is enabled by default.
 

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -3,7 +3,7 @@
    integration; notification plugin
 
 ===========================================
-Notification plugins: sending notifications
+Notification plugins: Sending notifications
 ===========================================
 
 Notifications are sent with the help of a notification plugin to one or more

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -35,9 +35,10 @@ Existing notification plugins
 1st party, other
 ----------------
 
-argus_notification_msteams.MSTeamsNotification
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Microsoft Teams
+~~~~~~~~~~~~~~~
 
+| Class: argus_notification_msteams.MSTeamsNotification
 | Source: https://github.com/Uninett/argus_notification_msteams
 | Pypi: `argus-notification-msteams <https://pypi.org/project/argus-notification-msteams/>`_
 

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -22,6 +22,36 @@ that type of plugin, like an email address, a phone number or a webhook.
 A specific type of destination might also need extra settings in the Django
 settings file, this is documented for each plugin.
 
+Existing notification plugins
+=============================
+
+Ist party, included on install
+------------------------------
+
+.. toctree::
+   email-plugin
+   sms-plugin
+
+Ist party, other
+----------------
+
+argus_notification_msteams.MSTeamsNotification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Source: https://github.com/Uninett/argus_notification_msteams
+
+pip install argus-notification-msteams
+
+Other notification plugins
+--------------------------
+
+None known to us at this time.
+
+.. note::
+   Open an issue to have a plugin added to this list. It needs to be publicly
+   accessible so we can check the code, and be on PyPI. We will link up both
+   the source code repo (or homepage otherwise) and the PyPI-entry.
+
 Configuring which notification plugins to use
 =============================================
 
@@ -34,25 +64,6 @@ The default is::
         "argus.notificationprofile.media.email.EmailNotification",
     ]
 
-Notification plugins included on install
-========================================
-
-.. toctree::
-   email-plugin
-   sms-plugin
-
-Other notification plugins
-==========================
-
-Open an issue to have a plugin added to this list. It needs to be publicly
-accessible so we can check the code, and be on PyPI. We will link up both the
-source code repo (or homepage otherwise) and the PyPI-entry.
-
-argus_notification_msteams.MSTeamsNotification
-----------------------------------------------
-
-| Source: https://github.com/Uninett/argus_notification_msteams
-| PyPI: https://pypi.org/project/argus-notification-msteams/
 
 Writing your own notification plugins
 =====================================

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -47,11 +47,7 @@ Other notification plugins
 
 None known to us at this time.
 
-.. note::
-   Open an issue (`Github <https://github.com/Uninett/Argus/issues>`_) to have
-   a plugin added to this list. It needs to be publicly accessible so we can
-   check the code, and be on PyPI. We will link up both the source code repo
-   (or homepage otherwise) and the PyPI-entry.
+.. include:: ../_note.rst
 
 Configuring which notification plugins to use
 =============================================

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -40,7 +40,7 @@ Microsoft Teams
 
 | Class: argus_notification_msteams.MSTeamsNotification
 | Source: https://github.com/Uninett/argus_notification_msteams
-| Pypi: `argus-notification-msteams <https://pypi.org/project/argus-notification-msteams/>`_
+| PyPI: `argus-notification-msteams <https://pypi.org/project/argus-notification-msteams/>`_
 
 Other notification plugins
 --------------------------

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -48,9 +48,10 @@ Other notification plugins
 None known to us at this time.
 
 .. note::
-   Open an issue to have a plugin added to this list. It needs to be publicly
-   accessible so we can check the code, and be on PyPI. We will link up both
-   the source code repo (or homepage otherwise) and the PyPI-entry.
+   Open an issue (`Github <https://github.com/Uninett/Argus/issues>`_) to have
+   a plugin added to this list. It needs to be publicly accessible so we can
+   check the code, and be on PyPI. We will link up both the source code repo
+   (or homepage otherwise) and the PyPI-entry.
 
 Configuring which notification plugins to use
 =============================================

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -38,9 +38,8 @@ Existing notification plugins
 argus_notification_msteams.MSTeamsNotification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Source: https://github.com/Uninett/argus_notification_msteams
-
-pip install argus-notification-msteams
+| Source: https://github.com/Uninett/argus_notification_msteams
+| Pypi: `argus-notification-msteams <https://pypi.org/project/argus-notification-msteams/>`_
 
 Other notification plugins
 --------------------------

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -25,14 +25,14 @@ settings file, this is documented for each plugin.
 Existing notification plugins
 =============================
 
-Ist party, included on install
+1st party, included on install
 ------------------------------
 
 .. toctree::
    email-plugin
    sms-plugin
 
-Ist party, other
+1st party, other
 ----------------
 
 argus_notification_msteams.MSTeamsNotification

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -38,7 +38,7 @@ Notification plugins maintained by Argus developers, optional
 Microsoft Teams
 
 
-| Class: argus_notification_msteams.MSTeamsNotification
+| Class: ``argus_notification_msteams.MSTeamsNotification``
 | Source: https://github.com/Uninett/argus_notification_msteams
 | PyPI: `argus-notification-msteams <https://pypi.org/project/argus-notification-msteams/>`_
 

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -25,18 +25,18 @@ settings file, this is documented for each plugin.
 Existing notification plugins
 =============================
 
-1st party, included on install
-------------------------------
+Notification plugins maintained by Argus developers, vendored
+-------------------------------------------------------------
 
 .. toctree::
    email-plugin
    sms-plugin
 
-1st party, other
-----------------
+Notification plugins maintained by Argus developers, optional
+-------------------------------------------------------------
 
 Microsoft Teams
-~~~~~~~~~~~~~~~
+
 
 | Class: argus_notification_msteams.MSTeamsNotification
 | Source: https://github.com/Uninett/argus_notification_msteams

--- a/docs/integrations/notifications/index.rst
+++ b/docs/integrations/notifications/index.rst
@@ -1,18 +1,23 @@
-====================================
-Notifications and their destinations
-====================================
+.. index::
+   integration; destination
+   integration; notification plugin
 
-Notifications are sent with the help of notification plugins to destinations.
+===========================================
+Notification plugins: sending notifications
+===========================================
 
-A notification plugin is a class that inherits from
+Notifications are sent with the help of a notification plugin to one or more
+destinations.
+
+A :index:`notification plugin` is a class that inherits from
 ``argus.notificationprofile.media.base.NotificationMedium``. It has a
 ``send(event, destinations, **kwargs)`` static method that does the actual
 sending.
 
-A destination is a user-specific and plugin-specific instance of the model
-DestinationConfig. In the DestinationConfig there's a field ``settings`` that
-has the necessary configuration for where to send the notification for that
-type of plugin, like an email address, a phone number or a webhook.
+A :index:`destination` is a user-specific and plugin-specific instance of the
+model DestinationConfig. In the DestinationConfig there's a field ``settings``
+that has the necessary configuration for where to send the notification for
+that type of plugin, like an email address, a phone number or a webhook.
 
 A specific type of destination might also need extra settings in the Django
 settings file, this is documented for each plugin.

--- a/docs/integrations/notifications/sms-plugin.rst
+++ b/docs/integrations/notifications/sms-plugin.rst
@@ -1,7 +1,7 @@
 SMS via Email
 =============
 
-| Class: argus.notificationprofile.media.sms_as_email.SMSNotification
+| Class: ``argus.notificationprofile.media.sms_as_email.SMSNotification``
 
 This plugin is **not** enabled by default.
 

--- a/docs/integrations/notifications/sms-plugin.rst
+++ b/docs/integrations/notifications/sms-plugin.rst
@@ -1,5 +1,7 @@
-argus.notificationprofile.media.sms_as_email.SMSNotification
-============================================================
+SMS via Email
+=============
+
+| Class: argus.notificationprofile.media.sms_as_email.SMSNotification
 
 This plugin is **not** enabled by default.
 

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -14,10 +14,52 @@ from an Argus incident with a pre-filled title and body.
 How to write a plugin for a desired ticket system is detailed in
 :ref:`writing-ticket-system-plugins`.
 
+Existing ticket system plugins
+==============================
+
+1st party ticket plugins
+------------------------
+
+Request Tracker
+~~~~~~~~~~~~~~~
+Source: https://pypi.org/project/argus-ticket-rt/
+
+pip install argus-ticket-rt
+
+Jira
+~~~~
+Source: https://pypi.org/project/argus-ticket-jira/
+
+pip install argus-ticket-jira
+
+Github
+~~~~~~
+Source: https://github.com/Uninett/argus_ticket_github
+
+pip install argus-ticket-github
+
+Gitlab
+~~~~~~
+Source: https://github.com/Uninett/argus_ticket_gitlab
+
+pip install argus-ticket-gitlab
+
+Other ticket plugins
+--------------------
+
+None known to us at this time.
+
+.. note::
+   Open an issue to have a plugin added to this list. It needs to be publicly
+   accessible (and preferably available on PyPI) so we can check the code. We
+   will link up both the source code repo (or homepage otherwise) and the
+   PyPI-entry.
+
 .. _ticket-systems-settings:
 
 Configuring a ticket plugin
 ===========================
+
 To enable this feature information needs to be added to the
 :ref:`site-specific-settings`.
 
@@ -45,26 +87,6 @@ to Argus.
 
 The specifics for each ticket system plugin is the documentation of the
 specific plugin.
-
-Known ticket system plugins
-===========================
-
-1st party ticket plugins
-------------------------
-
-* Request Tracker: https://pypi.org/project/argus-ticket-rt/, pip install argus-ticket-rt
-* Jira: https://pypi.org/project/argus-ticket-jira/, pip install argus-ticket-jira
-* Github: https://github.com/Uninett/argus_ticket_github, pip install argus-ticket-github
-* Gitlab: https://github.com/Uninett/argus_ticket_gitlab, pip install argus-ticket-gitlab
-
-Other ticket plugins
---------------------
-
-* None known to us at this time
-
-Open an issue to have a plugin added to this list. It needs to be publicly
-accessible (and preferably available on PyPI) so we can check the code. We will link up both the
-source code repo (or homepage otherwise) and the PyPI-entry.
 
 Writing your own ticket system plugin
 =====================================

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -21,8 +21,8 @@ How to write a plugin for a desired ticket system is detailed in
 Existing ticket system plugins
 ==============================
 
-1st party ticket plugins
-------------------------
+Ticket plugins maintained by Argus developers
+---------------------------------------------
 
 Request Tracker
 ~~~~~~~~~~~~~~~

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -1,11 +1,15 @@
+.. index::
+   integration; ticket system plugin
+   ticket system plugin
+
 .. _ticket-systems:
 
-==============
-Ticket systems
-==============
+====================================================
+Ticket system plugins: Automatically create a ticket
+====================================================
 
-It is possible to automatically create a ticket from an Argus incident with
-a pre-filled title and body.
+It is possible to automatically create a :index:`ticket` (aka. issue, case)
+from an Argus incident with a pre-filled title and body.
 
 How to write a plugin for a desired ticket system is detailed in
 :ref:`writing-ticket-system-plugins`.

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -29,28 +29,28 @@ Request Tracker
 
 | Class: argus_ticket_rt.RequestTrackerPlugin
 | Source: https://github.com/Uninett/argus_ticket_rt
-| Pypi: `argus-ticket-rt <https://pypi.org/project/argus-ticket-rt/>`_
+| PyPI: `argus-ticket-rt <https://pypi.org/project/argus-ticket-rt/>`_
 
 Jira
 ~~~~
 
 | Class: argus_ticket_jira.JiraPlugin
 | Source: https://github.com/Uninett/argus_ticket_jira
-| Pypi: `argus-ticket-jira <https://pypi.org/project/argus-ticket-jira/>`_
+| PyPI: `argus-ticket-jira <https://pypi.org/project/argus-ticket-jira/>`_
 
 Github
 ~~~~~~
 
 | Class: argus_ticket_github.GithubPlugin
 | Source: https://github.com/Uninett/argus_ticket_github
-| Pypi: `argus-ticket-github <https://pypi.org/project/argus-ticket-github/>`_
+| PyPI: `argus-ticket-github <https://pypi.org/project/argus-ticket-github/>`_
 
 Gitlab
 ~~~~~~
 
 | Class: argus_ticket_gitlab.GitlabPlugin
 | Source: https://github.com/Uninett/argus_ticket_gitlab
-| Pypi: `argus-ticket-gitlab <https://pypi.org/project/argus-ticket-gitlab/>`_
+| PyPI: `argus-ticket-gitlab <https://pypi.org/project/argus-ticket-gitlab/>`_
 
 Other ticket plugins
 --------------------

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -76,7 +76,7 @@ systems are ``TICKET_PLUGIN``, ``TICKET_ENDPOINT``,
 ``TICKET_AUTHENTICATION_SECRET`` and ``TICKET_INFORMATION``.
 
 ``TICKET_PLUGIN`` is the fully qualified name of the ticket plugin Python
-class.
+class. See the "Class" field in the list of plugins above for examples.
 
 ``TICKET_ENDPOINT`` is the link to the ticket system website the ticket should be
 created at.

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -26,27 +26,23 @@ Existing ticket system plugins
 
 Request Tracker
 ~~~~~~~~~~~~~~~
-Source: https://pypi.org/project/argus-ticket-rt/
 
-pip install argus-ticket-rt
+| Pypi: `argus-ticket-rt <https://pypi.org/project/argus-ticket-rt/>`_
 
 Jira
 ~~~~
-Source: https://pypi.org/project/argus-ticket-jira/
 
-pip install argus-ticket-jira
+| Pypi: `argus-ticket-jira <https://pypi.org/project/argus-ticket-jira/>`_
 
 Github
 ~~~~~~
-Source: https://github.com/Uninett/argus_ticket_github
 
-pip install argus-ticket-github
+| Pypi: `argus-ticket-github <https://pypi.org/project/argus-ticket-github/>`_
 
 Gitlab
 ~~~~~~
-Source: https://github.com/Uninett/argus_ticket_gitlab
 
-pip install argus-ticket-gitlab
+| Pypi: `argus-ticket-gitlab <https://pypi.org/project/argus-ticket-gitlab/>`_
 
 Other ticket plugins
 --------------------

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -57,11 +57,7 @@ Other ticket plugins
 
 None known to us at this time.
 
-.. note::
-   Open an issue (`Github <https://github.com/Uninett/Argus/issues>`_) to have
-   a plugin added to this list. It needs to be publicly accessible (and
-   preferably available on PyPI) so we can check the code. We will link up both
-   the source code repo (or homepage otherwise) and the PyPI-entry.
+.. include:: ../_note.rst
 
 .. _ticket-systems-settings:
 

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -27,28 +27,28 @@ Ticket plugins maintained by Argus developers
 Request Tracker
 ~~~~~~~~~~~~~~~
 
-| Class: argus_ticket_rt.RequestTrackerPlugin
+| Class: ``argus_ticket_rt.RequestTrackerPlugin``
 | Source: https://github.com/Uninett/argus_ticket_rt
 | PyPI: `argus-ticket-rt <https://pypi.org/project/argus-ticket-rt/>`_
 
 Jira
 ~~~~
 
-| Class: argus_ticket_jira.JiraPlugin
+| Class: ``argus_ticket_jira.JiraPlugin``
 | Source: https://github.com/Uninett/argus_ticket_jira
 | PyPI: `argus-ticket-jira <https://pypi.org/project/argus-ticket-jira/>`_
 
 Github
 ~~~~~~
 
-| Class: argus_ticket_github.GithubPlugin
+| Class: ``argus_ticket_github.GithubPlugin``
 | Source: https://github.com/Uninett/argus_ticket_github
 | PyPI: `argus-ticket-github <https://pypi.org/project/argus-ticket-github/>`_
 
 Gitlab
 ~~~~~~
 
-| Class: argus_ticket_gitlab.GitlabPlugin
+| Class: ``argus_ticket_gitlab.GitlabPlugin``
 | Source: https://github.com/Uninett/argus_ticket_gitlab
 | PyPI: `argus-ticket-gitlab <https://pypi.org/project/argus-ticket-gitlab/>`_
 

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -28,24 +28,28 @@ Request Tracker
 ~~~~~~~~~~~~~~~
 
 | Class: argus_ticket_rt.RequestTrackerPlugin
+| Source: https://github.com/Uninett/argus_ticket_rt
 | Pypi: `argus-ticket-rt <https://pypi.org/project/argus-ticket-rt/>`_
 
 Jira
 ~~~~
 
 | Class: argus_ticket_jira.JiraPlugin
+| Source: https://github.com/Uninett/argus_ticket_jira
 | Pypi: `argus-ticket-jira <https://pypi.org/project/argus-ticket-jira/>`_
 
 Github
 ~~~~~~
 
 | Class: argus_ticket_github.GithubPlugin
+| Source: https://github.com/Uninett/argus_ticket_github
 | Pypi: `argus-ticket-github <https://pypi.org/project/argus-ticket-github/>`_
 
 Gitlab
 ~~~~~~
 
 | Class: argus_ticket_gitlab.GitlabPlugin
+| Source: https://github.com/Uninett/argus_ticket_gitlab
 | Pypi: `argus-ticket-gitlab <https://pypi.org/project/argus-ticket-gitlab/>`_
 
 Other ticket plugins

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -4,9 +4,9 @@
 
 .. _ticket-systems:
 
-====================================================
-Ticket system plugins: Automatically create a ticket
-====================================================
+======================================================
+Ticket system plugins: Creating a ticket automatically
+======================================================
 
 .. index::
    see: case; ticket

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -8,6 +8,10 @@
 Ticket system plugins: Automatically create a ticket
 ====================================================
 
+.. index::
+   see: case; ticket
+   see: issue; ticket
+
 It is possible to automatically create a :index:`ticket` (aka. issue, case)
 from an Argus incident with a pre-filled title and body.
 

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -27,21 +27,25 @@ Existing ticket system plugins
 Request Tracker
 ~~~~~~~~~~~~~~~
 
+| Class: argus_ticket_rt.RequestTrackerPlugin
 | Pypi: `argus-ticket-rt <https://pypi.org/project/argus-ticket-rt/>`_
 
 Jira
 ~~~~
 
+| Class: argus_ticket_jira.JiraPlugin
 | Pypi: `argus-ticket-jira <https://pypi.org/project/argus-ticket-jira/>`_
 
 Github
 ~~~~~~
 
+| Class: argus_ticket_github.GithubPlugin
 | Pypi: `argus-ticket-github <https://pypi.org/project/argus-ticket-github/>`_
 
 Gitlab
 ~~~~~~
 
+| Class: argus_ticket_gitlab.GitlabPlugin
 | Pypi: `argus-ticket-gitlab <https://pypi.org/project/argus-ticket-gitlab/>`_
 
 Other ticket plugins

--- a/docs/integrations/ticket-systems/index.rst
+++ b/docs/integrations/ticket-systems/index.rst
@@ -58,10 +58,10 @@ Other ticket plugins
 None known to us at this time.
 
 .. note::
-   Open an issue to have a plugin added to this list. It needs to be publicly
-   accessible (and preferably available on PyPI) so we can check the code. We
-   will link up both the source code repo (or homepage otherwise) and the
-   PyPI-entry.
+   Open an issue (`Github <https://github.com/Uninett/Argus/issues>`_) to have
+   a plugin added to this list. It needs to be publicly accessible (and
+   preferably available on PyPI) so we can check the code. We will link up both
+   the source code repo (or homepage otherwise) and the PyPI-entry.
 
 .. _ticket-systems-settings:
 


### PR DESCRIPTION
Rewrite the titles and start of each type of integration so that they make more sense when taken together and are more visible in the table of contents.

Move the sections about existing integrations to the same place in each section and make them look more similar to each other.