### PR TITLE
 Add name to endblocks in templates 

### DIFF
--- a/src/argus/base/templates/base.html
+++ b/src/argus/base/templates/base.html
@@ -9,11 +9,13 @@
           content="monitoring, notifications, dashboard, events, incidents, alerts, alarms, monitoring systems, monitoring applications, monitoring tools, monitoring software">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% block title %}<title>Argus Server: {{ page_title }}</title>{% endblock %}
+    {% block title %}
+      <title>Argus Server: {{ page_title }}</title>
+    {% endblock title %}
     {% block head %}
     {% endblock head %}
   </head>
-  <body {% block body_overrides %}{% endblock %}>
+  <body {% block body_overrides %}{% endblock body_overrides %}>
     {% block header %}
       <h1>Argus Server: {{ page_title }}</h1>
     {% endblock header %}

--- a/src/argus/incident/templates/incident/admin/fake_incident_add_form.html
+++ b/src/argus/incident/templates/incident/admin/fake_incident_add_form.html
@@ -3,13 +3,17 @@
 {% block extrahead %}
   {{ block.super }}
   <script src="{% url 'admin:jsi18n' %}"></script>
-{% endblock %}
+{% endblock extrahead %}
 {% block extrastyle %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
-{% endblock %}
-{% block coltype %}colM{% endblock %}
-{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-form{% endblock %}
+{% endblock extrastyle %}
+{% block coltype %}
+  colM
+{% endblock coltype %}
+{% block bodyclass %}
+  {{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-form
+{% endblock bodyclass %}
 {% block breadcrumbs %}
   <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% translate "Home" %}</a>
@@ -17,12 +21,13 @@
     &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
     &rsaquo; {% blocktranslate with name=opts.verbose_name %}Add fake incident{% endblocktranslate %}
   </div>
-{% endblock %}
+{% endblock breadcrumbs %}
 {% block content %}
   <div id="content-main">
     <form method="post" id="{{ opts.model_name }}_form" novalidate>
       {% csrf_token %}
-      {% block form_top %}{% endblock %}
+      {% block form_top %}
+      {% endblock form_top %}
       <div>
         {% if errors %}
           <p class="errornote">
@@ -42,9 +47,11 @@
           {% for fieldset in adminform %}
             {% include "admin/includes/fieldset.html" %}
           {% endfor %}
-        {% endblock %}
-        {% block after_field_sets %}{% endblock %}
-        {% block after_related_objects %}{% endblock %}
+        {% endblock field_sets %}
+        {% block after_field_sets %}
+        {% endblock after_field_sets %}
+        {% block after_related_objects %}
+        {% endblock after_related_objects %}
         {% block submit_buttons_bottom %}
           <div class="submit-row">
             <input type="submit"
@@ -52,14 +59,14 @@
                    class="default"
                    name="_save">
           </div>
-        {% endblock %}
+        {% endblock submit_buttons_bottom %}
         {% block admin_change_form_document_ready %}
           <script id="django-admin-form-add-constants" src="{% static 'admin/js/change_form.js' %}" data-model-name="{{ opts.model_name }}" async>
           </script>
-        {% endblock %}
+        {% endblock admin_change_form_document_ready %}
         {# JavaScript for prepopulated fields #}
         {% prepopulated_fields_js %}
       </div>
     </form>
   </div>
-{% endblock %}
+{% endblock content %}

--- a/src/argus/incident/templates/incident/admin/incident_change_list.html
+++ b/src/argus/incident/templates/incident/admin/incident_change_list.html
@@ -7,4 +7,4 @@
     </li>
   {% endif %}
   {{ block.super }}
-{% endblock %}
+{% endblock object-tools-items %}


### PR DESCRIPTION
Dependent on #1013.

This fixes djLint's complaints about rule `T003 - Endblock should have name. Ex: {% endblock body %}.`