### PR TITLE
Use <time>-tag for incident datetimes

### DIFF
--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib import messages
+from django.utils.timezone import now as tznow
 from django.shortcuts import render, get_object_or_404
 
 from django.views.decorators.http import require_POST, require_GET
@@ -59,6 +60,14 @@ def prefetch_incident_daughters():
 @require_GET
 def incident_detail(request, pk: int):
     incident = get_object_or_404(Incident, id=pk)
+    duration = None
+    now = tznow()
+    if incident.end_time:
+        if incident.end_time <= now:
+            duration = incident.end_time - incident.start_time
+        else:
+            duration = now - incident.start_time
+    incident.duration = duration
     context = {
         "incident": incident,
         "page_title": str(incident),

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -40,14 +40,34 @@
             <div class="card-body">
               <h3 class="font-bold">Description</h3>
               <p>{{ incident.description }}</p>
-              <h3 class="font-bold">Start time</h3>
-              <p>{{ incident.start_time|date:preferences.argus_htmx.datetime_format }}</p>
-              <h3 class="font-bold">Duration</h3>
-              <p>{{ incident.end_time|date:preferences.argus_htmx.datetime_format }}</p>
+              {% if incident.stateful %}
+                <h3 class="font-bold">Start time</h3>
+                <p>
+                  <time datetime="{{ incident.start_time|date:"c" }}">{{ incident.start_time|date:preferences.argus_htmx.datetime_format }}</time>
+                </p>
+                {% if incident.open %}
+                  <h3 class="font-bold">End time</h3>
+                  <p>—</p>
+                  <h3 class="font-bold">Current duration</h3>
+                  <p>{{ incident.duration }}</p>
+                {% else %}
+                  <h3 class="font-bold">End time</h3>
+                  <p>
+                    <time datetime="{{ incident.end_time|date:"c" }}">{{ incident.end_time|date:preferences.argus_htmx.datetime_format }}</time>
+                  </p>
+                  <h3 class="font-bold">Total duration</h3>
+                  <p>{{ incident.duration }}</p>
+                {% endif %}
+              {% else %}
+                <h3 class="font-bold">Timestamp</h3>
+                <p>
+                  <time datetime="{{ incident.start_time }}">{{ incident.start_time|date:preferences.argus_htmx.datetime_format }}</time>
+                </p>
+              {% endif %}
               <h3 class="font-bold">Source</h3>
               <p>{{ incident.source.name }}</p>
               <h3 class="font-bold">Incident id in {{ incident.source.name }}</h3>
-              <p>{{ incident.source_incident_id }}</p>
+              <p>{{ incident.source_incident_id|default:"—" }}</p>
               <h3 class="font-bold">More details at</h3>
               <p>
                 {% if incident.details_url %}


### PR DESCRIPTION
Also, for stateful incidents:

* Show empty end time if still open
* Always show end_time and duration

For stateless incidents:

* Render start_time as "Timestamp" 
* Never show duration

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time for descriptions of the `<time>`-tag.