### PR TITLE
Split up import of multiple modules on one line

### DIFF
--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -1,6 +1,7 @@
 from zoneinfo import ZoneInfo
 
-import factory, factory.fuzzy
+import factory
+import factory.fuzzy
 
 from argus.auth.factories import SourceUserFactory
 from argus.util.datetime_utils import INFINITY_REPR


### PR DESCRIPTION
In preparation of adding `E4` rules to ruff - this fixes `E401` - multiple imports on one line.