### PR TITLE
Add easy way to include htmx frontend

### DIFF
--- a/changelog.d/+frontend-switch.added.md
+++ b/changelog.d/+frontend-switch.added.md
@@ -1,0 +1,3 @@
+Make it easier to use the new HTMx-based frontend, with docs. The new frontend
+cannot be run simultaneosuly with the REACT SPA frontend as some settings
+conflict.

--- a/docs/development/howtos/federated-logins.rst
+++ b/docs/development/howtos/federated-logins.rst
@@ -1,3 +1,5 @@
+.. _howto-federated-logins:
+
 ===================================
 How to add federated login (OAuth2)
 ===================================

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -14,9 +14,43 @@ It is not needed if running headless.
 Setup
 =====
 
-Install the app with pip::
+Production
+----------
 
-    pip install argus-htmx
+Install the app directly::
+
+    pip install argus-frontend-htmx
+
+... or indirectly via argus-server::
+
+    pip install argus-server[htmx]
+
+Development
+-----------
+
+If you're working just on argus-server::
+
+    cd argus-server-repo && pip install -e .[htmx]
+
+This will install the frontend as a package and it will not be editable.
+
+If you're working just on argus-frontend-htmx::
+
+    cd argus-htmx-repo && pip install -e .
+
+This will install the server as a package and it will not be editable.
+
+If you want to work on both in tandem::
+
+    cd argus-htmx-repo && pip install -e .
+    cd argus-server-repo && pip uninstall argus-server && pip install -e .
+
+Since argus-frontend-htmx depends on argus-server it will install the latter
+from a package, which is probably not what you want. That's why it might be
+necessary to uninstall the package before you install the editable version you
+will be working on. If you install argus-server first, then installing the
+frontend will still drag in the argus-server package since pip doesn't
+understand the the package and the editable install does the same job.
 
 Settings
 ========

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -33,7 +33,7 @@ Domain settings
 
 .. setting:: ARGUS_FRONTEND_URL
 
-* :setting:`ARGUS_FRONTEND_URL` is used for builidng permalinks to point back
+* :setting:`ARGUS_FRONTEND_URL` is used for building permalinks to point back
   to incidents in the dashboard.
 
 The setting must point to the publicly visible domain where the frontend is

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -4,7 +4,7 @@
 HTMx Frontend
 =============
 
-The new frontend s old-new school and uses HTMx to boost HTML pages. See the
+The new frontend is old-new school and uses HTMx to boost HTML pages. See the
 `Github repo of argus-htmx-frontend <https://github.com/uninett/argus-htmx-frontend>`_
 
 It has its own specific settings and currently depends on an app.
@@ -33,8 +33,8 @@ Domain settings
 
 .. setting:: ARGUS_FRONTEND_URL
 
-* :setting:`ARGUS_FRONTEND_URL` is used for builidng links to point back to
-  incidents in the dashboard when autocreating tickets.
+* :setting:`ARGUS_FRONTEND_URL` is used for builidng permalinks to point back
+  to incidents in the dashboard.
 
 The setting must point to the publicly visible domain where the frontend is
 running. This might be different from where the backend is running.

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -55,7 +55,7 @@ understand the the package and the editable install does the same job.
 Settings
 ========
 
-If you don't need to override any settings wth a file at all (maybe there are
+If you don't need to override any settings with a file at all (maybe there are
 environment variables for everything you need to change) you can use
 ``argus.htmx.settings`` directly. If not, copy the contents of
 ``argus.htmx.settings`` into the top of your tuned settings file.

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -55,12 +55,16 @@ understand the the package and the editable install does the same job.
 Settings
 ========
 
-Base the settings file on ``argus.htmx.settings``. We mutate some of the
-existing settings with the same system used for extra apps and overriding apps
-so have a look at ``argus_htmx.appconfig`` for the individual settings. Note
-especially that :setting:`ROOT_URLCONF` is set to ``argus.htmx.urls``. If you
-prefer to make your own root ``urls.py``, the frontend-specific urls can be
-imported from ``argus.htmx.htmx_urls``.
+If you don't need to override any settings wth a file at all (maybe there are
+environment variables for everything you need to change) you can use
+``argus.htmx.settings`` directly. If not, copy the contents of
+``argus.htmx.settings`` into the top of your tuned settings file.
+
+We mutate some of the existing settings with the same system used for extra
+apps and overriding apps so have a look at ``argus_htmx.appconfig`` for the
+individual settings. Note especially that :setting:`ROOT_URLCONF` is set to
+``argus.htmx.urls``. If you prefer to make your own root ``urls.py``, the
+frontend-specific urls can be imported from ``argus.htmx.htmx_urls``.
 
 Domain settings
 ---------------

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -1,0 +1,78 @@
+.. _htmx-frontend:
+
+=============
+HTMx Frontend
+=============
+
+The new frontend s old-new school and uses HTMx to boost HTML pages. See the
+`Github repo of argus-htmx-frontend <https://github.com/uninett/argus-htmx-frontend>`_
+
+It has its own specific settings and currently depends on an app.
+
+It is not needed if running headless.
+
+Setup
+=====
+
+Install the app with pip::
+
+    pip install argus-htmx
+
+Settings
+========
+
+Base the settings file on ``argus.htmx.settings``. We mutate some of the
+existing settings with the same system used for extra apps and overriding apps
+so have a look at ``argus_htmx.appconfig`` for the individual settings. Note
+especially that :setting:`ROOT_URLCONF` is set to ``argus.htmx.urls``. If you
+prefer to make your own root ``urls.py``, the frontend-specific urls can be
+imported from ``argus.htmx.htmx_urls``.
+
+Domain settings
+---------------
+
+.. setting:: ARGUS_FRONTEND_URL
+
+* :setting:`ARGUS_FRONTEND_URL` is used for builidng links to point back to
+  incidents in the dashboard when autocreating tickets.
+
+The setting must point to the publicly visible domain where the frontend is
+running. This might be different from where the backend is running.
+
+OAuth2
+------
+
+.. setting:: ARGUS_<backend>_KEY
+
+* :setting:`ARGUS_<backend>_KEY` holds the id/key for using a specific OAuth2
+  backend for authentication.
+
+.. setting:: ARGUS_<backend>_SECRET
+
+* :setting:`ARGUS_<backend>_SECRET` holds the password for using a specific
+  OAuth2 backend.
+
+Furthermore, visiting ``/oidc/login/<backend>/`` when an Oaouth2 backend is set
+up and installed will trigger a login via that backend.
+
+See the :ref:`Authentication reference <authentication-reference>` and the
+:ref:`OAuth2 howto <howto-federated-logins>` for the meaning of ``<backend>``.
+
+OpenID Connect
+--------------
+
+Use the python social auth backend
+``social_core.backends.open_id_connect.OpenIdConnectAuth``, see
+`PSA: OIDC (OpenID Connect) <https://python-social-auth.readthedocs.io/en/latest/backends/oidc.html>`_
+
+It is only possible to connect to one OIDC provider at a time without subclassing.
+
+If you want to use email-addresses as usernames, set
+:setting:`SOCIAL_AUTH_OIDC_USERNAME_KEY` to ``"email"``. If you don't do this,
+what username you will end up with is decided by the OIDC provider in question.
+It could be a UUID or some other unique generated string that will not make
+sense to your end-users.
+
+You can look inside the JWT (in the model ``UserSocialAuth``, field
+``extra_data``, key ``id_token``) for a different suitable value to use for
+a username.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 docs = ["sphinx>=2.2.0"]
+htmx = [
+    "argus-htmx-frontend>=0.14",
+    "social-auth-core>=4.1",
+    "social-auth-app-django>=5.0",
+]
 dev = [
     "django-debug-toolbar",
     "coverage",

--- a/src/argus/htmx/htmx_urls.py
+++ b/src/argus/htmx/htmx_urls.py
@@ -1,0 +1,10 @@
+from django.urls import include, path
+
+from argus.site.utils import get_urlpatterns
+
+from argus_htmx.appconfig import APP_SETTINGS
+
+urlpatterns = get_urlpatterns(APP_SETTINGS)
+urlpatterns += [
+    path("oidc/", include("social_django.urls", namespace="social")),
+]

--- a/src/argus/htmx/settings.py
+++ b/src/argus/htmx/settings.py
@@ -5,3 +5,5 @@ from argus_htmx.appconfig import APP_SETTINGS
 
 
 update_settings(globals(), APP_SETTINGS)
+
+ROOT_URLCONF = "argus.htmx.urls"

--- a/src/argus/htmx/settings.py
+++ b/src/argus/htmx/settings.py
@@ -1,0 +1,7 @@
+from argus.site.settings.backend import *
+from argus.site.utils import update_settings
+
+from argus_htmx.appconfig import APP_SETTINGS
+
+
+update_settings(globals(), APP_SETTINGS)

--- a/src/argus/htmx/urls.py
+++ b/src/argus/htmx/urls.py
@@ -1,0 +1,5 @@
+from argus.site.urls import urlpatterns
+
+from .htmx_urls import urlpatterns as htmx_urlpatterns
+
+urlpatterns = htmx_urlpatterns + urlpatterns

--- a/src/argus/site/settings/__init__.py
+++ b/src/argus/site/settings/__init__.py
@@ -4,8 +4,10 @@ import json
 import logging.config
 from os import getenv
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 from ._serializers import ListAppSetting
@@ -156,5 +158,10 @@ def update_loglevels(loglevel: str = "INFO", loggers=(), handlers=()) -> None:
         handlerdict = {}
         for handler in handlers:
             handlerdict["handler"] = {"level": loglevel}
-        logdict = {"version": 1, "disable_existing_loggers": False, "incremental": True, "handlers": handlerdict}
+        logdict = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "incremental": True,
+            "handlers": handlerdict,
+        }
         logging.config.dictConfig(logdict)

--- a/src/argus/site/settings/__init__.py
+++ b/src/argus/site/settings/__init__.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 from ._serializers import ListAppSetting

--- a/src/argus/site/settings/__init__.py
+++ b/src/argus/site/settings/__init__.py
@@ -4,7 +4,6 @@ import json
 import logging.config
 from os import getenv
 from pathlib import Path
-from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from django.utils.module_loading import import_string

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -13,10 +13,9 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 from urllib.parse import urlsplit
 
 import dj_database_url
-from django.core.exceptions import ImproperlyConfigured
 
 # Import some helpers
-from . import *
+from . import get_bool_env, get_str_env, get_int_env, setup_logging, normalize_url, get_json_env, validate_app_setting
 from ..utils import update_settings
 
 # Quick-start development settings - unsuitable for production
@@ -182,7 +181,7 @@ if LOGGING_MODULE:
     LOGGING_CONFIG = None
     STARTUP_LOGGING = setup_logging(LOGGING_MODULE)
 
-# For links to argus in tickets
+# For permalinks to incidents in argus dashboard
 FRONTEND_URL = get_str_env("ARGUS_FRONTEND_URL")
 
 # django-cors-headers

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 from urllib.parse import urlsplit
 
 import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
 
 # Import some helpers
 from . import *
@@ -181,9 +182,10 @@ if LOGGING_MODULE:
     LOGGING_CONFIG = None
     STARTUP_LOGGING = setup_logging(LOGGING_MODULE)
 
-# django-cors-headers
+# For links to argus in tickets
 FRONTEND_URL = get_str_env("ARGUS_FRONTEND_URL")
 
+# django-cors-headers
 CORS_ALLOWED_ORIGINS = []
 if FRONTEND_URL:
     CORS_ALLOWED_ORIGINS.append(normalize_url(FRONTEND_URL))

--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -20,7 +20,6 @@ from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
-from social_django.urls import extra
 
 from argus.auth.views import ObtainNewAuthToken
 from argus.notificationprofile.views import SchemaView
@@ -41,6 +40,8 @@ urlpatterns = [
     path("json-schema/<slug:slug>", SchemaView.as_view(), name="json-schema"),
     path("", index, name="api-home"),
 ]
+
+# Extra/overriding apps
 
 prefixed_urlpatterns = get_urlpatterns(settings.OVERRIDING_APPS)
 if prefixed_urlpatterns:


### PR DESCRIPTION
Depends on #906, #907

Use argus_htmx for the frontend by basing your settings file on `argus.htmx.settings`.