### PR TITLE
Add vertical gap between elements in HTMX destinations page

### DIFF
--- a/changelog.d/1080.added.md
+++ b/changelog.d/1080.added.md
@@ -1,0 +1,1 @@
+Add vertical gap between collapse element and create form on HTMX destinations page.

--- a/src/argus/htmx/templates/htmx/destination/_content.html
+++ b/src/argus/htmx/templates/htmx/destination/_content.html
@@ -1,4 +1,4 @@
-<div id="destination-content" class="flex flex-col items-center">
+<div id="destination-content" class="flex flex-col items-center gap-4">
   {% include "htmx/destination/_create_form.html" %}
   {% for error in errors %}<p class="text-error">{{ error }}</p>{% endfor %}
   {% include "htmx/destination/_form_list.html" %}

--- a/src/argus/htmx/templates/htmx/destination/_form_list.html
+++ b/src/argus/htmx/templates/htmx/destination/_form_list.html
@@ -1,4 +1,4 @@
-<div id="form-list" class="max-w-4xl w-full">
+<div id="form-list" class="flex flex-col max-w-4xl w-full gap-4">
   {% for media, forms in grouped_forms.items %}
     <details class="collapse bg-base-200 collapse-arrow" open="">
       <summary class="collapse-title text-xl font-medium">{{ media.name }} ({{ forms|length }})</summary>


### PR DESCRIPTION
Fixes #1080 

Relies on #1078. #1078 is in my own fork, so I cant base this PR on that, so most of the commits in the commit log of this PR belongs to #1078