### PR TITLE
Use url pattern for internal links

### DIFF
--- a/src/argus/incident/templates/incident/admin/incident_change_list.html
+++ b/src/argus/incident/templates/incident/admin/incident_change_list.html
@@ -3,7 +3,7 @@
 {% block object-tools-items %}
   {% if has_add_permission %}
     <li>
-      <a href="fake/" class="addlink">Fake incident</a>
+      <a href="{% url "admin:add-fake-incident" %}" class="addlink">Fake incident</a>
     </li>
   {% endif %}
   {{ block.super }}


### PR DESCRIPTION
Dependent on #1013.

Fixes djLint's complaints about `D018 - (Django) Internal links should use the {% url ... %} pattern.`