### PR TITLE
Allow customizing user menu

### DIFF
--- a/src/argus/htmx/templates/htmx/base.html
+++ b/src/argus/htmx/templates/htmx/base.html
@@ -38,26 +38,7 @@
                   {{ request.user|make_list|first }}
                 </span>
               </summary>
-              <ul class="menu menu-md dropdown-content bg-base-200 text-base-content rounded-box z-[1] mt-3 w-52 p-2 shadow max-h-svh">
-                <li class="menu-title">
-                  Logged in as: <span class="text-info">{{ request.user }}</span>
-                  <div class="divider divider-secondary my-0"></div>
-                </li>
-                <li>{% include "htmx/user/_theme_dropdown.html" %}</li>
-                <li>{% include "htmx/user/_dateformat_dropdown.html" %}</li>
-                <li>
-                  <a href="{% url 'htmx:user-preferences' %}">Preferences…</a>
-                </li>
-                <li>
-                  <a href="{% url 'htmx:destination-list' %}">Destinations</a>
-                </li>
-                <li>
-                  <form class="flex" action="{% url "htmx:logout" %}" method="post">
-                    {% csrf_token %}
-                    <button class="flex-1 text-start" type="submit">Log out</button>
-                  </form>
-                </li>
-              </ul>
+              {% include "htmx/user/_user_menu.html" %}
             </details>
           {% else %}
             <a class="btn" href="{% url 'htmx:login' %}">Log in</a>

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -1,0 +1,13 @@
+<ul class="menu menu-md dropdown-content bg-base-200 text-base-content rounded-box z-[1] mt-3 w-52 p-2 shadow max-h-svh">
+  <li class="menu-title">
+    Logged in as: <span class="text-info">{{ request.user }}</span>
+    <div class="divider divider-secondary my-0"></div>
+  </li>
+  {% block items %}
+    <li>{% include "htmx/user/_theme_dropdown.html" %}</li>
+    <li>{% include "htmx/user/_dateformat_dropdown.html" %}</li>
+    <li>{% include "htmx/user/_user_menu_preferences.html" %}</li>
+    <li>{% include "htmx/user/_user_menu_destinations.html" %}</li>
+    <li>{% include "htmx/user/_user_menu_logout.html" %}</li>
+  {% endblock items %}
+</ul>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_destinations.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_destinations.html
@@ -1,0 +1,1 @@
+<a href="{% url 'htmx:destination-list' %}">Destinations</a>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_logout.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_logout.html
@@ -1,0 +1,4 @@
+<form class="flex" action="{% url "htmx:logout" %}" method="post">
+  {% csrf_token %}
+  <button class="flex-1 text-start" type="submit">Log out</button>
+</form>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_preferences.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_preferences.html
@@ -1,0 +1,1 @@
+<a href="{% url 'htmx:user-preferences' %}">Preferences…</a>


### PR DESCRIPTION
Currently there is no way to customize the user menu apart from reimplementing `base.html`. We're (currently) not using destinations and would like to have it be optional. This MR restructures the templates so that it becomes easier to override (parts of) the user menu