### PR TITLE
Use pipx to install towncrier

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -14,6 +14,7 @@ jobs:
 
     - name: Install towncrier
       run: |
-        sudo apt-get install -y --no-install-recommends towncrier
+        sudo apt-get install -y pipx
+        pipx install towncrier
     - name: Check for changelog file
       run: towncrier check --compare-with origin/master


### PR DESCRIPTION
This is because the version of towncrier one gets using apt-get install towncrier is outdated. 

The newest version of (towncrier)[https://github.com/twisted/towncrier] is 24.8.0, using `apt-get install` on Ubuntu 22.04. we get 19.2.0 and on Ubuntu 24.04. we get 22.12.0. 

An example where this becomes a problem: https://github.com/Uninett/Argus/actions/runs/11383082848/job/31667963012?pr=907