### PR TITLE
Remove unused factory import from test

### DIFF
--- a/tests/auth/test_spa_views.py
+++ b/tests/auth/test_spa_views.py
@@ -3,7 +3,7 @@ from django.test import override_settings, tag
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from argus.auth.factories import AdminUserFactory, BaseUserFactory
+from argus.auth.factories import BaseUserFactory
 from argus.util.testing import disconnect_signals, connect_signals
 
 


### PR DESCRIPTION
This was added in d2e267a, right before #975 was merged, so this change should've been included there, but it was forgotten. 
