### PR TITLE
Convert uncaught exceptions to messages.error

### DIFF
--- a/changelog.d/+convert-exceptions-to-messages.changed.md
+++ b/changelog.d/+convert-exceptions-to-messages.changed.md
@@ -1,0 +1,1 @@
+Htmx: Otherwise uncaught exceptions are caught, logged and converted to messages.error.

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -68,9 +68,9 @@ class HtmxMessageMiddleware(MiddlewareMixin):
 
     def process_exception(self, request, exception):
         error_msg = "500 Internal Server Error"
-        if str(exception):
-            error_msg += f": {exception}"
         messages.error(request, error_msg)
+        if str(exception):
+            error_msg += f"{error_msg}: {exception}"
         LOG.error(error_msg)
         return None
 
@@ -102,8 +102,8 @@ class HtmxMessageMiddleware(MiddlewareMixin):
                     error_msg = error_msg.decode("utf-8")
                 if not error_msg:
                     error_msg = f"{response.status_code} {response.reason_phrase}"
-                messages.error(request, f"An unexpected error occured: {error_msg}. Please try again")
                 LOG.error("Unhandled exception: %s", error_msg)
+                messages.error(request, "An unexpected error occured. Please try again")
             # HTMX doesn't swap content for response codes >=400. However, we do want to show
             # the new messages, so we need to rewrite the response to 200, and make sure it only
             # swaps the oob notification content

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.http import HttpResponse
@@ -6,7 +8,10 @@ from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_str
 from django_htmx.http import HttpResponseClientRedirect
 from django.contrib import messages
+
 from .request import HtmxHttpRequest
+
+LOG = logging.getLogger(__name__)
 
 
 class LoginRequiredMiddleware:
@@ -61,6 +66,12 @@ class HtmxMessageMiddleware(MiddlewareMixin):
 
     TEMPLATE = "messages/_notification_messages_htmx_append.html"
 
+    def process_exception(self, request, exception):
+        error_msg = f"500 Internal Server Error: {exception}"
+        messages.error(request, error_msg)
+        LOG.error(error_msg)
+        return None
+
     def process_response(self, request: HtmxHttpRequest, response: HttpResponse) -> HttpResponse:
         if not request.htmx:
             return response
@@ -84,7 +95,11 @@ class HtmxMessageMiddleware(MiddlewareMixin):
             has_error_message = any("error" in message.tags for message in storage)
             storage.used = False
             if not has_error_message:
-                messages.error(request, "An error occured while processing your request, please try again")
+                error_msg = f"{response.status_code} {response.reason_phrase}"
+                messages.error(
+                    request, f"An error occured while processing your request, please try again: {error_msg}"
+                )
+                LOG.error("Unhandled exception: %s", error_msg)
             # HTMX doesn't swap content for response codes >=400. However, we do want to show
             # the new messages, so we need to rewrite the response to 200, and make sure it only
             # swaps the oob notification content

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -97,7 +97,9 @@ class HtmxMessageMiddleware(MiddlewareMixin):
             has_error_message = any("error" in message.tags for message in storage)
             storage.used = False
             if not has_error_message:
-                error_msg = f"{response.status_code} {response.reason_phrase}"
+                error_msg = str(getattr(response, "content", b""))
+                if not error_msg:
+                    error_msg = f"{response.status_code} {response.reason_phrase}"
                 messages.error(
                     request, f"An error occured while processing your request, please try again: {error_msg}"
                 )

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -71,7 +71,7 @@ class HtmxMessageMiddleware(MiddlewareMixin):
         messages.error(request, error_msg)
         if str(exception):
             error_msg += f"{error_msg}: {exception}"
-        LOG.error(error_msg)
+        LOG.exception(error_msg)
         return None
 
     def process_response(self, request: HtmxHttpRequest, response: HttpResponse) -> HttpResponse:

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -67,7 +67,9 @@ class HtmxMessageMiddleware(MiddlewareMixin):
     TEMPLATE = "messages/_notification_messages_htmx_append.html"
 
     def process_exception(self, request, exception):
-        error_msg = f"500 Internal Server Error: {exception}"
+        error_msg = "500 Internal Server Error"
+        if str(exception):
+            error_msg += f": {exception}"
         messages.error(request, error_msg)
         LOG.error(error_msg)
         return None

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -97,12 +97,12 @@ class HtmxMessageMiddleware(MiddlewareMixin):
             has_error_message = any("error" in message.tags for message in storage)
             storage.used = False
             if not has_error_message:
-                error_msg = str(getattr(response, "content", b""))
+                error_msg = getattr(response, "content", b"")
+                if isinstance(error_msg, bytes):
+                    error_msg = error_msg.decode("utf-8")
                 if not error_msg:
                     error_msg = f"{response.status_code} {response.reason_phrase}"
-                messages.error(
-                    request, f"An error occured while processing your request, please try again: {error_msg}"
-                )
+                messages.error(request, f"An unexpected error occured: {error_msg}. Please try again")
                 LOG.error("Unhandled exception: %s", error_msg)
             # HTMX doesn't swap content for response codes >=400. However, we do want to show
             # the new messages, so we need to rewrite the response to 200, and make sure it only

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -71,7 +71,7 @@ class HtmxMessageMiddleware(MiddlewareMixin):
         messages.error(request, error_msg)
         if str(exception):
             error_msg = f"{error_msg}: {exception}"
-        LOG.exception(error_msg)
+        LOG.error(error_msg)
         return None
 
     def process_response(self, request: HtmxHttpRequest, response: HttpResponse) -> HttpResponse:

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -70,7 +70,7 @@ class HtmxMessageMiddleware(MiddlewareMixin):
         error_msg = "500 Internal Server Error"
         messages.error(request, error_msg)
         if str(exception):
-            error_msg += f"{error_msg}: {exception}"
+            error_msg = f"{error_msg}: {exception}"
         LOG.exception(error_msg)
         return None
 


### PR DESCRIPTION
To test this `DEBUG` needs to be set to `False` to force not showing the yellow debug page.