### PR TITLE
Explain why ARGUS_FRONTEND_URL is needed better

### DIFF
--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -160,7 +160,7 @@ Domain settings
 The setting must point to the publicly visible domain where the frontend is
 running. This might be different from where the backend is running.
 
-Depending on how Argus is deployed this is the only sure fire way to get hold
+Depending on how Argus is deployed this is the only surefire way to get hold
 of the externally visible hostname in the code in all cases.
 
 OAuth2

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -155,10 +155,13 @@ Domain settings
 .. setting:: ARGUS_FRONTEND_URL
 
 * :setting:`ARGUS_FRONTEND_URL` is used for building permalinks to point back
-  to incidents in the dashboard.
+  to incidents in the dashboard, or whenever else an absolute url is needed.
 
 The setting must point to the publicly visible domain where the frontend is
 running. This might be different from where the backend is running.
+
+Depending on how argus is deployed this is the only sure fire way to get hold
+of the hostname.
 
 OAuth2
 ------

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -160,8 +160,8 @@ Domain settings
 The setting must point to the publicly visible domain where the frontend is
 running. This might be different from where the backend is running.
 
-Depending on how argus is deployed this is the only sure fire way to get hold
-of the hostname.
+Depending on how Argus is deployed this is the only sure fire way to get hold
+of the externally visible hostname in the code in all cases.
 
 OAuth2
 ------

--- a/docs/reference/react-frontend.rst
+++ b/docs/reference/react-frontend.rst
@@ -50,8 +50,8 @@ Domain settings
   to point back to incidents in the dashboard, or whenever else an absolute url
   is needed.
 
-Depending on how argus is deployed this is the only sure fire way to get hold
-of the hostname.
+Depending on how Argus is deployed this is the only sure fire way to get hold
+of the externally visible hostname in the code in all cases.
 
 In production, Argus requires the frontend and the backend to either be
 deployed on the same domain, or the frontend to be on a subdomain of the

--- a/docs/reference/react-frontend.rst
+++ b/docs/reference/react-frontend.rst
@@ -50,7 +50,7 @@ Domain settings
   to point back to incidents in the dashboard, or whenever else an absolute url
   is needed.
 
-Depending on how Argus is deployed this is the only sure fire way to get hold
+Depending on how Argus is deployed this is the only surefire way to get hold
 of the externally visible hostname in the code in all cases.
 
 In production, Argus requires the frontend and the backend to either be

--- a/docs/reference/react-frontend.rst
+++ b/docs/reference/react-frontend.rst
@@ -46,7 +46,12 @@ Domain settings
 
 * :setting:`ARGUS_FRONTEND_URL` is used for redirecting back to frontend after logging in
   through Feide and CORS. Must either be a subdomain of or the same as
-  :setting:`ARGUS_SPA_COOKIE_DOMAIN`.
+  :setting:`ARGUS_SPA_COOKIE_DOMAIN`. It is also used for building permalinks
+  to point back to incidents in the dashboard, or whenever else an absolute url
+  is needed.
+
+Depending on how argus is deployed this is the only sure fire way to get hold
+of the hostname.
 
 In production, Argus requires the frontend and the backend to either be
 deployed on the same domain, or the frontend to be on a subdomain of the


### PR DESCRIPTION
## Scope and purpose

Hopefully explains better why the setting "ARGUS_FRONTEND_URL" is needed.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [X] Added/changed documentation
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)