### PR TITLE
ARGUS_HTMX_FILTER_FUNCTION can take a callable or a dotted function path

### DIFF
--- a/changelog.d/1029.added.md
+++ b/changelog.d/1029.added.md
@@ -1,0 +1,1 @@
+argus.htmx: ARGUS_HTMX_FILTER_FUNCTION can take a callable or a dotted function path

--- a/docs/development/howtos/htmx-frontend/customize-filtering.rst
+++ b/docs/development/howtos/htmx-frontend/customize-filtering.rst
@@ -3,20 +3,23 @@ How to customize filtering the incidents list
 =============================================
 
 Incident list filtering is governed by the ``incident_list_filter`` function. By default, this
-function is imported from ``argus_htmx.incidents.filter``, but that module can be changed by
-overriding the ``ARGUS_HTMX_FILTER_FUNCTION`` to point to a different module. That module should
-contain a ``incident_list_filter`` function. It has the following signature::
+function is located at ``argus.htmx.incidents.filter.incident_list_filter`` but this location
+can be changed by overriding the ``ARGUS_HTMX_FILTER_FUNCTION`` to point to a different function.
+The function has the the following signature::
 
   def incident_list_filter(request: HttpRequest, qs: IncidentQuerySet) -> tuple[Form, IncidentQuerySet]:
       ...
 
-When loading the incidents list, this function is called with the request and the base incident
-queryset, and allows for updating this queryset. This way, the queryset can for example be
-filtered, reordered and/or data may be added (such as through ``annotate``).
+For backwards compatibility, it is also possible to specify a module in
+``ARGUS_HTMX_FILTER_FUNCTION`` instead of a function. Argus will then look for a function called
+``incident_list_filter`` inside that module.
+
+When loading the incidents list, the incident_list_filter function is called with the request and
+the base incident queryset, and allows for updating this queryset. This way, the queryset can for
+example be filtered, reordered and/or data may be added (such as through ``annotate``).
 
 Aside from the updated queryset, ``incident_list_filter`` returns a ``django.forms.Form``. This
 form is used to populate the incident filterbox and any filterable columns
-
 
 Filterable columns
 ------------------

--- a/docs/development/howtos/htmx-frontend/customize-filtering.rst
+++ b/docs/development/howtos/htmx-frontend/customize-filtering.rst
@@ -10,8 +10,9 @@ The function has the the following signature::
   def incident_list_filter(request: HttpRequest, qs: IncidentQuerySet) -> tuple[Form, IncidentQuerySet]:
       ...
 
-For backwards compatibility, it is also possible to specify a module in
-``ARGUS_HTMX_FILTER_FUNCTION`` instead of a function. Argus will then look for a function called
+The ``ARGUS_HTMX_FILTER_FUNCTION`` can either take a function directly or a dotted path to an
+importable function. For backwards compatibility, it is also possible to specify a dotted path
+to a module instead of a function. Argus will then look for a function called
 ``incident_list_filter`` inside that module.
 
 When loading the incidents list, the incident_list_filter function is called with the request and

--- a/src/argus/htmx/defaults.py
+++ b/src/argus/htmx/defaults.py
@@ -14,6 +14,7 @@ INCIDENT_TABLE_COLUMNS = [
     "description",
     "ticket",
 ]
+ARGUS_HTMX_FILTER_FUNCTION = "argus.htmx.incidents.filter.incident_list_filter"
 
 # These templates are auto-discovered by the templating engine and are relative
 # to the argus.htmx's `templates/` directory

--- a/src/argus/htmx/incidents/utils.py
+++ b/src/argus/htmx/incidents/utils.py
@@ -2,12 +2,12 @@ import importlib
 
 from django.conf import settings
 from django.utils.module_loading import import_string
+from argus.htmx import defaults
 
-FUNCTION_NAME = "incident_list_filter"
-DEFAULT_MODULE = "argus.htmx.incidents.filter"
+FUNCTION_NAME_DEFAULT = "incident_list_filter"
 
 
-def get_filter_function():
+def get_filter_function(arg=None):
     """Try and get the incident filter function from the ARGUS_HTMX_FILTER_FUNCTION setting.
     ARGUS_HTMX_FILTER_FUNCTION can be one of:
 
@@ -17,24 +17,25 @@ def get_filter_function():
       * a dotted path to a module. This module should then contain a function named
         ``incident_list_filter`` with the above signature
     """
-    setting = getattr(settings, "ARGUS_HTMX_FILTER_FUNCTION", DEFAULT_MODULE)
+    if arg is None:
+        arg = getattr(settings, "ARGUS_HTMX_FILTER_FUNCTION", defaults.ARGUS_HTMX_FILTER_FUNCTION)
 
-    if callable(setting):
-        return setting
+    if callable(arg):
+        return arg
 
-    if isinstance(setting, str):
+    if isinstance(arg, str):
         try:
             # try importing the dotted path as a module. This will fail if the dotted path
             # points to a function instead
-            module = importlib.import_module(setting)
+            module = importlib.import_module(arg)
         except ModuleNotFoundError:
             # import_string splits the dotted path into two sections (module, function name)
             # and tries to resolve that
-            return import_string(setting)
+            return import_string(arg)
         else:
-            function = getattr(module, FUNCTION_NAME, None)
+            function = getattr(module, FUNCTION_NAME_DEFAULT, None)
             if function:
                 return function
-            raise ImportError(f"Could not import {FUNCTION_NAME} from {setting}")
+            raise ImportError(f"Could not import {FUNCTION_NAME_DEFAULT} from {arg}")
 
     raise TypeError(f"ARGUS_HTMX_FILTER_FUNCTION must be a callable or string")

--- a/src/argus/htmx/incidents/utils.py
+++ b/src/argus/htmx/incidents/utils.py
@@ -1,19 +1,40 @@
 import importlib
 
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 FUNCTION_NAME = "incident_list_filter"
 DEFAULT_MODULE = "argus.htmx.incidents.filter"
 
 
 def get_filter_function():
+    """Try and get the incident filter function from the ARGUS_HTMX_FILTER_FUNCTION setting.
+    ARGUS_HTMX_FILTER_FUNCTION can be one of:
+
+      * a callable that takes a Request and a QuerySet argument, and returns a Form and an updated
+        QuerySet (see ``argus.htmx.incidents.filter.incident_list_filter``)
+      * a dotted path to an importable function that has the above signature
+      * a dotted path to a module. This module should then contain a function named
+        ``incident_list_filter`` with the above signature
+    """
     setting = getattr(settings, "ARGUS_HTMX_FILTER_FUNCTION", DEFAULT_MODULE)
+
     if callable(setting):
         return setting
+
     if isinstance(setting, str):
-        module = importlib.import_module(setting)
-        function = getattr(module, FUNCTION_NAME, None)
-        if function:
-            return function
-        raise ImportError(f"Could not import {FUNCTION_NAME} from {setting}")
+        try:
+            # try importing the dotted path as a module. This will fail if the dotted path
+            # points to a function instead
+            module = importlib.import_module(setting)
+        except ModuleNotFoundError:
+            # import_string splits the dotted path into two sections (module, function name)
+            # and tries to resolve that
+            return import_string(setting)
+        else:
+            function = getattr(module, FUNCTION_NAME, None)
+            if function:
+                return function
+            raise ImportError(f"Could not import {FUNCTION_NAME} from {setting}")
+
     raise TypeError(f"ARGUS_HTMX_FILTER_FUNCTION must be a callable or string")

--- a/tests/htmx/incidents/test_utils.py
+++ b/tests/htmx/incidents/test_utils.py
@@ -1,10 +1,17 @@
 from django import test
 
+from argus.auth.factories import SourceUserFactory
 from argus.htmx.incidents.filter import incident_list_filter
 from argus.htmx.incidents.utils import get_filter_function
+from argus.incident.factories import SourceSystemFactory
 
 
 class TestGetFilterFunction(test.TestCase):
+    def setUp(self) -> None:
+        # ensure we have a SourceSystem to keep django happy
+        user = SourceUserFactory()
+        SourceSystemFactory(user=user)
+
     def test_gets_incident_list_filter_by_default(self):
         self.assertIs(get_filter_function(), incident_list_filter)
 

--- a/tests/htmx/incidents/test_utils.py
+++ b/tests/htmx/incidents/test_utils.py
@@ -1,19 +1,16 @@
 from django import test
 
-from argus.auth.factories import SourceUserFactory
-from argus.htmx.incidents.filter import incident_list_filter
 from argus.htmx.incidents.utils import get_filter_function
-from argus.incident.factories import SourceSystemFactory
 
 
 class TestGetFilterFunction(test.TestCase):
     def setUp(self) -> None:
-        # ensure we have a SourceSystem to keep django happy
-        user = SourceUserFactory()
-        SourceSystemFactory(user=user)
+        from argus.htmx.incidents.filter import incident_list_filter
+
+        self.incident_list_filter = incident_list_filter
 
     def test_gets_incident_list_filter_by_default(self):
-        self.assertIs(get_filter_function(), incident_list_filter)
+        self.assertIs(get_filter_function(), self.incident_list_filter)
 
     def test_gets_callable_directly(self):
         sentinel = object
@@ -22,8 +19,11 @@ class TestGetFilterFunction(test.TestCase):
     def test_gets_incident_list_filter_from_dotted_path(self):
         self.assertIs(
             get_filter_function("argus.htmx.incidents.filter.incident_list_filter"),
-            incident_list_filter,
+            self.incident_list_filter,
         )
 
     def test_gets_incident_list_filter_from_module(self):
-        self.assertIs(get_filter_function("argus.htmx.incidents.filter"), incident_list_filter)
+        self.assertIs(
+            get_filter_function("argus.htmx.incidents.filter"),
+            self.incident_list_filter,
+        )

--- a/tests/htmx/incidents/test_utils.py
+++ b/tests/htmx/incidents/test_utils.py
@@ -1,12 +1,7 @@
-from unittest.mock import Mock
-
 from django import test
-from django.http import HttpResponseRedirect
-from django.test.client import RequestFactory
 
 from argus.htmx.incidents.filter import incident_list_filter
 from argus.htmx.incidents.utils import get_filter_function
-from argus.htmx.middleware import LoginRequiredMiddleware
 
 
 class TestGetFilterFunction(test.TestCase):

--- a/tests/htmx/incidents/test_utils.py
+++ b/tests/htmx/incidents/test_utils.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from django import test
+from django.http import HttpResponseRedirect
+from django.test.client import RequestFactory
+
+from argus.htmx.incidents.filter import incident_list_filter
+from argus.htmx.incidents.utils import get_filter_function
+from argus.htmx.middleware import LoginRequiredMiddleware
+
+
+class TestGetFilterFunction(test.TestCase):
+    def test_gets_incident_list_filter_by_default(self):
+        self.assertIs(get_filter_function(), incident_list_filter)
+
+    def test_gets_callable_directly(self):
+        sentinel = object
+        self.assertIs(get_filter_function(sentinel), sentinel)
+
+    def test_gets_incident_list_filter_from_dotted_path(self):
+        self.assertIs(
+            get_filter_function("argus.htmx.incidents.filter.incident_list_filter"),
+            incident_list_filter,
+        )
+
+    def test_gets_incident_list_filter_from_module(self):
+        self.assertIs(get_filter_function("argus.htmx.incidents.filter"), incident_list_filter)

--- a/tests/htmx/incidents/test_utils.py
+++ b/tests/htmx/incidents/test_utils.py
@@ -5,6 +5,9 @@ from argus.htmx.incidents.utils import get_filter_function
 
 class TestGetFilterFunction(test.TestCase):
     def setUp(self) -> None:
+        # importing incident_list_filter requires a fully migrated database. During tests,
+        # especially in CI, this cannot be guaranteed if we import incident_list_filter at the
+        # top of this file. So we postpone importing until the tests are run.
         from argus.htmx.incidents.filter import incident_list_filter
 
         self.incident_list_filter = incident_list_filter


### PR DESCRIPTION
support for supplying one of:

* callable
* dotted path to an importable function
* dotted path module that contains a ``incident_list_filter`` callable (for backwards compatibility