### PR TITLE
Reduce number of queries to preferences db table 

### DIFF
--- a/changelog.d/1082.changed.md
+++ b/changelog.d/1082.changed.md
@@ -1,0 +1,1 @@
+argus.htmx: reduce number of queries to preferences db table

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Dict, List, Optional, Type, Union, Protocol
+from typing import Any, List, Optional, Type, Union, Protocol
 
 from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
@@ -201,7 +201,7 @@ class Preferences(models.Model):
             models.UniqueConstraint(name="unique_preference", fields=["user", "namespace"]),
         ]
 
-    NAMESPACES: Dict[str, Type[Preferences]] = {}
+    NAMESPACES: dict[str, Type[Preferences]] = {}
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="preferences")
     namespace = models.CharField(blank=False, max_length=255)

--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -94,18 +94,14 @@ class User(AbstractUser):
         # user is not considered in use
         return False
 
-    def get_or_create_preferences(self) -> List[Preferences]:
-        return Preferences.ensure_for_user(self)
-
     def get_preferences_context(self):
-        pref_sets = self.get_or_create_preferences()
+        pref_sets = Preferences.ensure_for_user(self)
         prefdict = {}
         for pref_set in pref_sets:
             prefdict[pref_set.namespace] = pref_set.get_context()
         return prefdict
 
     def get_namespaced_preferences(self, namespace):
-        print("here", namespace)
         obj, _ = Preferences.objects.get_or_create(user=self, namespace=namespace)
         if not obj.preferences and (defaults := obj.get_defaults()):
             obj.preferences = defaults

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -61,8 +61,8 @@ def get_preference(request, namespace, preference):
 def get_or_update_preference(request, data, namespace, preference) -> Tuple[Any, bool]:
     """Save the single preference given in data to the given namespace
 
-    Returns a tuple (value, success) with value the value of the preference and succces a boolean
-    indicating wether the preference was succesfully updated
+    Returns a tuple (value, success). Value is the value of the preference, and success a boolean
+    indicating whether the preference was successfully updated
     """
     prefs = get_preference_obj(request, namespace)
     value = prefs.get_preference(preference)

--- a/src/argus/htmx/dateformat/views.py
+++ b/src/argus/htmx/dateformat/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django.http import HttpResponse
 from django_htmx.http import HttpResponseClientRefresh
 
-from argus.auth.utils import save_preference
+from argus.auth.utils import get_or_update_preference
 
 from argus.htmx.incidents.views import HtmxHttpRequest
 from .constants import DATETIME_FORMATS
@@ -22,5 +22,5 @@ def dateformat_names(request: HtmxHttpRequest) -> HttpResponse:
 
 @require_POST
 def change_dateformat(request: HtmxHttpRequest) -> HttpResponse:
-    save_preference(request, request.POST, "argus_htmx", "datetime_format_name")
+    get_or_update_preference(request, request.POST, "argus_htmx", "datetime_format_name")
     return HttpResponseClientRefresh()

--- a/src/argus/htmx/incidents/views.py
+++ b/src/argus/htmx/incidents/views.py
@@ -13,7 +13,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django_htmx.middleware import HtmxDetails
 from django_htmx.http import HttpResponseClientRefresh
 
-from argus.auth.utils import get_preference, save_preference
+from argus.auth.utils import get_or_update_preference
 from argus.incident.models import Incident
 from argus.util.datetime_utils import make_aware
 
@@ -117,10 +117,8 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
 
     # Standard Django pagination
 
-    page_size = get_preference(request, "argus_htmx", "page_size")
-    success = save_preference(request, request.GET, "argus_htmx", "page_size")
-    if success:
-        page_size = get_preference(request, "argus_htmx", "page_size")
+    page_size, _ = get_or_update_preference(request, request.GET, "argus_htmx", "page_size")
+
     paginator = Paginator(object_list=qs, per_page=page_size)
     page_num = params.pop("page", "1")
     page = paginator.get_page(page_num)

--- a/src/argus/htmx/themes/views.py
+++ b/src/argus/htmx/themes/views.py
@@ -23,7 +23,7 @@ def theme_names(request: HtmxHttpRequest) -> HttpResponse:
 
 @require_POST
 def change_theme(request: HtmxHttpRequest) -> HttpResponse:
-    success = get_or_update_preference(request, request.POST, "argus_htmx", "theme")
+    _, success = get_or_update_preference(request, request.POST, "argus_htmx", "theme")
     if success:
         return render(request, "htmx/themes/_current_theme.html")
     return HttpResponseClientRefresh()

--- a/src/argus/htmx/themes/views.py
+++ b/src/argus/htmx/themes/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django.http import HttpResponse
 from django_htmx.http import HttpResponseClientRefresh
 
-from argus.auth.utils import save_preference
+from argus.auth.utils import get_or_update_preference
 
 from argus.htmx.constants import THEME_NAMES
 from argus.htmx.incidents.views import HtmxHttpRequest
@@ -23,7 +23,7 @@ def theme_names(request: HtmxHttpRequest) -> HttpResponse:
 
 @require_POST
 def change_theme(request: HtmxHttpRequest) -> HttpResponse:
-    success = save_preference(request, request.POST, "argus_htmx", "theme")
+    success = get_or_update_preference(request, request.POST, "argus_htmx", "theme")
     if success:
         return render(request, "htmx/themes/_current_theme.html")
     return HttpResponseClientRefresh()

--- a/src/argus/htmx/user/views.py
+++ b/src/argus/htmx/user/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render
 from django.views.decorators.http import require_GET, require_POST
 from django_htmx.http import HttpResponseClientRefresh
 
-from argus.auth.utils import save_preference
+from argus.auth.utils import get_or_update_preference
 
 from argus.htmx.constants import ALLOWED_PAGE_SIZES
 from argus.htmx.incidents.views import HtmxHttpRequest
@@ -17,7 +17,7 @@ def page_size_names(request: HtmxHttpRequest) -> HttpResponse:
 
 @require_POST
 def change_page_size(request: HtmxHttpRequest) -> HttpResponse:
-    save_preference(request, request.POST, "argus_htmx", "page_size")
+    get_or_update_preference(request, request.POST, "argus_htmx", "page_size")
     return HttpResponseClientRefresh()
 
 

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -70,9 +70,7 @@ class UserIsUsedTests(TestCase):
 
 
 class UserMiscMethodTests(TestCase):
-    def test_get_preferences_context_returns_dict_of_all_properly_registered_preferences(
-        self,
-    ):
+    def test_get_preferences_context_returns_dict_of_all_properly_registered_preferences(self):
         user = PersonUserFactory()
 
         results = user.get_preferences_context()

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -244,16 +244,6 @@ class PreferencesManagerTests(TestCase):
         result = Preferences.objects.get_by_natural_key(user, MyPreferences._namespace)
         self.assertEqual(prefs, result)
 
-    def test_get_or_create_preferences_creates_all_namespaces_for_user(self):
-        user1 = PersonUserFactory()
-
-        # no preferences yet
-        self.assertFalse(Preferences.objects.filter(user=user1).exists())
-
-        user1.get_or_create_preferences()
-        # three each (two from tests, one from app)
-        self.assertEqual(Preferences.objects.filter(user=user1).count(), 3)
-
     def test_get_all_defaults_returns_all_prefs_defaults(self):
         defaults = Preferences.objects.get_all_defaults()
         self.assertIsInstance(defaults, dict)

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -70,7 +70,9 @@ class UserIsUsedTests(TestCase):
 
 
 class UserMiscMethodTests(TestCase):
-    def test_get_preferences_context_returns_dict_of_all_properly_registered_preferences(self):
+    def test_get_preferences_context_returns_dict_of_all_properly_registered_preferences(
+        self,
+    ):
         user = PersonUserFactory()
 
         results = user.get_preferences_context()
@@ -137,6 +139,12 @@ class PreferencesTests(TestCase):
         self.assertEqual(instances.count(), 1)
         instance = instances[0]
         self.assertIsInstance(instance, MyPreferences)
+
+    def test_get_namespaced_preferences_creates_preferences_with_defaults(self):
+        user = PersonUserFactory()
+        pref_set = user.get_namespaced_preferences(namespace=MyPreferences._namespace)
+        self.assertIsInstance(pref_set, MyPreferences)
+        self.assertEqual(pref_set.preferences, {"magic_number": 42})
 
     def test_vanilla_get_context_dumps_preferences_field_including_defaults(self):
         user = PersonUserFactory()
@@ -236,18 +244,15 @@ class PreferencesManagerTests(TestCase):
         result = Preferences.objects.get_by_natural_key(user, MyPreferences._namespace)
         self.assertEqual(prefs, result)
 
-    def test_create_missing_preferences_creates_all_namespaces_for_all_users(self):
+    def test_get_or_create_preferences_creates_all_namespaces_for_user(self):
         user1 = PersonUserFactory()
-        user2 = PersonUserFactory()
 
         # no preferences yet
         self.assertFalse(Preferences.objects.filter(user=user1).exists())
-        self.assertFalse(Preferences.objects.filter(user=user2).exists())
 
-        Preferences.objects.create_missing_preferences()
+        user1.get_or_create_preferences()
         # three each (two from tests, one from app)
         self.assertEqual(Preferences.objects.filter(user=user1).count(), 3)
-        self.assertEqual(Preferences.objects.filter(user=user2).count(), 3)
 
     def test_get_all_defaults_returns_all_prefs_defaults(self):
         defaults = Preferences.objects.get_all_defaults()


### PR DESCRIPTION
Prior to #1023 and this PR, a single request to `incidents/` lead to 21 (!) queries to the `argus_auth_preferences` table 😄. This PR reduces this number by 7 (#1023 takes care of another 12) so that in the end we have only have 2 queries left

- one for looking up the `page_size` preference
- one for looking up all preferences in the context processor

We could try and limit that further, but I don't think that that's worth the effort. One thing I'm thinking of, is a middleware that grabs all preferences and adds them to the Request, so that views, utils, context processors and others can just read them from there.


Other views also benefit from these PRs, but I don't have numbers for them

