### PR TITLE
Add djLint for formatting HTML

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format codebase
+name: Verify formatting
 
 on:
   push:
@@ -6,13 +6,29 @@ on:
   pull_request:
 
 jobs:
-  format:
+  ruff:
     runs-on: ubuntu-latest
-    name: Format
+    name: Verify Python formatting
     steps:
     - uses: actions/checkout@v4
 
-    - name: Format
-      uses: astral-sh/ruff-action@v2
+    - uses: astral-sh/ruff-action@v2
       with:
         args: "format --check"
+
+  djlint:
+    runs-on: ubuntu-latest
+    name: Check HTML formatting
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+
+    - name: Install dependencies
+      run: |
+        pip install -U pip
+        pip install djlint
+
+    - name: Format HTML
+      run: djlint . --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
 profile="django"
 indent = 2
 ignore="H006"
+use_gitignore=true
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "coverage",
     "django-extensions",
     "ruff",
+    "djlint",
     "ipython",
     "pre-commit",
     "python-dotenv",


### PR DESCRIPTION
Dependent on #1013. 

Adds a workflow that checks that all HTML templates are formatted using djLint. 
djLint has already been added to pre-commit when merging in Argus-HTMX.
Also adds djLint to dev dependencies. 
Make djLint ignore all files ignored by `.gitignore`