### PR TITLE
Skip towncrier check on 'nonews' label

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -1,10 +1,14 @@
 name: Check for changelog file
 
-on: [pull_request]
+on: 
+  pull_request: 
+      # labeled/unlabeled = label is added/removed
+      # synchronize = PR's head branch was updated
+      types: [labeled, unlabeled, opened, reopened, synchronize]
 
 jobs:
   towncrier:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'nonews') }}
     runs-on: ubuntu-latest
     name: Towncrier check
     steps:


### PR DESCRIPTION
This also changes that the check runs when a label is added/removed and on the default actions: when a PR is opened/reopened or the PR's head branch is updated.

It's fitting - this PR will also be right away used as test
