### PR TITLE
Add `F401` rule (unused imports) to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ extend-exclude = [
 output-format = "full"
 
 [tool.ruff.lint]
-select = ["E7", "E9", "F63", "F7", "F82"]
+select = ["E7", "E9", "F401", "F63", "F7", "F82"]
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
Dependent on #972, #973, #974, #975 and #1031.

Slightly up for discussion (if we do not add it, then we have to remove it from the Argus-HTMX workflow)