### PR TITLE
Add loading indicator to form modals

### DIFF
--- a/changelog.d/+bulk-action-indicator.added.md
+++ b/changelog.d/+bulk-action-indicator.added.md
@@ -1,0 +1,1 @@
+argus.htmx: add loading indicator to bulk action buttons

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4877,11 +4877,6 @@ details.collapse summary::-webkit-details-marker {
   color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity)));
 }
 
-.text-primary-content {
-  --tw-text-opacity: 1;
-  color: var(--fallback-pc,oklch(var(--pc)/var(--tw-text-opacity)));
-}
-
 .text-warning {
   --tw-text-opacity: 1;
   color: var(--fallback-wa,oklch(var(--wa)/var(--tw-text-opacity)));

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4877,6 +4877,11 @@ details.collapse summary::-webkit-details-marker {
   color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity)));
 }
 
+.text-primary-content {
+  --tw-text-opacity: 1;
+  color: var(--fallback-pc,oklch(var(--pc)/var(--tw-text-opacity)));
+}
+
 .text-warning {
   --tw-text-opacity: 1;
   color: var(--fallback-wa,oklch(var(--wa)/var(--tw-text-opacity)));

--- a/src/argus/htmx/templates/htmx/_base_form_modal.html
+++ b/src/argus/htmx/templates/htmx/_base_form_modal.html
@@ -32,7 +32,7 @@
         </form>
       </div>
     </div>
-    <div class="htmx-indicator loading loading-spinner"></div>
+    <div class="htmx-indicator loading loading-spinner text-primary"></div>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button>close</button>

--- a/src/argus/htmx/templates/htmx/_base_form_modal.html
+++ b/src/argus/htmx/templates/htmx/_base_form_modal.html
@@ -23,7 +23,10 @@
         <div class="divider divider-end">
           <button type="submit"
                   form="{{ dialog_id }}-form"
-                  class="btn {{ button_class|default:"btn-primary" }}">{{ submit_text }}</button>
+                  class="btn {{ button_class|default:'btn-primary' }} loading-box">
+            <span>{{ submit_text }}</span>
+            <div class="htmx-indicator loading loading-spinner"></div>
+          </button>
           <button class="btn">{{ cancel_text }}</button>
         </div>
       </form>

--- a/src/argus/htmx/templates/htmx/_base_form_modal.html
+++ b/src/argus/htmx/templates/htmx/_base_form_modal.html
@@ -1,36 +1,38 @@
 <button class="btn {{ button_class|default:"btn-primary" }}"
         onclick="htmx.find('#{{ dialog_id }}').showModal()">{{ button_title }}</button>
 <dialog id="{{ dialog_id }}" class="modal">
-  <div class="modal-box card card-compact shadow-xl">
-    <div class="divider divider-start">
-      <h3 class="card-title">{{ header }}</h3>
-    </div>
-    <form id="{{ dialog_id }}-form"
-          class="card-body"
-          {% block form_control %}
-          method="post"
-          action="{{ endpoint }}"
-          {% endblock form_control %}>
-      {% csrf_token %}
-      <fieldset class="menu menu-vertical gap-4">
-        <legend class="antialiased text-base font-bold py-2">{{ explanation }}</legend>
-        {% block dialogform %}
-        {% endblock dialogform %}
-      </fieldset>
-    </form>
-    <div class="modal-action card-actions">
-      <form method="dialog" class="w-full">
-        <div class="divider divider-end">
-          <button type="submit"
-                  form="{{ dialog_id }}-form"
-                  class="btn {{ button_class|default:'btn-primary' }} loading-box">
-            <span>{{ submit_text }}</span>
-            <div class="htmx-indicator loading loading-spinner"></div>
-          </button>
-          <button class="btn">{{ cancel_text }}</button>
-        </div>
+  <div class="modal-box card card-compact shadow-xl loading-box">
+    <div class="w-full">
+      <div class="divider divider-start">
+        <h3 class="card-title">{{ header }}</h3>
+      </div>
+      <form id="{{ dialog_id }}-form"
+            class="card-body"
+            {% block form_control %}
+            method="post"
+            action="{{ endpoint }}"
+            {% endblock form_control %}>
+        {% csrf_token %}
+        <fieldset class="menu menu-vertical gap-4">
+          <legend class="antialiased text-base font-bold py-2">{{ explanation }}</legend>
+          {% block dialogform %}
+          {% endblock dialogform %}
+        </fieldset>
       </form>
+      <div class="modal-action card-actions">
+        <form method="dialog" class="w-full">
+          <div class="divider divider-end">
+            <button type="submit"
+                    form="{{ dialog_id }}-form"
+                    class="btn {{ button_class|default:'btn-primary' }}">
+              <span>{{ submit_text }}</span>
+            </button>
+            <button class="btn">{{ cancel_text }}</button>
+          </div>
+        </form>
+      </div>
     </div>
+    <div class="htmx-indicator loading loading-spinner"></div>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button>close</button>

--- a/src/argus/htmx/templates/htmx/incidents/_base_incident_update_modal.html
+++ b/src/argus/htmx/templates/htmx/incidents/_base_incident_update_modal.html
@@ -1,7 +1,7 @@
 {% extends "htmx/_base_form_modal.html" %}
 {% block form_control %}
   hx-post="{% url endpoint|default:'htmx:incidents-update' action=action %}"
-  hx-indicator="button .htmx-indicator"
+  hx-indicator="#{{ dialog_id }} .htmx-indicator"
   {% if action_type == "bulk-update" %}
     hx-include="[name='incident_ids']"
   {% else %}

--- a/src/argus/htmx/templates/htmx/incidents/_base_incident_update_modal.html
+++ b/src/argus/htmx/templates/htmx/incidents/_base_incident_update_modal.html
@@ -1,6 +1,7 @@
 {% extends "htmx/_base_form_modal.html" %}
 {% block form_control %}
   hx-post="{% url endpoint|default:'htmx:incidents-update' action=action %}"
+  hx-indicator="button .htmx-indicator"
   {% if action_type == "bulk-update" %}
     hx-include="[name='incident_ids']"
   {% else %}


### PR DESCRIPTION
Adds a loading indicator to the _base_form_modal that can be toggled using hx-indicator and adds this hx-indicator to the bulk modals

Other modals may also implement thix by setting `hx-indicator`

from https://github.com/Uninett/argus-htmx-frontend/pull/237