### PR TITLE
Upgrade ruff version in pre-commit to 0.8.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         exclude: &exclude_pattern '^changelog.d/'
     -   id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.8.6
     hooks:
         # Run the linter
     -   id: ruff


### PR DESCRIPTION
0.8.6 is the newest release of ruff: https://github.com/astral-sh/ruff/releases/tag/0.8.6