### PR TITLE
Robustify preferences lookup

### DIFF
--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -228,7 +228,7 @@ class Preferences(models.Model):
     @classmethod
     def get_defaults(cls):
         "Override to add magic"
-        return cls._FIELD_DEFAULTS.copy() or {}
+        return cls._FIELD_DEFAULTS.copy() if cls._FIELD_DEFAULTS else {}
 
     @classmethod
     def ensure_for_user(cls, user):

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -213,7 +213,7 @@ class Preferences(models.Model):
     preferences = models.JSONField(blank=True, default=dict)
 
     objects = PreferencesManager()
-    unregistered_preferences = UnregisteredPreferencesManager()
+    unregistered = UnregisteredPreferencesManager()
 
     # storage for field forms in preference
     FORMS = None

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -94,7 +94,7 @@ class User(AbstractUser):
 
     def get_or_create_preferences(self):
         Preferences.ensure_for_user(self)
-        return self.preferences.all()
+        return self.preferences.filter(namespace__in=Preferences.NAMESPACES)
 
     def get_preferences_context(self):
         pref_sets = self.get_or_create_preferences()

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -108,6 +108,9 @@ class User(AbstractUser):
 
 
 class PreferencesManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().filter(namespace__in=Preferences.NAMESPACES)
+
     def get_by_natural_key(self, user, namespace):
         return self.get(user=user, namespace=namespace)
 
@@ -125,7 +128,9 @@ class PreferencesManager(models.Manager):
                 prefdict[namespace] = defaults
         return prefdict
 
-    def get_unregistered_preferences(self):
+
+class UnregisteredPreferencesManager(models.Manager):
+    def get_queryset(self):
         """Find preferences that are not backed by a subclass
 
         It *is* possible to create a preference that has no subclass:
@@ -136,7 +141,7 @@ class PreferencesManager(models.Manager):
 
         Find them so that they can be handled, preferrably deleted.
         """
-        return self.exclude(namespace__in=Preferences.NAMESPACES)
+        return super().get_queryset().exclude(namespace__in=Preferences.NAMESPACES)
 
 
 class SessionPreferences:
@@ -208,6 +213,7 @@ class Preferences(models.Model):
     preferences = models.JSONField(blank=True, default=dict)
 
     objects = PreferencesManager()
+    unregistered_preferences = UnregisteredPreferencesManager()
 
     # storage for field forms in preference
     FORMS = None

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -125,6 +125,19 @@ class PreferencesManager(models.Manager):
                 prefdict[namespace] = defaults
         return prefdict
 
+    def get_unregistered_preferences(self):
+        """Find preferences that are not backed by a subclass
+
+        It *is* possible to create a preference that has no subclass:
+
+        * Directly in database
+        * Preferences().save
+        * Preferences.objects.create()
+
+        Find them so that they can be handled, preferrably deleted.
+        """
+        return self.exclude(namespace__in=Preferences.NAMESPACES)
+
 
 class SessionPreferences:
     def __init__(self, session, namespace):

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -288,9 +288,9 @@ class UnregisteredPreferencesManagerTests(TestCase):
         )
 
     def test_all_does_not_find_registered_preferences(self):
-        results = Preferences.unregistered_preferences.all()
+        results = Preferences.unregistered.all()
         self.assertNotIn(MyPreferences, results)
 
     def test_all_finds_all_unregistered_preferences(self):
-        results = Preferences.unregistered_preferences.all()
+        results = Preferences.unregistered.all()
         self.assertIn(self.unregistered_preference, results)


### PR DESCRIPTION
If adding a preference instance without going through a subclass, things may break.

This PR makes them break less.