### PR TITLE
Ignore rules `F403`, `F405` star imports in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ output-format = "full"
 
 [tool.ruff.lint]
 select = ["E7", "E9", "F5", "F6", "F7", "F82", "F9"]
+ignore = ["F403", "F405"]
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/undefined-local-with-import-star/
https://docs.astral.sh/ruff/rules/undefined-local-with-import-star-usage/