### PR TITLE
Use default rules for ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ extend-exclude = [
 output-format = "full"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F4", "F5", "F6", "F7", "F8", "F9"]
+select = ["E4", "E7", "E9", "F"]
 ignore = ["F403", "F405"]
 
 [tool.towncrier]


### PR DESCRIPTION
After #1012 we have now arrived at using the default rules for ruff (except for ignoring `F403` and `F405`). So we can clean up this part of the configuration. 