### PR TITLE
Filter incident by tags using simple input field

### DIFF
--- a/changelog.d/1044.added.md
+++ b/changelog.d/1044.added.md
@@ -1,0 +1,1 @@
+Add text field to filter incident list by tags

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -125,6 +125,9 @@ def incident_list_filter(request, qs):
     if filter_pk:
         filter_obj = Filter.objects.get(pk=filter_pk)
     if filter_obj:
+        filterblob = filter_obj.filter
+        if "tags" in filterblob.keys():
+            filterblob["tags"] = ", ".join(filterblob["tags"])
         form = IncidentFilterForm(filter_obj.filter)
     else:
         if request.method == "POST":

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -46,6 +46,16 @@ class IncidentFilterForm(forms.Form):
         required=False,
         label="Sources",
     )
+    tags = forms.CharField(
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "enter tags...",
+                "class": "show-selected-box input input-accent input-bordered input-md border overflow-y-auto min-h-8 h-auto max-h-16 max-w-xs leading-tight",
+            }
+        ),
+        required=False,
+        label="Tags",
+    )
     maxlevel = forms.IntegerField(
         widget=forms.NumberInput(
             attrs={"type": "range", "step": "1", "min": min(Level).value, "max": max(Level).value}
@@ -88,6 +98,10 @@ class IncidentFilterForm(forms.Form):
         sourceSystemIds = self.cleaned_data.get("sourceSystemIds", [])
         if sourceSystemIds:
             filterblob["sourceSystemIds"] = sourceSystemIds
+
+        tags = self.cleaned_data.get("tags", [])
+        if tags:
+            filterblob["tags"] = tags.split(", ")
 
         maxlevel = self.cleaned_data.get("maxlevel", 0)
         if maxlevel:

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -101,7 +101,7 @@ class IncidentFilterForm(forms.Form):
 
         tags = self.cleaned_data.get("tags", [])
         if tags:
-            filterblob["tags"] = tags.split(", ")
+            filterblob["tags"] = [tag.strip() for tag in tags.split(",")]
 
         maxlevel = self.cleaned_data.get("maxlevel", 0)
         if maxlevel:

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -55,6 +55,7 @@ class IncidentFilterForm(forms.Form):
         ),
         required=False,
         label="Tags",
+        help_text='Press "Enter" after each completed tag',
     )
     maxlevel = forms.IntegerField(
         widget=forms.NumberInput(

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -49,7 +49,7 @@ class IncidentFilterForm(forms.Form):
     tags = forms.CharField(
         widget=forms.TextInput(
             attrs={
-                "placeholder": "enter tags...",
+                "placeholder": "key=value, ...",
                 "class": "show-selected-box input input-accent input-bordered input-md border overflow-y-auto min-h-8 h-auto max-h-16 max-w-xs leading-tight",
             }
         ),

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -50,7 +50,7 @@ class IncidentFilterForm(forms.Form):
         widget=forms.TextInput(
             attrs={
                 "placeholder": "key=value, ...",
-                "class": "show-selected-box input input-accent input-bordered input-md border overflow-y-auto min-h-8 h-auto max-h-16 max-w-xs leading-tight",
+                "class": "input input-accent input-bordered input-md border overflow-y-auto min-h-8 h-auto max-h-16 max-w-xs leading-tight",
             }
         ),
         required=False,
@@ -75,8 +75,8 @@ class IncidentFilterForm(forms.Form):
         tags = self.cleaned_data["tags"]
         if tags:
             try:
-                tags = tags.split(", ")
-                [Tag.split(tag) for tag in tags]
+                tags_list = [tag.strip() for tag in tags.split(",")]
+                [Tag.split(tag) for tag in tags_list]
             except ValueError:
                 raise forms.ValidationError("Tags need to have the format key=value, key2=value2")
 

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib import messages
 from django.urls import reverse
 from django.views.generic import ListView
 
@@ -77,11 +78,18 @@ class IncidentFilterForm(forms.Form):
         if tags:
             try:
                 tags_list = [tag.strip() for tag in tags.split(",")]
-                [Tag.split(tag) for tag in tags_list]
+                tags_qss = Tag.objects.parse(*tags_list)
             except ValueError:
                 raise forms.ValidationError("Tags need to have the format key=value, key2=value2")
 
-        return tags
+        existing_tags = []
+        for tags_qs in tags_qss:
+            existing_tags.extend([str(tag) for tag in tags_qs])
+        if len(existing_tags) < len(tags_list):
+            # TODO add message here that invalid tags were cleaned
+            None
+
+        return ", ".join(existing_tags)
 
     def _tristate(self, onkey, offkey):
         on = self.cleaned_data.get(onkey, None)

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from django.views.generic import ListView
 
 from argus.filter import get_filter_backend
-from argus.incident.models import SourceSystem
+from argus.incident.models import SourceSystem, Tag
 from argus.incident.constants import Level
 from argus.htmx.widgets import BadgeDropdownMultiSelect
 from argus.notificationprofile.models import Filter
@@ -70,6 +70,17 @@ class IncidentFilterForm(forms.Form):
         # mollify tests
         self.fields["sourceSystemIds"].widget.partial_get = reverse("htmx:incident-filter")
         self.fields["sourceSystemIds"].choices = tuple(SourceSystem.objects.values_list("id", "name"))
+
+    def clean_tags(self):
+        tags = self.cleaned_data["tags"]
+        if tags:
+            try:
+                tags = tags.split(", ")
+                [Tag.split(tag) for tag in tags]
+            except ValueError:
+                raise forms.ValidationError("Tags need to have the format key=value, key2=value2")
+
+        return tags
 
     def _tristate(self, onkey, offkey):
         on = self.cleaned_data.get(onkey, None)

--- a/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
@@ -15,7 +15,7 @@
       {% for field in filter_form %}
         {% if not field.field.in_header %}
           <li class="form-control">
-            {% if field.name == "sourceSystemIds" %}
+            {% if field.name == "sourceSystemIds" or field.name == "tags" %}
               <div class="flex flex-nowrap">
                 <label class="label">
                   <span class="label-text">{{ field.label }}</span>


### PR DESCRIPTION
Closes #1044. 

This is the simplest implementation without any error handling, since I am working on implementing active search for tags. 
The tags need to be entered in the format `a=b, c=d`.