### PR TITLE
Drop name references for characters

### DIFF
--- a/src/argus/incident/templates/incident/admin/fake_incident_add_form.html
+++ b/src/argus/incident/templates/incident/admin/fake_incident_add_form.html
@@ -17,9 +17,9 @@
 {% block breadcrumbs %}
   <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% translate "Home" %}</a>
-    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
-    &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
-    &rsaquo; {% blocktranslate with name=opts.verbose_name %}Add fake incident{% endblocktranslate %}
+    › <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    › <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    › {% blocktranslate with name=opts.verbose_name %}Add fake incident{% endblocktranslate %}
   </div>
 {% endblock breadcrumbs %}
 {% block content %}


### PR DESCRIPTION
Dependent on https://github.com/Uninett/Argus/pull/1013.

Fixes djLint's complaints about `H023 - Do not use entity references.`