### PR TITLE
Add page title to destinations, timeslots and profiles pages

### DIFF
--- a/src/argus/htmx/auth/views.py
+++ b/src/argus/htmx/auth/views.py
@@ -50,4 +50,5 @@ class LoginView(DjangoLoginView):
         context = super().get_context_data(**kwargs)
         backends = get_htmx_authentication_backend_name_and_type()
         context["backends"] = backends
+        context["page_title"] = "Log in"
         return context

--- a/src/argus/htmx/destination/views.py
+++ b/src/argus/htmx/destination/views.py
@@ -86,6 +86,7 @@ def _render_destination_list(
         "create_form": create_form,
         "grouped_forms": grouped_forms,
         "errors": errors,
+        "page_title": "Destinations",
     }
     return render(request, template, context=context)
 

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -54,6 +54,11 @@ class NotificationProfileMixin:
     def get_success_url(self):
         return reverse("htmx:notificationprofile-list")
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Profiles"
+        return context
+
 
 class ChangeMixin:
     "Common functionality for create and update views"

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -42,6 +42,11 @@ class TimeslotMixin:
     def get_success_url(self):
         return reverse("htmx:timeslot-list")
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Timeslots"
+        return context
+
 
 class FormsetMixin:
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Screenshots:
Before:
![Screenshot from 2025-01-14 13-42-47](https://github.com/user-attachments/assets/14e68fde-2cff-4665-962e-40909ef35234)
After:
![Screenshot from 2025-01-14 13-42-36](https://github.com/user-attachments/assets/8fe7d433-5239-4827-a98a-d7b249f6f5ec)

This applies to the pages
http://localhost:8000/destinations/

http://localhost:8000/timeslots/
http://localhost:8000/timeslots/create/
http://localhost:8000/timeslots/<id\>/
http://localhost:8000/timeslots/<id\>/update/
http://localhost:8000/timeslots/<id\>/delete/

http://localhost:8000/notificationprofiles/
http://localhost:8000/notificationprofiles/create/