### PR TITLE
Make ruff more verbose

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,6 @@ repos:
         # Run the linter
     -   id: ruff
         name: "Ruff linting"
-        args: [
-          '--output-format=full',
-          '--statistics'
-        ]
         # Run the formatter
     -   id: ruff-format
         name: "Ruff formatting"


### PR DESCRIPTION
Turns out, the `--statistics`-flag no longer exists, it just fails, and `--output-format=full` is the default.