### PR TITLE
Generate factory source users with a counter

### DIFF
--- a/src/argus/auth/factories.py
+++ b/src/argus/auth/factories.py
@@ -37,7 +37,7 @@ class SourceUserFactory(BaseUserFactory):
         model = User
         django_get_or_create = ("username",)
 
-    username = factory.Faker("word")
+    username = factory.Sequence(lambda n: "source_%d" % n)
     is_staff = False
     is_superuser = False
 


### PR DESCRIPTION
I've been having spurious test failures due to non-unique users again.

This should hopefully avoid identical usernames in tests.