### PR TITLE
Drop support for Python 3.9, Django 5.0

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -10,7 +10,7 @@ sonar.sources=src
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.python.version=3.9, 3.10, 3.11, 3.12
+sonar.python.version=3.10, 3.11, 3.12, 3.13
 sonar.tests=tests
 
 sonar.exclusions=src/argus/htmx/static/styles.css

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is designed to run a development environment for Argus,
 # with the Argus source code tree mounted at /argus
 #
-FROM python:3.10
+FROM python:3.12
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini \

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ There are several ways to install Argus.
 
 #### Requirements
 
-* Python 3.9+
+* Python 3.10+
 * Django 4.2 or 5.1
 * pip
-* PostgreSQL 12+
+* PostgreSQL 14+
 
 > [!WARNING]
 > The next [Django LTS](https://docs.djangoproject.com/en/5.2/releases/5.2/)

--- a/changelog.d/+drop-py39.removed.md
+++ b/changelog.d/+drop-py39.removed.md
@@ -1,0 +1,1 @@
+Dropped support for testing and running on Python 3.9

--- a/changelog.d/+drop-py39.removed.md
+++ b/changelog.d/+drop-py39.removed.md
@@ -1,1 +1,1 @@
-Dropped support for testing and running on Python 3.9
+Dropped support for testing and running on Python 3.9 and Django 5.0.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Defines a production image for the Argus API server
 # Needs the repository root directory as its context
-FROM python:3.10
+FROM python:3.12
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini build-essential

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "argus-server"
 description = "Argus is an alert aggregator for monitoring systems"
 authors = [{name="Uninett Opensource", email="opensource@uninett.no"}]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}
 classifiers = [
     "Framework :: Django",
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "GPL-3.0-or-later"}
 classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
@@ -19,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,15 @@
 [tox]
 envlist =
     clean
-    py39-django{42}
     py{310,311,312}-django{42,50,51}
     py{313}-django{51}
     coverage-html
 skipsdist = True
 skip_missing_interpreters = True
-basepython = python3.10
+basepython = python3.12
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
@@ -25,7 +23,6 @@ commands =
     -coverage erase
 
 [testenv:coverage-html]
-basepython = python3.10
 deps =
     coverage
 setenv =
@@ -79,7 +76,6 @@ commands =
     python manage.py graph_models argus_auth argus_incident argus_notificationprofile --group-models -X AbstractUser,AbstractBaseUser,Permission,PermissionsMixin -o docs/reference/img/ER_model.png
 
 [testenv:coverage-xml]
-basepython = python3.10
 deps =
     coverage
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     clean
-    py{310,311,312}-django{42,50,51}
+    py{310,311,312}-django{42,51}
     py{313}-django{51}
     coverage-html
 skipsdist = True
@@ -54,7 +54,6 @@ setenv =
 
 commands =
     pip-compile --extra spa --extra htmx --resolver backtracking --output-file requirements-django42.txt {posargs} pyproject.toml requirements/django42.txt constraints.txt
-    pip-compile --extra spa --extra htmx --resolver backtracking --output-file requirements-django50.txt {posargs} pyproject.toml requirements/django50.txt constraints.txt
     pip-compile --extra spa --extra htmx --resolver backtracking --output-file requirements-django51.txt {posargs} pyproject.toml requirements/django51.txt constraints.txt
     cp requirements-django42.txt requirements.txt
 


### PR DESCRIPTION
Follows after #939

Python 3.9 has support for 11 more months, until 31 Oct 2025. Django's beyond 4.2 does not support 3.9. Django 4.2 is EOL after 3.9, at 30 Apr 2026.