### PR TITLE
Rewrite assigned lambda expression as def

### DIFF
--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -83,7 +83,8 @@ class APITests(APITestCase):
         self.assertEqual(response.data["username"], self.normal_user1.username)
 
     def test_get_user_returns_the_correct_fields(self):
-        user_path = lambda user: reverse("v1:auth:user", args=[user.pk])
+        def user_path(user: User):
+            return reverse("v1:auth:user", args=[user.pk])
 
         def assert_correct_fields_for_user(user: User):
             response = self.normal_user1_client.get(user_path(user))


### PR DESCRIPTION
In order to add `E7` to ruff rules, this fixes `E731` - "Do not assign a `lambda` expression, use a `def`"