### PR TITLE
Allow filtering from columns

### DIFF
--- a/changelog.d/+filterable-columns.added.md
+++ b/changelog.d/+filterable-columns.added.md
@@ -1,0 +1,1 @@
+HTMX: support incident filtering from incident list table columns

--- a/docs/development/howtos/htmx-frontend/customize-filtering.rst
+++ b/docs/development/howtos/htmx-frontend/customize-filtering.rst
@@ -1,0 +1,49 @@
+=============================================
+How to customize filtering the incidents list
+=============================================
+
+Incident list filtering is governed by the ``incident_list_filter`` function. By default, this
+function is imported from ``argus_htmx.incidents.filter``, but that module can be changed by
+overriding the ``ARGUS_HTMX_FILTER_FUNCTION`` to point to a different module. That module should
+contain a ``incident_list_filter`` function. It has the following signature::
+
+  def incident_list_filter(request: HttpRequest, qs: IncidentQuerySet) -> tuple[Form, IncidentQuerySet]:
+      ...
+
+When loading the incidents list, this function is called with the request and the base incident
+queryset, and allows for updating this queryset. This way, the queryset can for example be
+filtered, reordered and/or data may be added (such as through ``annotate``).
+
+Aside from the updated queryset, ``incident_list_filter`` returns a ``django.forms.Form``. This
+form is used to populate the incident filterbox and any filterable columns
+
+
+Filterable columns
+------------------
+
+Argus has support for applying filters directly on the incident list column header. To do this, for
+example to allow the filtering "Description" column, add/update the ``IncidentTableColumn`` in your
+``INCIDENT_TABLE_COLUMN`` setting::
+
+  INCIDENT_TABLE_COLUMNS = [
+    ...
+    IncidentTableColumn(
+        "description",
+        label="Description",
+        cell_template="htmx/incidents/_incident_description.html",
+        filter_field="description",
+    ),
+    ...
+  ]
+
+You then need to update your ``incident_list_filter`` ``Form`` to something akin to the following::
+
+  class IncidentFilterForm(forms.Form):
+      ...
+      description = forms.CharField(max_length=255, required=False)
+      description.in_header = True
+      ...
+
+The attribute name ``description`` should match the value of the
+``IncidentTableColumn.filter_field`` attribute. This will tell argus_htmx to not render a filter
+input for the description in the incident filter box, but to use the column header filter instead

--- a/src/argus/htmx/incidents/customization.py
+++ b/src/argus/htmx/incidents/customization.py
@@ -22,6 +22,9 @@ class IncidentTableColumn:
     :param cell_template: template to use when rendering a cell for this column
     :param context: additional context to pass to the rendering cell. Will be made
         available as ``cell_context`` in the cell template
+    :param filter_field: when given, this column is considered filterable and a filter
+        input is attached to the column header that can provide a query param with `filter_field`
+        as the key
     """
 
     name: str  # identifier
@@ -29,6 +32,7 @@ class IncidentTableColumn:
     cell_template: str
     header_template: Optional[str] = None
     context: Optional[dict] = None
+    filter_field: Optional[str] = None
 
 
 _BUILTIN_COLUMN_LIST = [

--- a/src/argus/htmx/incidents/utils.py
+++ b/src/argus/htmx/incidents/utils.py
@@ -7,9 +7,13 @@ DEFAULT_MODULE = "argus.htmx.incidents.filter"
 
 
 def get_filter_function():
-    dotted_path = getattr(settings, "ARGUS_HTMX_FILTER_FUNCTION", DEFAULT_MODULE)
-    module = importlib.import_module(dotted_path)
-    function = getattr(module, FUNCTION_NAME, None)
-    if function:
-        return function
-    raise ImportError(f"Could not import {FUNCTION_NAME} from {dotted_path}")
+    setting = getattr(settings, "ARGUS_HTMX_FILTER_FUNCTION", DEFAULT_MODULE)
+    if callable(setting):
+        return setting
+    if isinstance(setting, str):
+        module = importlib.import_module(setting)
+        function = getattr(module, FUNCTION_NAME, None)
+        if function:
+            return function
+        raise ImportError(f"Could not import {FUNCTION_NAME} from {setting}")
+    raise TypeError(f"ARGUS_HTMX_FILTER_FUNCTION must be a callable or string")

--- a/src/argus/htmx/templates/htmx/incidents/_incident_filterable_column.html
+++ b/src/argus/htmx/templates/htmx/incidents/_incident_filterable_column.html
@@ -1,0 +1,30 @@
+{% load argus_htmx %}
+<div class="flex flex-col relative">
+  {% with filter_value=filter_form|fieldvalue:column.filter_field %}
+    <div>
+      {{ column.label }}
+      <span>
+        <button type="button"
+                class="btn btn-xs {% if filter_value %} btn-primary {% else %} btn-ghost {% endif %} min-h-4 h-4"
+                _="on click toggle .hidden on next .column-filter">🔍</button>
+      </span>
+    </div>
+    <div class="absolute flex gap-2 column-filter hidden bg-base-100 border-primary border p-2 rounded-lg w-full w-72 top-5 z-10"
+         _="on keyup[key is 'Escape'] from body add .hidden to me">
+      <input name="{{ column.filter_field }}"
+             autocomplete="off"
+             class="input input-xs grow input-accent"
+             value="{{ filter_form|fieldvalue:column.filter_field }}">
+      <button type="button"
+              class="btn btn-xs btn-primary"
+              _="on click add .hidden to closest .column-filter"
+              hx-get="{% url 'htmx:incident-list' %}"
+              hx-trigger="click"
+              hx-include="#table-refresh-info, #incident-filter-box, .column-filter"
+              hx-target="#table"
+              hx-swap="outerHTML"
+              hx-push-url="true"
+              hx-indicator="#incident-list .htmx-indicator">Filter</button>
+    </div>
+  {% endwith %}
+</div>

--- a/src/argus/htmx/templates/htmx/incidents/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incidents/_incident_filterbox.html
@@ -1,7 +1,7 @@
 {% load widget_tweaks %}
 <form id="incident-filter-box"
       hx-get="{% url 'htmx:incident-list' %}"
-      hx-include="#table-refresh-info, #incident-filter-box"
+      hx-include="#table-refresh-info, #incident-filter-box, .column-filter"
       hx-trigger="keydown[keyCode==13], change delay:100ms"
       hx-target="#table"
       hx-swap="outerHTML"
@@ -12,36 +12,38 @@
     <legend class="sr-only">Filter incidents</legend>
     <ul class="menu menu-horizontal menu-sm flex items-center gap-2 py-1.5">
       {% for field in filter_form %}
-        <li class="form-control">
-          {% if field.name == "source" %}
-            <div class="flex flex-nowrap">
-              <label class="label">
+        {% if not field.field.in_header %}
+          <li class="form-control">
+            {% if field.name == "source" %}
+              <div class="flex flex-nowrap">
+                <label class="label">
+                  <span class="label-text">{{ field.label }}</span>
+                </label>
+                {{ field }}
+              </div>
+            {% else %}
+              <label class="cursor-pointer label">
                 <span class="label-text">{{ field.label }}</span>
-              </label>
-              {{ field }}
-            </div>
-          {% else %}
-            <label class="cursor-pointer label">
-              <span class="label-text">{{ field.label }}</span>
-              {% if field|field_type == "booleanfield" %}
-                {{ field|add_class:"checkbox checkbox-accent border" }}
-              {% elif field.name == "maxlevel" %}
-                <div>
-                  {{ field|add_class:"range range-primary range-xs" }}
-                  <div class="flex w-full justify-between px-2 text-xs">
-                    {% for tick in "12345" %}<span>{{ tick }}</span>{% endfor %}
+                {% if field|field_type == "booleanfield" %}
+                  {{ field|add_class:"checkbox checkbox-accent border" }}
+                {% elif field.name == "maxlevel" %}
+                  <div>
+                    {{ field|add_class:"range range-primary range-xs" }}
+                    <div class="flex w-full justify-between px-2 text-xs">
+                      {% for tick in "12345" %}<span>{{ tick }}</span>{% endfor %}
+                    </div>
                   </div>
-                </div>
-              {% elif field|field_type == "choicefield" %}
-                {{ field|add_class:"select select-accent border" }}
-              {% elif field|field_type == "multiplechoicefield" %}
-                {{ field|attr:"size:1"|add_class:"select select-accent border" }}
-              {% elif field|field_type == "charfield" %}
-                {{ field|add_class:"input input-accent input-bordered border" }}
-              {% endif %}
-            </label>
-          {% endif %}
-        </li>
+                {% elif field|field_type == "choicefield" %}
+                  {{ field|add_class:"select select-accent border" }}
+                {% elif field|field_type == "multiplechoicefield" %}
+                  {{ field|attr:"size:1"|add_class:"select select-accent border" }}
+                {% elif field|field_type == "charfield" %}
+                  {{ field|add_class:"input input-accent input-bordered border" }}
+                {% endif %}
+              </label>
+            {% endif %}
+          </li>
+        {% endif %}
       {% empty %}
         <li>No filter fields configured</li>
       {% endfor %}

--- a/src/argus/htmx/templates/htmx/incidents/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incidents/_incident_table.html
@@ -13,6 +13,8 @@
           <th class="border-b border-primary">
             {% if col.header_template %}
               {% include col.header_template with label=col.label %}
+            {% elif col.filter_field %}
+              {% include "htmx/incidents/_incident_filterable_column.html" with column=col %}
             {% else %}
               {{ col.label }}
             {% endif %}

--- a/src/argus/htmx/templatetags/argus_htmx.py
+++ b/src/argus/htmx/templatetags/argus_htmx.py
@@ -32,3 +32,8 @@ def pp_level(level: int) -> str:
     if level not in mapping:
         return mapping["5"]
     return mapping[level]
+
+
+@register.filter
+def fieldvalue(form, fieldname):
+    return form[fieldname].value() or ""

--- a/tests/htmx/test_incidents.py
+++ b/tests/htmx/test_incidents.py
@@ -45,10 +45,10 @@ class TestRegularColumn(test.TestCase):
         request.htmx = False
         self.response = incident_list(request)
 
-    def test_adds_filter_button_to_header(self):
+    def test_doesnt_add_filter_button_to_header(self):
         self.assertNotContains(self.response, '_="on click toggle .hidden on next .column-filter"')
 
-    def test_doesnt_add_filter_to_filterbox(self):
+    def test_add_filter_to_filterbox(self):
         self.assertContains(self.response, '<span class="label-text">Description</span>')
 
 

--- a/tests/htmx/test_incidents.py
+++ b/tests/htmx/test_incidents.py
@@ -1,0 +1,78 @@
+from django import forms, test
+from django.test.client import RequestFactory
+from argus.auth.factories import PersonUserFactory
+from argus.filter.queryset_filters import QuerySetFilter
+from argus.htmx.incidents.customization import IncidentTableColumn
+from argus.htmx.incidents.views import incident_list
+
+
+class IncidentRegularFilterForm(forms.Form):
+    description = forms.CharField(max_length=255, required=False)
+
+
+class IncidentColumnFilterForm(forms.Form):
+    description = forms.CharField(max_length=255, required=False)
+    description.in_header = True
+
+
+def incident_list_filter_factory(form_cls):
+    def incident_list_filter(request, qs):
+        form = form_cls(request.GET or None)
+
+        if form.is_valid():
+            filterblob = form.to_filterblob()
+            qs = QuerySetFilter.filtered_incidents(filterblob, qs)
+        return form, qs
+
+    return incident_list_filter
+
+
+@test.override_settings(
+    ROOT_URLCONF="argus.htmx.root_urls",
+    ARGUS_HTMX_FILTER_FUNCTION=incident_list_filter_factory(IncidentRegularFilterForm),
+    INCIDENT_TABLE_COLUMNS=[
+        IncidentTableColumn(
+            "description",
+            label="Description",
+            cell_template="htmx/incidents/_incident_description.html",
+        ),
+    ],
+)
+class TestRegularColumn(test.TestCase):
+    def setUp(self):
+        request = RequestFactory().get("/incidents")
+        request.user = PersonUserFactory()
+        request.htmx = False
+        self.response = incident_list(request)
+
+    def test_adds_filter_button_to_header(self):
+        self.assertNotContains(self.response, '_="on click toggle .hidden on next .column-filter"')
+
+    def test_doesnt_add_filter_to_filterbox(self):
+        self.assertContains(self.response, '<span class="label-text">Description</span>')
+
+
+@test.override_settings(
+    ROOT_URLCONF="argus.htmx.root_urls",
+    ARGUS_HTMX_FILTER_FUNCTION=incident_list_filter_factory(IncidentColumnFilterForm),
+    INCIDENT_TABLE_COLUMNS=[
+        IncidentTableColumn(
+            "description",
+            label="Description",
+            cell_template="htmx/incidents/_incident_description.html",
+            filter_field="description",
+        ),
+    ],
+)
+class TestFilterableColumn(test.TestCase):
+    def setUp(self):
+        request = RequestFactory().get("/incidents")
+        request.user = PersonUserFactory()
+        request.htmx = False
+        self.response = incident_list(request)
+
+    def test_adds_filter_button_to_header(self):
+        self.assertContains(self.response, '_="on click toggle .hidden on next .column-filter"')
+
+    def test_doesnt_add_filter_to_filterbox(self):
+        self.assertNotContains(self.response, '<span class="label-text">Description</span>')


### PR DESCRIPTION
moved from https://github.com/Uninett/argus-htmx-frontend/pull/144

Allow specifiying when a column may be "filterable" (by specifying the `IncidentTableColumn.filter_field`). This means:
* a button will be attached to the column header 
* clicking that button will display an input element
* typing into this element (ie change event) will fire an htmx request with the specified `filter_field` as the query param to filter incidents

![image](https://github.com/user-attachments/assets/a0fae698-bbab-47e3-98e0-987c432abeaf)
![image](https://github.com/user-attachments/assets/fa83bd83-8f2e-4d1c-8dfb-96df780bcaef)

TODO:
- [x] create the ui elements and activate this element when `IncidentTableColumn.filter_field` is set
- [x] wrap the column headers in a form and send this form as htmx request on change event
  - [x] include filter-box form fields in the request
- [x] prefill input value based on current values

Limitations:
* only support simple text input for now

