### PR TITLE
Return user to login page on unauthenticated HTMX request

### DIFF
--- a/changelog.d/+unauthenticated-htmx-full-redirect.changed.md
+++ b/changelog.d/+unauthenticated-htmx-full-redirect.changed.md
@@ -1,0 +1,1 @@
+Return user to login page on unauthenticated HTMX request

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -45,7 +45,7 @@ class LoginRequiredMiddleware:
 
         # Redirect unauthenticated users to login page
         response = redirect_to_login(request.get_full_path(), self.login_url, "next")
-        if request.htmx:
+        if getattr(request, "htmx", False):
             response = HttpResponseClientRedirect(response.url)
 
         return response

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -4,6 +4,7 @@ from django.http import HttpRequest, HttpResponse
 from django.template import loader
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_str
+from django_htmx.http import HttpResponseClientRedirect
 
 
 class LoginRequiredMiddleware:
@@ -43,7 +44,11 @@ class LoginRequiredMiddleware:
             return None
 
         # Redirect unauthenticated users to login page
-        return redirect_to_login(request.get_full_path(), self.login_url, "next")
+        response = redirect_to_login(request.get_full_path(), self.login_url, "next")
+        if request.htmx:
+            response = HttpResponseClientRedirect(response.url)
+
+        return response
 
 
 class HtmxMessageMiddleware(MiddlewareMixin):


### PR DESCRIPTION
~~requires #955~~


fixes #981 

How to test:

Two different browser sessions:

1. Session 1: Log in with admin user
2. Session 2: Log in with fresh, new user (For instance by logging in via SSO with an unknown user. By default this creates a user. You could also have session 1 create one.)
3. Session 1: Delete the user created in step 2.
4. Session 2: Change a filter in the filter box to trigger the problem