### PR TITLE
Make AUTHENTICATION_BACKENDS mutable

### DIFF
--- a/changelog.d/+mutable-authentication-backends.changed.md
+++ b/changelog.d/+mutable-authentication-backends.changed.md
@@ -1,0 +1,1 @@
+Make `AUTHENTICATION_BACKENDS` setting mutable

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -154,10 +154,10 @@ STORAGES = {
     },
 }
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.RemoteUserBackend",
     "django.contrib.auth.backends.ModelBackend",
-)
+]
 
 SILENCED_SYSTEM_CHECKS = [
     "rest_framework.W001",  # Turns off warning about PAGE_SIZE without DEFAULT_PAGINATION_CLASS


### PR DESCRIPTION
In line with other settings that may be mutated by higher level settings files, this setting should be mutable