### PR TITLE
Fix HTMX destination forms not allowing same label across different medias

### DIFF
--- a/changelog.d/1075.fixed.md
+++ b/changelog.d/1075.fixed.md
@@ -1,0 +1,1 @@
+Fix bug that made it so the HTMX destinations forms did not allow DestinationConfigs with different medias to have the same label.

--- a/src/argus/htmx/destination/forms.py
+++ b/src/argus/htmx/destination/forms.py
@@ -67,7 +67,7 @@ class DestinationFormCreate(ModelForm):
                 self.cleaned_data["settings"] = settings
 
         if label := self.cleaned_data.get("label"):
-            destination_filter = DestinationConfig.objects.filter(label=label)
+            destination_filter = DestinationConfig.objects.filter(label=label, media=media)
             if self.instance:
                 destination_filter = destination_filter.exclude(pk=self.instance.pk)
             if destination_filter.exists():


### PR DESCRIPTION
Fixes #1075 