### PR TITLE
Use `isinstance` for checking that settings are dict

### DIFF
--- a/src/argus/notificationprofile/serializers.py
+++ b/src/argus/notificationprofile/serializers.py
@@ -141,7 +141,7 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
         if self.instance and "media" in attrs.keys() and not attrs["media"].slug == self.instance.media.slug:
             raise serializers.ValidationError("Media cannot be updated, only settings.")
         if "settings" in attrs.keys():
-            if type(attrs["settings"]) != dict:
+            if not isinstance(attrs["settings"], dict):
                 raise serializers.ValidationError("Settings has to be a dictionary.")
             if self.instance:
                 medium = api_safely_get_medium_object(self.instance.media.slug)


### PR DESCRIPTION
In order to add `E7` to ruff rules. This fixes `E721` - "Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks"