### PR TITLE
Add meta description and keywords

### DIFF
--- a/src/argus/base/templates/base.html
+++ b/src/argus/base/templates/base.html
@@ -3,6 +3,10 @@
 <html lang="en-US">
   <!-- argus/site/templates/base.html -->
   <head>
+    <meta name="description"
+          content="Argus is a tool for aggregating events from multiple monitoring applications into a single, unified dashboard and notification system.">
+    <meta name="keywords"
+          content="monitoring, notifications, dashboard, events, incidents, alerts, alarms, monitoring systems, monitoring applications, monitoring tools, monitoring software">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block title %}<title>Argus Server: {{ page_title }}</title>{% endblock %}

--- a/src/argus/incident/templates/incident/ticket/default_ticket_body.html
+++ b/src/argus/incident/templates/incident/ticket/default_ticket_body.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{# djlint:off H030,H031 #}
 <html lang="en">
   <head>
     <meta charset="UTF-8">

--- a/src/argus/notificationprofile/templates/notificationprofile/email.html
+++ b/src/argus/notificationprofile/templates/notificationprofile/email.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{# djlint:off H030,H031 #}
 <html lang="en">
   <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
Dependent on #1013.

This is basically a copy of Uninett/argus-htmx-frontend#208. 

It also makes djLint ignore the rules `H030 - Consider adding a meta description.` and `H0301 - Consider adding meta keywords.` for the ticket and email templates.