### PR TITLE
Add E4 rules to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ extend-exclude = [
 output-format = "full"
 
 [tool.ruff.lint]
-select = ["E7", "E9", "F4", "F5", "F6", "F7", "F82", "F9"]
+select = ["E4", "E7", "E9", "F4", "F5", "F6", "F7", "F82", "F9"]
 ignore = ["F403", "F405"]
 
 [tool.towncrier]


### PR DESCRIPTION
Dependent on #962.

Slightly up for discussion (if we do not add it, then we have to remove it from the Argus-HTMX workflow)