### PR TITLE
Add tox testenv to regenerate ER model

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,4 @@ ipython
 django-extensions
 Werkzeug  # for django-extensions:runserver_plus
 unittest-xml-reporting
+pydotplus # for generating the ER model

--- a/tox.ini
+++ b/tox.ini
@@ -101,3 +101,11 @@ omit =
 exclude_lines =
     # Ignore not abstract methods, as these cannot be tested
     raise NotImplementedError
+
+[testenv:generate-er-model]
+setenv =
+deps =
+    -r requirements-django42.txt
+    -r requirements/dev.txt
+commands =
+    python manage.py graph_models argus_auth argus_incident argus_notificationprofile --group-models -X Permission,AbstractBaseUser,PermissionsMixin -o docs/reference/img/ER_model.png


### PR DESCRIPTION
Instead of having to have all the dependencies installed locally one can simply run `tox -e generate-er-model`. 

This is a step in closing #215. 