### PR TITLE
defer SourceSystem query to initialization of IncidentFilterForm

### DIFF
--- a/changelog.d/1176.fixed.md
+++ b/changelog.d/1176.fixed.md
@@ -1,0 +1,1 @@
+Do not run database query when importing IncidentFormFilter

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -38,6 +38,14 @@ class IncidentFilterForm(forms.Form):
     closed = forms.BooleanField(required=False)
     acked = forms.BooleanField(required=False)
     unacked = forms.BooleanField(required=False)
+    sourceSystemIds = forms.MultipleChoiceField(
+        widget=BadgeDropdownMultiSelect(
+            attrs={"placeholder": "select sources..."},
+            partial_get=None,
+        ),
+        required=False,
+        label="Sources",
+    )
     maxlevel = forms.IntegerField(
         widget=forms.NumberInput(
             attrs={"type": "range", "step": "1", "min": min(Level).value, "max": max(Level).value}
@@ -46,21 +54,12 @@ class IncidentFilterForm(forms.Form):
         initial=max(Level).value,
         required=False,
     )
-    field_order = ["open", "closed", "acked", "unacked", "sourceSystemIds", "maxlevel"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # mollify tests
-        self.fields["sourceSystemIds"] = forms.MultipleChoiceField(
-            widget=BadgeDropdownMultiSelect(
-                attrs={"placeholder": "select sources..."},
-                partial_get=reverse("htmx:incident-filter"),
-            ),
-            choices=tuple(SourceSystem.objects.values_list("id", "name")),
-            required=False,
-            label="Sources",
-        )
-        self.order_fields(self.field_order)
+        self.fields["sourceSystemIds"].widget.partial_get = reverse("htmx:incident-filter")
+        self.fields["sourceSystemIds"].choices = tuple(SourceSystem.objects.values_list("id", "name"))
 
     def _tristate(self, onkey, offkey):
         on = self.cleaned_data.get(onkey, None)


### PR DESCRIPTION
`argus.htmx.incident.filter` runs a query on import. This means that if this module is imported, a database connection must exist. Whether or not this is bad practice can be debated, but there is a practical implication. For us (Geant) at least as of now. Previously we were able to run certain management commands (such as `tailwind_config`) without requiring a database. We did not depend on `argus.htmx.incident.filter` since we are using our custom filter backed. However, with the new filter urls, `argus.htmx.incident.filter` is always imported (when resolving the urls). This means that now we need a valid database connection when running any management command. This is not desirable.

This PR moves the choices query of the `sourceSystemIds` form field in the `IncidentFilterForm` to the `__init__` method so that the query is no longer made during import.

We should also work on separating the view code from the filter backend code, and to make sure that any functionality that should go through the filter backend interface, goes through the filter backend interface, but that's a separate issue.

I have tested this locally and the form still seems to work fine, but we're generally not using this form, so you may want to verify yourself as well