### PR TITLE
Only update affected media list when updating destination in HTMX frontend

### DIFF
--- a/changelog.d/1136.changed.md
+++ b/changelog.d/1136.changed.md
@@ -1,0 +1,1 @@
+Update only the related media list when updating a destination.

--- a/src/argus/htmx/templates/htmx/destination/_edit_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_edit_form.html
@@ -1,6 +1,7 @@
 <form hx-post="{% url 'htmx:htmx-update' form.instance.id %}"
       hx-trigger="submit"
-      hx-target="#form-list"
+      hx-target="closest details"
+      hx-swap="outerHTML"
       class="flex flex-nowrap items-center gap-4">
   {% csrf_token %}
   <fieldset class="flex flex-nowrap items-center gap-4">


### PR DESCRIPTION
Fixes #1136 

Makes it so only the related list for the destination you try to delete is updated with HTMX.