### PR TITLE
Turn on overriding of django widget templates

### DIFF
--- a/src/argus/htmx/appconfig.py
+++ b/src/argus/htmx/appconfig.py
@@ -42,6 +42,10 @@ _app_settings = [
             "argus.htmx.middleware.HtmxMessageMiddleware": "end",
         },
     },
+    {
+        "app_name": "django.forms",
+        "settings": {"FORM_RENDERER": "django.forms.renderers.TemplatesSetting"},
+    },
 ]
 
 APP_SETTINGS = ListAppSetting(_app_settings).root

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -2104,12 +2104,6 @@ input.tab:checked + .tab-content,
   color: var(--fallback-a,oklch(var(--a)/var(--tw-text-opacity)));
 }
 
-.btm-nav > *:where(.active) {
-  border-top-width: 2px;
-  --tw-bg-opacity: 1;
-  background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity)));
-}
-
 .btm-nav > * .label {
   font-size: 1rem;
   line-height: 1.5rem;
@@ -3332,13 +3326,6 @@ details.collapse summary::-webkit-details-marker {
   background-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-bg-opacity)));
 }
 
-.table-zebra tr.active,
-    .table-zebra tr.active:nth-child(even),
-    .table-zebra-zebra tbody tr:nth-child(even) {
-  --tw-bg-opacity: 1;
-  background-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-bg-opacity)));
-}
-
 .table :where(thead tr, tbody tr:not(:last-child), tbody tr:first-child:last-child) {
   border-bottom-width: 1px;
   --tw-border-opacity: 1;
@@ -3467,22 +3454,6 @@ details.collapse summary::-webkit-details-marker {
         0 0 0 2px rgb(0 0 0 / 5%);
     text-shadow: 0 1px rgb(0 0 0 / var(--glass-text-shadow-opacity, 5%));
   }
-}
-
-.btm-nav-xs > *:where(.active) {
-  border-top-width: 1px;
-}
-
-.btm-nav-sm > *:where(.active) {
-  border-top-width: 2px;
-}
-
-.btm-nav-md > *:where(.active) {
-  border-top-width: 2px;
-}
-
-.btm-nav-lg > *:where(.active) {
-  border-top-width: 4px;
 }
 
 .btn-xs {
@@ -4195,6 +4166,10 @@ details.collapse summary::-webkit-details-marker {
 
 .table {
   display: table;
+}
+
+.contents {
+  display: contents;
 }
 
 .hidden {

--- a/src/argus/htmx/templates/django/forms/div.html
+++ b/src/argus/htmx/templates/django/forms/div.html
@@ -1,0 +1,28 @@
+{% if errors and not fields %}
+  <div>
+    {% for field in hidden_fields %}{{ field }}{% endfor %}
+  </div>
+{% endif %}
+{% for field, errors in fields %}
+  <div {% with classes=field.css_classes %}
+       {% if classes %}class="{{ classes }}"{% endif %}
+       {% endwith %}>
+    {% if field.use_fieldset %}
+      <fieldset>
+        {% if field.label %}{{ field.legend_tag }}{% endif %}
+      {% else %}
+        {% if field.label %}{{ field.label_tag }}{% endif %}
+      {% endif %}
+      {% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
+      <div>{{ field }}</div>
+      <div>{{ errors }}</div>
+      {% if field.use_fieldset %}</fieldset>{% endif %}
+    {% if forloop.last %}
+      {% for field in hidden_fields %}{{ field }}{% endfor %}
+    {% endif %}
+  </div>
+{% endfor %}
+{{ errors }}
+{% if not fields and not errors %}
+  {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}


### PR DESCRIPTION
.. with the default template used for form.as_div as an example. Test by looking at the profiles page with and without this included!

This adds the directory "django/forms" to "src/argus/htmx/templates". By copying forms from "django/forms/templates/django/forms" in the django source code and then altering them we can override default field looks! If we for instance always want a select box to have the classes "select selected-bordered" we can do that directly in the templates.