### PR TITLE
Move channels-app and CORS settings to spa

### DIFF
--- a/changelog.d/+fix-spa-deps.fixed.md
+++ b/changelog.d/+fix-spa-deps.fixed.md
@@ -1,0 +1,5 @@
+Moved channels app from base settings to spa settings, where it belongs. The
+dependency had already been moved, so this avoids an ImportError on new
+installs. The spa frontend also needs CORS, but due to the complexity of when
+the middleware needs to be called, the cors app and middleware have not been
+moved, only the spa-specific setting.

--- a/docs/reference/react-frontend.rst
+++ b/docs/reference/react-frontend.rst
@@ -7,8 +7,9 @@ REACT Frontend
 The classic frontend is a single page application (SPA) written in REACT. See
 the `Github repo of Argus-frontend <https://github.com/uninett/Argus-frontend>`_
 
-It depends on `redis <https://redis.io/>`_, needs its own specific settings and
-has a handful of API endpoints that are not needed if running headless.
+It depends on `redis <https://redis.io/>`_, some additional 3rd party django
+apps, needs its own specific settings and has a handful of API endpoints that
+are not needed if running headless.
 
 Dependencies
 ============
@@ -23,13 +24,15 @@ here.
 Settings
 ========
 
-Base the settings file on ``argus.spa.settings``. Note that the app
-``argus.spa`` is added to :setting:`INSTALLED_APPS`.
+Base the settings file on ``argus.spa.settings``.
 
-The individual settings are in ``argus.spa.spa_settings``, note especially that
-:setting:`ROOT_URLCONF` is set to ``argus.spa.root_urls``. If you prefer to
+The individual settings are in ``argus.spa.spa_settings``, but note:
+
+* :setting:`ROOT_URLCONF` is set to ``argus.spa.root_urls``. If you prefer to
 make your own root ``urls.py``, the frontend-specific urls can be imported from
 ``argus.spa.spa_urls``.
+* :setting:`INSTALLED_APPS` is rewritten to add the apps ``channels`` and
+``argus.spa``. The order matters,``channels`` must be early.
 
 Domain settings
 ---------------
@@ -66,6 +69,20 @@ By default, Argus will look for a Redis server on ``localhost:6379``. To use a
 different server, set the :setting:`ARGUS_REDIS_SERVER` environment variable, e.g::
 
   ARGUS_REDIS_SERVER=my-redis-server.example.org:6379
+
+.. setting:: CHANNEL_LAYERS
+
+The realtime updates uses the app ``channels``. This setting by default depends
+on :seting:`ARGUS_REDIS_SERVER`, itshould normally not be necessary to change
+it.
+
+CORS handling
+-------------
+
+For the react frontend to have permissions to talk to the backend in
+production, CORS headers must be set correctly. See the documentation at
+`django-cors-headers <https://pypi.org/project/django-cors-headers/>`_ for what
+is possible.
 
 Dataporten via OAuth2
 ---------------------

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import dj_database_url
 
 # Import some helpers
-from . import get_bool_env, get_str_env, get_int_env, setup_logging, normalize_url, get_json_env, validate_app_setting
+from . import get_bool_env, get_str_env, get_int_env, setup_logging, get_json_env, validate_app_setting
 from ..utils import update_settings
 
 # Quick-start development settings - unsuitable for production
@@ -29,7 +29,6 @@ INTERNAL_IPS = []
 # fmt: off
 # fsck off, black
 INSTALLED_APPS = [
-    "channels",  # Must be early
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -45,7 +44,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "django_filters",
     "phonenumber_field",
-    "knox",
+    "knox",  # token auth
 
     # Argus apps
     "argus.auth",
@@ -183,11 +182,6 @@ if LOGGING_MODULE:
 
 # For permalinks to incidents in argus dashboard
 FRONTEND_URL = get_str_env("ARGUS_FRONTEND_URL")
-
-# django-cors-headers
-CORS_ALLOWED_ORIGINS = []
-if FRONTEND_URL:
-    CORS_ALLOWED_ORIGINS.append(normalize_url(FRONTEND_URL))
 
 # django-rest-framework
 

--- a/src/argus/spa/settings.py
+++ b/src/argus/spa/settings.py
@@ -1,5 +1,1 @@
-from argus.site.settings.backend import *
-
 from .spa_settings import *
-
-INSTALLED_APPS += ["argus.spa"]

--- a/src/argus/spa/settings.py
+++ b/src/argus/spa/settings.py
@@ -1,1 +1,3 @@
 from .spa_settings import *
+
+from argus.site.settings.backend import *

--- a/src/argus/spa/spa_settings.py
+++ b/src/argus/spa/spa_settings.py
@@ -1,9 +1,12 @@
 from urllib.parse import urlsplit
 
-from argus.site.settings import get_str_env
+from argus.site.settings.backend import *
+from argus.site.settings import get_str_env, normalize_url
 
 
 FRONTEND = "spa"
+
+INSTALLED_APPS = ["channels"] + INSTALLED_APPS + ["argus.spa"]
 
 LOGIN_URL = "/login/"
 LOGOUT_URL = "/logout/"
@@ -31,6 +34,11 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 ROOT_URLCONF = "argus.spa.root_urls"
+
+# django-cors-headers
+CORS_ALLOWED_ORIGINS = []
+if FRONTEND_URL:
+    CORS_ALLOWED_ORIGINS.append(normalize_url(FRONTEND_URL))
 
 # django-channels
 

--- a/src/argus/spa/spa_settings.py
+++ b/src/argus/spa/spa_settings.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlsplit
 
-from argus.site.settings.backend import *
+from argus.site.settings.base import *
 from argus.site.settings import get_str_env, normalize_url
 
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1192 

<!-- remove things that do not apply -->
### This pull request

Moves a django app and some settings from base settings to spa settings.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)