### PR TITLE
Allow deletion of "unused" users in admin

### DIFF
--- a/changelog.d/+allow-deletion-of-unused-users.changed.md
+++ b/changelog.d/+allow-deletion-of-unused-users.changed.md
@@ -1,0 +1,2 @@
+Allow deletion of "dormant" users, that is: users that have never created an
+event or incident.

--- a/src/argus/auth/admin.py
+++ b/src/argus/auth/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 
 from .models import User
 from argus.notificationprofile.models import DestinationConfig
@@ -19,10 +19,12 @@ class DestinationConfigInline(admin.TabularInline):
         return qs.filter(user=self.parent_obj)
 
 
-class UserAdmin(BaseUserAdmin):
+class UserAdmin(DjangoUserAdmin):
     # inlines = [DestinationConfigInline]
 
     def has_delete_permission(self, request, obj=None):
+        if obj:
+            return not obj.is_used()
         return False
 
 

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -19,3 +19,21 @@ class User(AbstractUser):
             except Group.DoesNotExist:
                 return None
         return group in self.groups.all()
+
+    def is_used(self):
+        # user has created events
+        if self.caused_events.exists():
+            return True
+
+        # user is a source system that has created incidents
+        source = getattr(self, "source_system", None)
+        if source and source.incidents.exists():
+            return True
+
+        # notification_profiles: manually created but user is safe to
+        # delete
+        # timeslots: autocreated per person user
+        # destinations: autocreated per user with email via social auth
+
+        # user is not considered in use
+        return False

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -39,3 +39,7 @@ class UserTests(TestCase):
         user = PersonUserFactory()
         group = Group.objects.create(name="foobar")
         self.assertFalse(user.is_member_of_group(group))
+
+    def test_is_dormant_if_no_actions_taken(self):
+        user = PersonUserFactory()
+        self.assertFalse(user.is_used())


### PR DESCRIPTION
Closes #928.

By "unused" I mean users who haven't done anything yet: they have not created any events.

Logging in via federated login can create users, sometimes spurious ones that needs cleaning away.