### PR TITLE
Remove Dict, List, Tuple and Set imports from Typing

### DIFF
--- a/src/argus/auth/V1/serializers.py
+++ b/src/argus/auth/V1/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from typing import List
 
 from argus.notificationprofile.models import DestinationConfig
 from ..models import User
@@ -37,7 +36,7 @@ class UserSerializerV1(serializers.ModelSerializer):
             "phone_numbers",
         ]
 
-    def get_phone_numbers(self, user: User) -> List[dict]:
+    def get_phone_numbers(self, user: User) -> list[dict]:
         return [
             {"pk": destination.pk, "user": user.pk, "phone_number": destination.settings["phone_number"]}
             for destination in user.destinations.filter(media_id="sms")

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Dict, Optional, Union, Protocol
+from typing import Any, Optional, Union, Protocol
 
 from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
@@ -187,14 +187,14 @@ class SessionPreferences:
 
 
 class PreferencesBase(Protocol):
-    FORMS: Dict[str, forms.Form]
-    _FIELD_DEFAULTS: Dict[str, Any]
+    FORMS: dict[str, forms.Form]
+    _FIELD_DEFAULTS: dict[str, Any]
 
     @classmethod
-    def get_defaults(cls) -> Dict[str, Any]:
+    def get_defaults(cls) -> dict[str, Any]:
         pass
 
-    def update_context(self, context: Dict[str, Any]) -> Dict[str, Any]:
+    def update_context(self, context: dict[str, Any]) -> dict[str, Any]:
         pass
 
 

--- a/src/argus/filter/filterwrapper.py
+++ b/src/argus/filter/filterwrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Dict, Optional, Any, Tuple
+from typing import TYPE_CHECKING, Optional, Any
 
 from django.conf import settings
 
@@ -21,7 +21,7 @@ __all__ = [
 
 
 TriState = Optional[bool]
-FilterBlobType = Dict[str, Any]  # Validator: drf serializer, depends on API version
+FilterBlobType = dict[str, Any]  # Validator: drf serializer, depends on API version
 
 
 LOG = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class FilterWrapper:
     def _get_filter_value(self, key: str) -> Optional[Any]:
         return self.filter.get(key, None)
 
-    def _get_filter_value_and_ignored_status(self, key: str) -> Tuple[Optional[Any], bool]:
+    def _get_filter_value_and_ignored_status(self, key: str) -> tuple[Optional[Any], bool]:
         filter_ = self._get_filter_value(key)
         if key in self.TRINARY_FILTERS:
             return filter_, filter_ is None

--- a/src/argus/htmx/incidents/customization.py
+++ b/src/argus/htmx/incidents/customization.py
@@ -6,7 +6,7 @@ Currently customizable UI elements:
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from django.conf import settings
 
@@ -57,7 +57,7 @@ _BUILTIN_COLUMN_LIST = [
 BUILTIN_COLUMNS = {col.name: col for col in _BUILTIN_COLUMN_LIST}
 
 
-def get_incident_table_columns() -> List[IncidentTableColumn]:
+def get_incident_table_columns() -> list[IncidentTableColumn]:
     columns = getattr(settings, "INCIDENT_TABLE_COLUMNS", argus_htmx_settings.INCIDENT_TABLE_COLUMNS)
     return [_resolve_column(col) for col in columns]
 

--- a/src/argus/htmx/utils.py
+++ b/src/argus/htmx/utils.py
@@ -4,7 +4,7 @@
 #
 # Uses composition, see bulk_change_incidents()
 
-from typing import List, Dict, Any
+from typing import Any
 
 from django.utils import timezone
 
@@ -16,7 +16,7 @@ def send_changed_incidents(incidents):
     bulk_changed.send(sender=Incident, instances=incidents)
 
 
-def get_qs_for_incident_ids(incident_ids: List[int], qs=None):
+def get_qs_for_incident_ids(incident_ids: list[int], qs=None):
     # setup
     if qs is None:
         qs = Incident.objects.all()
@@ -28,7 +28,7 @@ def get_qs_for_incident_ids(incident_ids: List[int], qs=None):
     return qs, missing_ids
 
 
-def bulk_ack_queryset(actor, qs, data: Dict[str, Any]):
+def bulk_ack_queryset(actor, qs, data: dict[str, Any]):
     timestamp = data["timestamp"]
     description = data.get("description", "")
     expiration = data.get("expiration", None)
@@ -39,7 +39,7 @@ def bulk_ack_queryset(actor, qs, data: Dict[str, Any]):
     return incidents
 
 
-def bulk_close_queryset(actor, qs, data: Dict[str, Any]):
+def bulk_close_queryset(actor, qs, data: dict[str, Any]):
     timestamp = data["timestamp"]
     description = data.get("description", "")
     events = qs.close(actor, timestamp, description)
@@ -49,7 +49,7 @@ def bulk_close_queryset(actor, qs, data: Dict[str, Any]):
     return incidents
 
 
-def bulk_reopen_queryset(actor, qs, data: Dict[str, Any]):
+def bulk_reopen_queryset(actor, qs, data: dict[str, Any]):
     timestamp = data["timestamp"]
     description = data.get("description", "")
     events = qs.reopen(actor, timestamp, description)
@@ -59,13 +59,13 @@ def bulk_reopen_queryset(actor, qs, data: Dict[str, Any]):
     return incidents
 
 
-def bulk_change_ticket_url_queryset(actor, qs, data: Dict[str, Any]):
+def bulk_change_ticket_url_queryset(actor, qs, data: dict[str, Any]):
     timestamp = data["timestamp"]
     ticket_url = data.get("ticket_url", "")
     return qs.update_ticket_url(actor, ticket_url, timestamp=timestamp)
 
 
-def bulk_change_incidents(actor, incident_ids: List[int], data: Dict[str, Any], func, qs=None):
+def bulk_change_incidents(actor, incident_ids: list[int], data: dict[str, Any], func, qs=None):
     """
     Update incidents in bulk
 

--- a/src/argus/incident/serializers.py
+++ b/src/argus/incident/serializers.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from typing import List, Tuple
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -26,7 +25,7 @@ from .models import (
 User = get_user_model()
 
 
-def clean_tag(value: str) -> Tuple[str, str]:
+def clean_tag(value: str) -> tuple[str, str]:
     try:
         [key, value] = Tag.split(value)
     except (ValueError, ValidationError) as e:
@@ -222,7 +221,7 @@ class IncidentPureDeserializer(serializers.ModelSerializer):
                 )
 
     @staticmethod
-    def add_and_remove_tags(instance: Incident, user: User, tags_data: List[dict]):
+    def add_and_remove_tags(instance: Incident, user: User, tags_data: list[dict]):
         posted_tags = {Tag.objects.get_or_create(**tag_data)[0] for tag_data in tags_data}
 
         existing_tag_relations = instance.incident_tag_relations.select_related("tag")

--- a/src/argus/notificationprofile/V1/serializers.py
+++ b/src/argus/notificationprofile/V1/serializers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rest_framework import fields, serializers
 
 from argus.filter.primitive_serializers import CustomMultipleChoiceField
@@ -26,7 +24,7 @@ class ResponseNotificationProfileSerializerV1(serializers.ModelSerializer):
             "phone_number",
         ]
 
-    def get_media(self, profile: NotificationProfile) -> List[str]:
+    def get_media(self, profile: NotificationProfile) -> list[str]:
         media = []
         if profile.destinations.filter(media_id="email").exists():
             media.append("EM")

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from types import NoneType
-    from typing import Union, Set
+    from typing import Union
 
     from django.contrib.auth import get_user_model
     from django.db.models.query import QuerySet
@@ -56,7 +56,7 @@ class NotificationMedium(ABC):
         pass
 
     @classmethod
-    def get_relevant_addresses(cls, destinations: Iterable[DestinationConfig]) -> Set[DestinationConfig]:
+    def get_relevant_addresses(cls, destinations: Iterable[DestinationConfig]) -> set[DestinationConfig]:
         """Returns a set of addresses the message should be sent to"""
         pass
 

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from types import NoneType
-    from typing import Union, Set
+    from typing import Union
 
     from django.contrib.auth import get_user_model
     from django.db.models.query import QuerySet
@@ -143,7 +143,7 @@ class EmailNotification(NotificationMedium):
         return queryset.filter(settings__email_address=settings["email_address"]).exists()
 
     @classmethod
-    def get_relevant_addresses(cls, destinations: Iterable[DestinationConfig]) -> Set[DestinationConfig]:
+    def get_relevant_addresses(cls, destinations: Iterable[DestinationConfig]) -> set[DestinationConfig]:
         """Returns a list of email addresses the message should be sent to"""
         email_addresses = [
             destination.settings["email_address"]

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -22,8 +22,6 @@ from .email import send_email_safely
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from typing import Set
-
     from django.contrib.auth import get_user_model
     from django.db.models.query import QuerySet
 
@@ -88,7 +86,7 @@ class SMSNotification(NotificationMedium):
         return queryset.filter(settings__phone_number=settings["phone_number"]).exists()
 
     @classmethod
-    def get_relevant_addresses(cls, destinations: Iterable[DestinationConfig]) -> Set[DestinationConfig]:
+    def get_relevant_addresses(cls, destinations: Iterable[DestinationConfig]) -> set[DestinationConfig]:
         """Returns a list of phone numbers the message should be sent to"""
         phone_numbers = [
             destination.settings["phone_number"]

--- a/src/argus/site/settings/_serializers.py
+++ b/src/argus/site/settings/_serializers.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -12,10 +12,10 @@ class AppUrlSetting(BaseModel):
 class AppSetting(BaseModel):
     app_name: Optional[str] = None
     urls: Optional[AppUrlSetting] = None
-    context_processors: Optional[List[str]] = None
-    middleware: Optional[Dict[str, str]] = None
-    settings: Optional[Dict[str, Any]] = None
+    context_processors: Optional[list[str]] = None
+    middleware: Optional[dict[str, str]] = None
+    settings: Optional[dict[str, Any]] = None
 
 
 class ListAppSetting(RootModel):
-    root: List[AppSetting]
+    root: list[AppSetting]

--- a/src/argus/util/admin_utils.py
+++ b/src/argus/util/admin_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Sequence, Union
+from typing import Callable, Sequence, Union
 
 from django.contrib import admin
 from django.contrib.admin.utils import quote
@@ -55,7 +55,7 @@ def list_filter_factory(
 
 def add_elements_to_deleted_objects(
     objs: Sequence[Model],
-    to_delete: List[Union[str, list]],
+    to_delete: list[Union[str, list]],
     get_elements_func: Callable[[Model], Sequence[Model]],
     admin_site,
 ):


### PR DESCRIPTION
Dependent on #973.

See https://peps.python.org/pep-0585/.
Since Python 3.9 one can simply use the build-in version.