### PR TITLE
Use ruff Github action for critical linting

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,27 +13,9 @@ jobs:
     name: Lint
     steps:
     - uses: actions/checkout@v4
-
-    - uses: actions/cache@v4
-      id: cache
+    - uses: astral-sh/ruff-action@v1
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install tox ruff
-
-    - name: ruff critical lint
-      run: tox -e ruff-critical
+        changed-files: 'true'
 
   test:
     needs: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,10 @@ extend-exclude = [
     "migrations",
     "templates",
 ]
+output-format = "full"
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82"]
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
To make it more independent of tox. 

`changed-files` needs to be included back before merging.