### PR TITLE
Improve app settings

### DIFF
--- a/changelog.d/+improve-app-settings.changed.md
+++ b/changelog.d/+improve-app-settings.changed.md
@@ -1,0 +1,1 @@
+Make it possible to change any setting via the (EXTRA|OVERRIDING)\_APPS-machinery .

--- a/docs/reference/site-specific-settings.rst
+++ b/docs/reference/site-specific-settings.rst
@@ -58,15 +58,39 @@ Settings for adding additional Django apps
 Format of the app settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Both settings are a list of dicts.
+
 App
 ...
 
-Both settings are a list of dicts. The minimal content of the dict is::
+To add an app, the minimal content of the dict is::
 
     { "app_name": "myapp" }
 
 "myapp" is the same string you would normally put into
 :setting:`INSTALLED_APPS`.
+
+Settings
+........
+
+You can overwrite any setting with the "settings"-key::
+
+    {
+        "settings": {
+            "LOGIN_URL": "/magic/"
+        }
+    }
+
+This is useful for settings that do not belong to specific apps.
+
+You can set settings for an app too::
+
+       {
+           "app_name": "myapp",
+           "settings": {
+               "MYAPP_MAGIC_NUMBER": 785464279385649275692
+           }
+       }
 
 Urls
 ....
@@ -85,7 +109,7 @@ There are two possible formats:
            "app_name": "myapp",
            "urls": {
                "path": "myapp/",
-               "urlpatterns_module": "myapp.urls",
+               "urlpatterns_module": "myapp.urls"
            }
        }
 
@@ -100,7 +124,7 @@ There are two possible formats:
            "urls": {
                "path": "myapp/",
                "urlpatterns_module": "myapp.urls",
-               "namespace": "mynamespace",
+               "namespace": "mynamespace"
            }
        }
 
@@ -125,13 +149,21 @@ Format::
         "context_processors": [
             "holiday_cheer.context_processors.date_context",
             "holiday_cheer.context_processors.holidays"
-        ],
+        ]
+    }
+
+Context processors that are not specific to an app can also be set::
+
+    {
+        "context_processors": [
+            "django.template.context_processors.debug"
+        ]
     }
 
 Middleware
 ..........
 
-Optionally, additional middlewares can be added to :setting:`MIDDLEWARE`-setting.
+Optionally, additional middlewares can be added to the :setting:`MIDDLEWARE`-setting.
 
 Format::
 
@@ -139,8 +171,8 @@ Format::
         "app_name": "holiday_cheer",
         "middleware": {
             "holiday_cheer.appended_middleware": "end",
-            "holiday_cheer.prepended_middleware": "start",
-        },
+            "holiday_cheer.prepended_middleware": "start"
+        }
     }
 
 Subformat::
@@ -152,6 +184,14 @@ default is appending (ACTION is "end" or a random string), but it is also
 possible to prepend (ACTION is "start"). A prepended middleware will be run
 *before* the security- and session middlewares which might not be what you
 want.
+
+Middleware not belonging to an app can also be added::
+
+    {
+        "middleware": {
+            "django.middleware.cache.GZipMiddleware": "end"
+        }
+    }
 
 Database settings
 -----------------

--- a/src/argus/site/settings/_serializers.py
+++ b/src/argus/site/settings/_serializers.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Any
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -14,6 +14,7 @@ class AppSetting(BaseModel):
     urls: Optional[AppUrlSetting] = None
     context_processors: Optional[List[str]] = None
     middleware: Optional[Dict[str, str]] = None
+    settings: Optional[Dict[str, Any]] = None
 
 
 class ListAppSetting(RootModel):

--- a/src/argus/site/settings/_serializers.py
+++ b/src/argus/site/settings/_serializers.py
@@ -10,7 +10,7 @@ class AppUrlSetting(BaseModel):
 
 
 class AppSetting(BaseModel):
-    app_name: str
+    app_name: Optional[str] = None
     urls: Optional[AppUrlSetting] = None
     context_processors: Optional[List[str]] = None
     middleware: Optional[Dict[str, str]] = None

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -16,7 +16,7 @@ import dj_database_url
 
 # Import some helpers
 from . import *
-from ..utils import update_context_processors_list, update_middleware_list, get_settings
+from ..utils import update_settings
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -320,22 +320,10 @@ SOCIAL_AUTH_NEW_USER_REDIRECT_URL = SOCIAL_AUTH_LOGIN_REDIRECT_URL
 _overriding_apps_env = get_json_env("ARGUS_OVERRIDING_APPS", [], quiet=False)
 OVERRIDING_APPS = validate_app_setting(_overriding_apps_env)
 del _overriding_apps_env
-if OVERRIDING_APPS:
-    _overriding_app_names = [app.app_name for app in OVERRIDING_APPS]
-    INSTALLED_APPS = _overriding_app_names + INSTALLED_APPS
-    TEMPLATES = update_context_processors_list(TEMPLATES, OVERRIDING_APPS)
-    MIDDLEWARE = update_middleware_list(MIDDLEWARE, OVERRIDING_APPS)
-    for setting, value in get_settings(OVERRIDING_APPS).items():
-        globals()[setting] = value
+update_settings(globals(), OVERRIDING_APPS, override=True)
 
 # add extra functionality without overrides
 _extra_apps_env = get_json_env("ARGUS_EXTRA_APPS", [], quiet=False)
 EXTRA_APPS = validate_app_setting(_extra_apps_env)
 del _extra_apps_env
-if EXTRA_APPS:
-    _extra_app_names = [app.app_name for app in EXTRA_APPS]
-    INSTALLED_APPS += _extra_app_names
-    TEMPLATES = update_context_processors_list(TEMPLATES, EXTRA_APPS)
-    MIDDLEWARE = update_middleware_list(MIDDLEWARE, EXTRA_APPS)
-    for setting, value in get_settings(EXTRA_APPS).items():
-        globals()[setting] = value
+update_settings(globals(), EXTRA_APPS)

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -16,7 +16,7 @@ import dj_database_url
 
 # Import some helpers
 from . import *
-from ..utils import update_context_processors_list, update_middleware_list
+from ..utils import update_context_processors_list, update_middleware_list, get_settings
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -25,15 +25,6 @@ from ..utils import update_context_processors_list, update_middleware_list
 DEBUG = get_bool_env("DEBUG", False)
 
 ALLOWED_HOSTS = []
-
-# Application definition
-
-_overriding_apps_env = get_json_env("ARGUS_OVERRIDING_APPS", [], quiet=False)
-OVERRIDING_APPS = validate_app_setting(_overriding_apps_env)
-del _overriding_apps_env
-_extra_apps_env = get_json_env("ARGUS_EXTRA_APPS", [], quiet=False)
-EXTRA_APPS = validate_app_setting(_extra_apps_env)
-del _extra_apps_env
 
 # fmt: off
 # fsck off, black
@@ -99,19 +90,6 @@ TEMPLATES = [
         },
     }
 ]
-
-# override themes, urls, context processors
-if OVERRIDING_APPS:
-    _overriding_app_names = [app.app_name for app in OVERRIDING_APPS]
-    INSTALLED_APPS = _overriding_app_names + INSTALLED_APPS
-    TEMPLATES = update_context_processors_list(TEMPLATES, OVERRIDING_APPS)
-    MIDDLEWARE = update_middleware_list(MIDDLEWARE, OVERRIDING_APPS)
-# add extra functionality without overrides
-if EXTRA_APPS:
-    _extra_app_names = [app.app_name for app in EXTRA_APPS]
-    INSTALLED_APPS += _extra_app_names
-    TEMPLATES = update_context_processors_list(TEMPLATES, EXTRA_APPS)
-    MIDDLEWARE = update_middleware_list(MIDDLEWARE, EXTRA_APPS)
 
 WSGI_APPLICATION = "argus.site.wsgi.application"
 
@@ -335,3 +313,29 @@ SOCIAL_AUTH_NEW_USER_REDIRECT_URL = SOCIAL_AUTH_LOGIN_REDIRECT_URL
 #
 # SOCIAL_AUTH_DATAPORTEN_FEIDE_KEY = SOCIAL_AUTH_DATAPORTEN_KEY
 # SOCIAL_AUTH_DATAPORTEN_FEIDE_SECRET = SOCIAL_AUTH_DATAPORTEN_SECRET
+
+# App settings: override themes, urls, context processors
+
+# add apps that may override other apps
+_overriding_apps_env = get_json_env("ARGUS_OVERRIDING_APPS", [], quiet=False)
+OVERRIDING_APPS = validate_app_setting(_overriding_apps_env)
+del _overriding_apps_env
+if OVERRIDING_APPS:
+    _overriding_app_names = [app.app_name for app in OVERRIDING_APPS]
+    INSTALLED_APPS = _overriding_app_names + INSTALLED_APPS
+    TEMPLATES = update_context_processors_list(TEMPLATES, OVERRIDING_APPS)
+    MIDDLEWARE = update_middleware_list(MIDDLEWARE, OVERRIDING_APPS)
+    for setting, value in get_settings(OVERRIDING_APPS).items():
+        globals()[setting] = value
+
+# add extra functionality without overrides
+_extra_apps_env = get_json_env("ARGUS_EXTRA_APPS", [], quiet=False)
+EXTRA_APPS = validate_app_setting(_extra_apps_env)
+del _extra_apps_env
+if EXTRA_APPS:
+    _extra_app_names = [app.app_name for app in EXTRA_APPS]
+    INSTALLED_APPS += _extra_app_names
+    TEMPLATES = update_context_processors_list(TEMPLATES, EXTRA_APPS)
+    MIDDLEWARE = update_middleware_list(MIDDLEWARE, EXTRA_APPS)
+    for setting, value in get_settings(EXTRA_APPS).items():
+        globals()[setting] = value

--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -24,7 +24,7 @@ from social_django.urls import extra
 
 from argus.auth.views import ObtainNewAuthToken
 from argus.notificationprofile.views import SchemaView
-from argus.site.utils import get_urlpatterns_from_setting
+from argus.site.utils import get_urlpatterns
 from argus.site.views import error, index, MetadataView
 
 
@@ -42,10 +42,10 @@ urlpatterns = [
     path("", index, name="api-home"),
 ]
 
-prefixed_urlpatterns = get_urlpatterns_from_setting(settings.OVERRIDING_APPS)
+prefixed_urlpatterns = get_urlpatterns(settings.OVERRIDING_APPS)
 if prefixed_urlpatterns:
     urlpatterns = prefixed_urlpatterns + urlpatterns
 
-postfixed_urlpatterns = get_urlpatterns_from_setting(settings.EXTRA_APPS)
+postfixed_urlpatterns = get_urlpatterns(settings.EXTRA_APPS)
 if postfixed_urlpatterns:
     urlpatterns += postfixed_urlpatterns

--- a/src/argus/site/utils.py
+++ b/src/argus/site/utils.py
@@ -58,3 +58,12 @@ def update_middleware_list(middleware_setting, app_settings):
                 end_list.append(middleware)
     safety_copy = start_list + safety_copy + end_list
     return safety_copy
+
+
+def get_settings(app_settings):
+    settings = {}
+    for app in app_settings:
+        if not getattr(app, "settings", None):
+            continue
+        settings.update(app.settings)
+    return settings

--- a/tests/site/test_settings_helpers.py
+++ b/tests/site/test_settings_helpers.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 
 from argus.site.settings import normalize_url, _add_missing_scheme_to_url
 from argus.site.settings._serializers import AppSetting
-from argus.site.utils import get_urlpatterns_from_setting, update_context_processors_list
+from argus.site.utils import get_urlpatterns, update_context_processors_list
 
 
 class NormalizeUrlTests(unittest.TestCase):
@@ -47,7 +47,7 @@ class NormalizeUrlTests(unittest.TestCase):
 
 class GetUrlPatternsFromSettingsTest(unittest.TestCase):
     def test_when_setting_is_falsey_return_empty_list(self):
-        self.assertEqual(get_urlpatterns_from_setting(None), [])
+        self.assertEqual(get_urlpatterns(None), [])
 
     def test_when_setting_urls_is_falsey_it_should_return_empty_list(self):
         class Obj:
@@ -56,7 +56,7 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
         obj = Obj()
         obj.urls = None
 
-        self.assertEqual(get_urlpatterns_from_setting([obj]), [])
+        self.assertEqual(get_urlpatterns([obj]), [])
 
     def test_urls_without_namespace_return_list_of_paths_without_namespace(self):
         # django.urls.include has one obligatory positional argument that is
@@ -72,7 +72,7 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
             },
         }
         setting = AppSetting(**raw_setting)
-        result = get_urlpatterns_from_setting([setting])
+        result = get_urlpatterns([setting])
         self.assertEqual(len(result), 1)
         self.assertTrue(isinstance(result[0], URLResolver))
         self.assertFalse(result[0].namespace)
@@ -92,7 +92,7 @@ class GetUrlPatternsFromSettingsTest(unittest.TestCase):
             },
         }
         setting = AppSetting(**raw_setting)
-        result = get_urlpatterns_from_setting([setting])
+        result = get_urlpatterns([setting])
         self.assertEqual(len(result), 1)
         self.assertTrue(isinstance(result[0], URLResolver))
         self.assertEqual(result[0].namespace, "blbl")


### PR DESCRIPTION
The new frontend needs different simple settings (like LOGIN_URL) from the old frontend so we need to support that.

We can piggy-back on the (EXTRA|OVERRIDING)_APPS to do this but geant prefers vanilla settings files.

This is an attempt at having our cake and eating it too. Reusing the (EXTRA|OVERRIDING)_APPS-machinery and still making it easy to override everything with separate settings-files.

(This is not the final step in the journey, just an easily reviewable one.)