### PR TITLE
Polish timeslots page: easy pickings

### DIFF
--- a/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
+++ b/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
@@ -1,0 +1,21 @@
+<section class="card-body">
+  <form method="post"
+        action="{% if form.instance.pk %}{% url "htmx:timeslot-update" pk=form.instance.pk %}{% else %}{% url "htmx:timeslot-create" %}{% endif %}">
+    {% csrf_token %}
+    <div class="flex flex-col gap-4">
+      {{ form.as_div }}
+      <div class="flex flex-col gap-4">{{ formset.as_div }}</div>
+      <div class="card-actions justify-end">
+        {% if form.instance.pk %}
+          <input type="submit" class="btn btn-primary" value="Save">
+          <button class="contents">
+            <a class="btn btn-primary"
+               href="{% url "htmx:timeslot-delete" pk=form.instance.pk %}">Delete</a>
+          </button>
+        {% else %}
+          <input type="submit" class="btn btn-primary" value="Create">
+        {% endif %}
+      </div>
+    </div>
+  </form>
+</section>

--- a/src/argus/htmx/templates/htmx/timeslot/base.html
+++ b/src/argus/htmx/templates/htmx/timeslot/base.html
@@ -1,0 +1,8 @@
+{% extends "htmx/base.html" %}
+{% block main %}
+  <h2 class="text-center text-xl font-semibold">Timeslots</h2>
+  <div class="flex justify-center">
+    {% block timeslot_main %}
+    {% endblock timeslot_main %}
+  </div>
+{% endblock main %}

--- a/src/argus/htmx/templates/htmx/timeslot/timeslot_detail.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timeslot_detail.html
@@ -1,6 +1,0 @@
-{% extends "htmx/base.html" %}
-{% block main %}
-  {% with show_buttons=True %}
-    {% include "./_timeslot_detail.html" %}
-  {% endwith %}
-{% endblock main %}

--- a/src/argus/htmx/templates/htmx/timeslot/timeslot_form.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timeslot_form.html
@@ -1,9 +1,6 @@
-{% extends "htmx/base.html" %}
-{% block main %}
-  <form method="post">
-    {% csrf_token %}
-    {{ form.as_div }}
-    {{ formset.as_div }}
-    <input class="btn btn-primary" type="submit" value="Save">
-  </form>
-{% endblock main %}
+{% extends "./base.html" %}
+{% block timeslot_main %}
+  <section class="card my-4 bg-base-100 shadow-2xl">
+    {% include "./_timeslot_form.html" %}
+  </section>
+{% endblock timeslot_main %}

--- a/src/argus/htmx/templates/htmx/timeslot/timeslot_list.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timeslot_list.html
@@ -1,23 +1,13 @@
-{% extends "htmx/base.html" %}
-{% block main %}
-  <p>
-    <a class="btn btn-primary" href="{% url "htmx:timeslot-create" %}">Create</a>
-  </p>
-  {% for object in object_list %}
-    <div>
-      {% include "./_timeslot_detail.html" %}
-      <p>
-        <a class="btn btn-primary"
-           href="{% url "htmx:timeslot-detail" pk=object.pk %}">View</a>
-      </p>
-      <p>
-        <a class="btn btn-primary"
-           href="{% url "htmx:timeslot-update" pk=object.pk %}">Update</a>
-      </p>
-      <p>
-        <a class="btn btn-primary"
-           href="{% url "htmx:timeslot-delete" pk=object.pk %}">Delete</a>
-      </p>
-    </div>
-  {% endfor %}
-{% endblock main %}
+{% extends "./base.html" %}
+{% block timeslot_main %}
+  <div>
+    <button>
+      <a class="btn btn-primary" href="{% url "htmx:timeslot-create" %}">Create</a>
+    </button>
+    {% for entry in form_list %}
+      <div class="card my-4 bg-base-100 shadow-2xl">
+        {% include "./_timeslot_form.html" with form=entry.form formset=entry.formset %}
+      </div>
+    {% endfor %}
+  </div>
+{% endblock timeslot_main %}


### PR DESCRIPTION
Improve the timeslots page a bit.

Missing:

* delete one of several time recurrences
* pretty fields, especially settle on pretty *time* fields. two methods are shown.
* good space between timeslot name and the time recurrences
* space between various sets of time recurrences
* nice UI that hides the time recurrence implementation
* modal for create
* modal for delete
* low priority - button to add more time recurrences