### PR TITLE
Replace level constants with Level Django enum

### DIFF
--- a/src/argus/dev/management/commands/create_fake_incident.py
+++ b/src/argus/dev/management/commands/create_fake_incident.py
@@ -5,7 +5,7 @@ from random import randint
 
 from django.core.management.base import BaseCommand
 
-from argus.incident.constants import MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL
+from argus.incident.constants import Level
 from argus.incident.models import create_fake_incident
 
 
@@ -34,8 +34,8 @@ class Command(BaseCommand):
             "--level",
             type=int,
             action=Range,
-            minimum=MIN_INCIDENT_LEVEL,
-            maximum=MAX_INCIDENT_LEVEL,
+            minimum=min(Level).value,
+            maximum=max(Level).value,
             default=0,
             help="Set level to <level>, otherwise a random number within the correct range is used",
         )

--- a/src/argus/filter/V1/serializers.py
+++ b/src/argus/filter/V1/serializers.py
@@ -4,7 +4,7 @@ from typing import List
 from rest_framework import fields, serializers
 from rest_framework import serializers
 
-from argus.incident.constants import MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL
+from argus.incident.constants import Level
 from argus.notificationprofile.models import Filter
 
 from ..primitive_serializers import CustomMultipleChoiceField
@@ -31,7 +31,7 @@ class FilterBlobSerializerV1(serializers.Serializer):
     acked = serializers.BooleanField(required=False, allow_null=True)
     stateful = serializers.BooleanField(required=False, allow_null=True)
     maxlevel = serializers.IntegerField(
-        required=False, allow_null=True, max_value=MAX_INCIDENT_LEVEL, min_value=MIN_INCIDENT_LEVEL
+        required=False, allow_null=True, max_value=max(Level).value, min_value=min(Level).value
     )
 
 

--- a/src/argus/filter/V1/serializers.py
+++ b/src/argus/filter/V1/serializers.py
@@ -4,7 +4,7 @@ from typing import List
 from rest_framework import fields, serializers
 from rest_framework import serializers
 
-from argus.incident.constants import INCIDENT_LEVELS
+from argus.incident.constants import MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL
 from argus.notificationprofile.models import Filter
 
 from ..primitive_serializers import CustomMultipleChoiceField
@@ -31,7 +31,7 @@ class FilterBlobSerializerV1(serializers.Serializer):
     acked = serializers.BooleanField(required=False, allow_null=True)
     stateful = serializers.BooleanField(required=False, allow_null=True)
     maxlevel = serializers.IntegerField(
-        required=False, allow_null=True, max_value=max(INCIDENT_LEVELS), min_value=min(INCIDENT_LEVELS)
+        required=False, allow_null=True, max_value=MAX_INCIDENT_LEVEL, min_value=MIN_INCIDENT_LEVEL
     )
 
 

--- a/src/argus/filter/filters.py
+++ b/src/argus/filter/filters.py
@@ -11,6 +11,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 
 from argus.notificationprofile.models import Filter, NotificationProfile
+from argus.incident.constants import Level
 from argus.incident.fields import KeyValueField
 from argus.incident.models import Incident
 
@@ -131,7 +132,7 @@ _INCIDENT_OPENAPI_SOURCE_AUTO_FILTER_PARAMETERS = [
         name="source__type__in",
         description="Fetch incidents with a source of a type with numeric id `ID1` or `ID2` or..",
     ),
-    OpenApiParameter(name="level__lte", description="Fetch incidents with levels in `LEVEL`", enum=Incident.LEVELS),
+    OpenApiParameter(name="level__lte", description="Fetch incidents with levels in `LEVEL`", enum=Level.values),
 ]
 
 

--- a/src/argus/filter/swappable/serializers.py
+++ b/src/argus/filter/swappable/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from argus.incident.constants import MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL
+from argus.incident.constants import Level
 from argus.incident.models import Event
 from ..primitive_serializers import CustomMultipleChoiceField
 
@@ -25,7 +25,7 @@ class FilterBlobSerializer(serializers.Serializer):
     acked = serializers.BooleanField(required=False, allow_null=True)
     stateful = serializers.BooleanField(required=False, allow_null=True)
     maxlevel = serializers.IntegerField(
-        required=False, allow_null=True, max_value=MAX_INCIDENT_LEVEL, min_value=MIN_INCIDENT_LEVEL
+        required=False, allow_null=True, max_value=max(Level).value, min_value=min(Level).value
     )
     event_types = CustomMultipleChoiceField(
         choices=Event.Type.choices,

--- a/src/argus/filter/swappable/serializers.py
+++ b/src/argus/filter/swappable/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from argus.incident.constants import INCIDENT_LEVELS
+from argus.incident.constants import MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL
 from argus.incident.models import Event
 from ..primitive_serializers import CustomMultipleChoiceField
 
@@ -25,7 +25,7 @@ class FilterBlobSerializer(serializers.Serializer):
     acked = serializers.BooleanField(required=False, allow_null=True)
     stateful = serializers.BooleanField(required=False, allow_null=True)
     maxlevel = serializers.IntegerField(
-        required=False, allow_null=True, max_value=max(INCIDENT_LEVELS), min_value=min(INCIDENT_LEVELS)
+        required=False, allow_null=True, max_value=MAX_INCIDENT_LEVEL, min_value=MIN_INCIDENT_LEVEL
     )
     event_types = CustomMultipleChoiceField(
         choices=Event.Type.choices,

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -11,6 +11,7 @@ from argus.filter.filters import BooleanStringOAEnum
 from argus.filter.filters import SourceLockedIncidentFilter
 from argus.filter.filters import SOURCE_LOCKED_INCIDENT_OPENAPI_PARAMETER_DESCRIPTIONS
 
+from ..constants import Level
 from ..models import Incident, SourceSystem
 from ..serializers import IncidentPureDeserializer, SourceSystemSerializer
 from ..views import IncidentViewSet
@@ -58,7 +59,7 @@ from .serializers import (
             OpenApiParameter(
                 name="level__lte",
                 description="Fetch incidents with levels less than or equal to `LEVEL`",
-                enum=Incident.LEVELS,
+                enum=Level.values,
             ),
             OpenApiParameter(
                 name="open",

--- a/src/argus/incident/constants.py
+++ b/src/argus/incident/constants.py
@@ -1,12 +1,7 @@
 from django.db import models
 
 # Prevent import loops
-# DO NOT import anything here, ever
-
-MIN_INCIDENT_LEVEL = 1  # Do not override
-MAX_INCIDENT_LEVEL = 5
-INCIDENT_LEVELS = tuple(range(MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL + 1))
-INCIDENT_LEVEL_CHOICES = tuple(zip(INCIDENT_LEVELS, map(str, INCIDENT_LEVELS)))
+# DO NOT import anything from argus here, ever
 
 
 class Level(models.IntegerChoices):
@@ -15,3 +10,7 @@ class Level(models.IntegerChoices):
     MODERATE = 3, "Moderate"
     LOW = 4, "Low"
     INFORMATION = 5, "Information"
+
+
+INCIDENT_LEVELS = tuple(Level.values)
+INCIDENT_LEVEL_CHOICES = tuple(zip(INCIDENT_LEVELS, map(str, INCIDENT_LEVELS)))

--- a/src/argus/incident/constants.py
+++ b/src/argus/incident/constants.py
@@ -12,5 +12,4 @@ class Level(models.IntegerChoices):
     INFORMATION = 5, "Information"
 
 
-INCIDENT_LEVELS = tuple(Level.values)
-INCIDENT_LEVEL_CHOICES = tuple(zip(INCIDENT_LEVELS, map(str, INCIDENT_LEVELS)))
+INCIDENT_LEVEL_CHOICES = tuple(zip(Level.values, map(str, Level.values)))

--- a/src/argus/incident/constants.py
+++ b/src/argus/incident/constants.py
@@ -10,6 +10,3 @@ class Level(models.IntegerChoices):
     MODERATE = 3, "Moderate"
     LOW = 4, "Low"
     INFORMATION = 5, "Information"
-
-
-INCIDENT_LEVEL_CHOICES = tuple(zip(Level.values, map(str, Level.values)))

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -5,6 +5,7 @@ import factory, factory.fuzzy
 from argus.auth.factories import SourceUserFactory
 from argus.util.datetime_utils import INFINITY_REPR
 from . import models
+from .constants import Level
 
 
 __all__ = [
@@ -56,7 +57,7 @@ class IncidentFactory(factory.django.DjangoModelFactory):
     source_incident_id = factory.Sequence(lambda s: s)
     details_url = factory.Faker("uri")
     description = factory.Faker("sentence")
-    level = factory.fuzzy.FuzzyChoice(models.Incident.LEVELS)  # Random valid level
+    level = factory.fuzzy.FuzzyChoice(Level.values)  # Random valid level
     ticket_url = factory.Faker("uri")
 
 

--- a/src/argus/incident/forms.py
+++ b/src/argus/incident/forms.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.forms import modelform_factory
 
-from .constants import INCIDENT_LEVELS
+from .constants import Level
 from .models import Incident, SourceSystem, Tag
 
 User = get_user_model()
@@ -57,7 +57,7 @@ class AddSourceSystemForm(forms.ModelForm):
 
 class FakeIncidentForm(forms.ModelForm):
     level = forms.TypedChoiceField(
-        choices=[("", "")] + [(str(level), str(level)) for level in INCIDENT_LEVELS],
+        choices=[("", "")] + [(str(level), str(level)) for level in Level.values],
         coerce=int,
     )
     stateful = forms.BooleanField(

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from functools import reduce
 import logging
 from operator import and_
-from random import randint
+from random import randint, choice
 from urllib.parse import urljoin
 
 from django.contrib.auth import get_user_model
@@ -14,7 +14,7 @@ from django.db.models import F, Q
 from django.utils import timezone
 
 from argus.util.datetime_utils import INFINITY_REPR, get_infinity_repr
-from .constants import INCIDENT_LEVELS, INCIDENT_LEVEL_CHOICES, MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL, Level
+from .constants import INCIDENT_LEVELS, INCIDENT_LEVEL_CHOICES, Level
 from .fields import DateTimeInfinityField
 from .validators import validate_lowercase, validate_key
 
@@ -49,7 +49,7 @@ def create_fake_incident(tags=None, description=None, stateful=True, level=None,
         source_incident_id=source_incident_id,
         source=source_system,
         description=description,
-        level=level or randint(MIN_INCIDENT_LEVEL, MAX_INCIDENT_LEVEL),
+        level=level or choice(Level.values),
         metadata=metadata or {},
     )
 

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -378,7 +378,7 @@ class Incident(models.Model):
     source_incident_id = models.TextField(blank=True, default="", verbose_name="source incident ID")
     details_url = models.TextField(blank=True, validators=[URLValidator], verbose_name="details URL")
     description = models.TextField(blank=True)
-    level = models.IntegerField(choices=LEVEL_CHOICES, default=5)
+    level = models.IntegerField(choices=LEVEL_CHOICES, default=max(Level).value)
     ticket_url = models.TextField(
         blank=True,
         validators=[URLValidator],

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -14,7 +14,7 @@ from django.db.models import F, Q
 from django.utils import timezone
 
 from argus.util.datetime_utils import INFINITY_REPR, get_infinity_repr
-from .constants import INCIDENT_LEVELS, INCIDENT_LEVEL_CHOICES, Level
+from .constants import INCIDENT_LEVEL_CHOICES, Level
 from .fields import DateTimeInfinityField
 from .validators import validate_lowercase, validate_key
 
@@ -361,7 +361,6 @@ class IncidentQuerySet(models.QuerySet):
 # TODO: review whether fields should be nullable, and on_delete modes
 class Incident(models.Model):
     # Prevent import loop
-    LEVELS = INCIDENT_LEVELS
     LEVEL_CHOICES = INCIDENT_LEVEL_CHOICES
 
     start_time = models.DateTimeField(help_text="The time the incident was created.")

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -14,7 +14,7 @@ from django.db.models import F, Q
 from django.utils import timezone
 
 from argus.util.datetime_utils import INFINITY_REPR, get_infinity_repr
-from .constants import INCIDENT_LEVEL_CHOICES, Level
+from .constants import Level
 from .fields import DateTimeInfinityField
 from .validators import validate_lowercase, validate_key
 
@@ -360,8 +360,7 @@ class IncidentQuerySet(models.QuerySet):
 
 # TODO: review whether fields should be nullable, and on_delete modes
 class Incident(models.Model):
-    # Prevent import loop
-    LEVEL_CHOICES = INCIDENT_LEVEL_CHOICES
+    LEVEL_CHOICES = tuple(zip(Level.values, map(str, Level.values)))
 
     start_time = models.DateTimeField(help_text="The time the incident was created.")
     end_time = DateTimeInfinityField(

--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import fields, serializers
 
 from argus.filter.serializers import FilterSerializer
-from argus.incident.constants import INCIDENT_LEVELS
 from argus.incident.models import Event
 from .media import api_safely_get_medium_object
 from .models import DestinationConfig, Media, NotificationProfile, TimeRecurrence, Timeslot

--- a/tests/filter/test_filterwrapper.py
+++ b/tests/filter/test_filterwrapper.py
@@ -133,7 +133,6 @@ class FallbackFilterWrapperIncidentFitsMaxlevelTests(unittest.TestCase):
 @tag("unittest")
 class FallbackFilterWrapperIncidentFitsSourceSystemTests(unittest.TestCase):
     # Validation is handled before the data gets to FallbackFilterWrapper
-    # A maxlevel must be one of the integers in Incident.LEVELS if it is set at all.
 
     def test_incident_fits_source_system_is_None_if_not_mentioned_in_filter(self):
         incident = Mock()
@@ -164,7 +163,6 @@ class FallbackFilterWrapperIncidentFitsSourceSystemTests(unittest.TestCase):
 @tag("unittest")
 class FallbackFilterWrapperIncidentFitsTagsTests(unittest.TestCase):
     # Validation is handled before the data gets to FallbackFilterWrapper
-    # A maxlevel must be one of the integers in Incident.LEVELS if it is set at all.
 
     def test_incident_fits_tags_is_None_if_not_mentioned_in_filter(self):
         incident = Mock()

--- a/tests/filter/test_filterwrapper.py
+++ b/tests/filter/test_filterwrapper.py
@@ -96,7 +96,7 @@ class FallbackFilterWrapperIncidentFitsTristateTests(unittest.TestCase):
 @tag("unittest")
 class FallbackFilterWrapperIncidentFitsMaxlevelTests(unittest.TestCase):
     # Validation is handled before the data gets to FallbackFilterWrapper
-    # A maxlevel must be one of the integers in Incident.LEVELS if it is set at all.
+    # A maxlevel must be one of the integer values in Incident.Level if it is set at all.
 
     def test_incident_fits_maxlevel_is_None_if_not_mentioned_in_filter(self):
         incident = Mock()


### PR DESCRIPTION
Closes #877

There is one more possible change, from:

```
class Incident(models.Model):
    LEVEL_CHOICES = tuple(zip(Level.values, map(str, Level.values)))
    ..
    level = models.IntegerField(choices=LEVEL_CHOICES, default=5)
    ..
```

![image](https://github.com/user-attachments/assets/0e9fdb3c-71fa-402b-8987-66c8090de775)

to:

```
class Incident(models.Model):
    ..
    level = models.IntegerField(choices=Level, default=5)
    ..
```

![image](https://github.com/user-attachments/assets/a9a19ade-c7aa-4560-bd96-99872463945e)

.. but that will hide the numbers in the admin and any other model form.

Another question is whether it would be useful to keep some of the constants around, just derive them from Level in the `constants.py` file.