### PR TITLE
Deprecate api v1

### DIFF
--- a/changelog.d/+deprecate-api-v1.changed.md
+++ b/changelog.d/+deprecate-api-v1.changed.md
@@ -1,0 +1,2 @@
+NOTE! Version v1 of the API is hereby deprecated! It *will* be removed one day.
+Update your glue services, please.

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -5,6 +5,12 @@ API Endpoints
 Endpoints, API v1
 =================
 
+.. warning::
+
+     v1 of the API is deprecated and will be removed.
+
+
+
 Authorization
 -------------
 
@@ -881,11 +887,6 @@ Notification profile endpoints
 
 Endpoints, API v2
 =================
-
-.. note::
-
-     v2 of the API is not stable yet.
-
 
 Authorization
 -------------

--- a/src/argus/auth/V1/urls.py
+++ b/src/argus/auth/V1/urls.py
@@ -1,17 +1,16 @@
 from django.urls import path
 from rest_framework import routers
 
-from . import views as views_V1
-from .. import views
+from . import views as views
 
 
 router = routers.SimpleRouter()
-router.register(r"phone-number", views_V1.PhoneNumberViewV1, basename="phone_number")
+router.register(r"phone-number", views.PhoneNumberViewV1, basename="phone_number")
 
 
 app_name = "auth"
 urlpatterns = [
     # path("login/", django_views.LoginView.as_view(redirect_authenticated_user=True), name="login"),
-    path("user/", views_V1.CurrentUserViewV1.as_view(), name="current-user"),
-    path("users/<int:pk>/", views.BasicUserDetail.as_view(), name="user"),
+    path("user/", views.CurrentUserViewV1.as_view(), name="current-user"),
+    path("users/<int:pk>/", views.BasicUserDetailV1.as_view(), name="user"),
 ] + router.urls

--- a/src/argus/auth/V1/views.py
+++ b/src/argus/auth/V1/views.py
@@ -8,12 +8,24 @@ from rest_framework.views import APIView
 from argus.drf.permissions import IsOwner
 from argus.notificationprofile.models import DestinationConfig
 from argus.notificationprofile.serializers import RequestDestinationConfigSerializer
+
+from ..views import BasicUserDetail
 from .serializers import RequestPhoneNumberSerializerV1, ResponsePhoneNumberSerializerV1, UserSerializerV1
 
 
 PHONE_NUMBERS_DEPRECATED = (
     "Phone numbers are now accessible through the destinations API. See /api/v2/notificationprofiles/destinations/."
 )
+
+# deprecate views unchanged from V2
+
+
+@extend_schema_view(get=extend_schema(deprecated=True))
+class BasicUserDetailV1(BasicUserDetail):
+    pass
+
+
+# overridden views
 
 
 class CurrentUserViewV1(APIView):

--- a/src/argus/auth/V1/views.py
+++ b/src/argus/auth/V1/views.py
@@ -17,7 +17,7 @@ PHONE_NUMBERS_DEPRECATED = (
     "Phone numbers are now accessible through the destinations API. See /api/v2/notificationprofiles/destinations/."
 )
 
-# deprecate views unchanged from V2
+# deprecated views unchanged from V2
 
 
 @extend_schema_view(get=extend_schema(deprecated=True))

--- a/src/argus/auth/V1/views.py
+++ b/src/argus/auth/V1/views.py
@@ -20,13 +20,13 @@ class CurrentUserViewV1(APIView):
     permission_classes = [IsAuthenticated]
     serializer_class = UserSerializerV1
 
+    @extend_schema(deprecated=True)
     def get(self, request, *args, **kwargs):
         serializer = self.serializer_class(request.user)
         return Response(serializer.data)
 
 
 @extend_schema_view(
-    deprecated=True,
     list=extend_schema(
         deprecated=True,
         description=PHONE_NUMBERS_DEPRECATED,

--- a/src/argus/incident/V1/urls.py
+++ b/src/argus/incident/V1/urls.py
@@ -2,25 +2,24 @@ from django.urls import path
 
 from rest_framework import routers
 
-from . import views as views_V1
-from .. import views
+from . import views
 
 
 router = routers.SimpleRouter()
-router.register(r"sources", views.SourceSystemViewSet)
-router.register(r"source-types", views.SourceSystemTypeViewSet)
-router.register(r"", views_V1.IncidentViewSetV1)
+router.register(r"sources", views.SourceSystemViewSetV1)
+router.register(r"source-types", views.SourceSystemTypeViewSetV1)
+router.register(r"", views.IncidentViewSetV1)
 
-sourced_incident_list = views_V1.SourceLockedIncidentViewSetV1.as_view({"get": "list", "post": "create"})
+sourced_incident_list = views.SourceLockedIncidentViewSetV1.as_view({"get": "list", "post": "create"})
 
-event_list = views.EventViewSet.as_view({"get": "list", "post": "create"})
-event_detail = views.EventViewSet.as_view({"get": "retrieve"})
+event_list = views.EventViewSetV1.as_view({"get": "list", "post": "create"})
+event_detail = views.EventViewSetV1.as_view({"get": "retrieve"})
 
-ack_list = views_V1.AcknowledgementViewSetV1.as_view({"get": "list", "post": "create"})
-ack_detail = views_V1.AcknowledgementViewSetV1.as_view({"get": "retrieve", "put": "update", "patch": "partial_update"})
+ack_list = views.AcknowledgementViewSetV1.as_view({"get": "list", "post": "create"})
+ack_detail = views.AcknowledgementViewSetV1.as_view({"get": "retrieve", "put": "update", "patch": "partial_update"})
 
-tag_list = views.IncidentTagViewSet.as_view({"get": "list", "post": "create"})
-tag_detail = views.IncidentTagViewSet.as_view({"get": "retrieve", "delete": "destroy"})
+tag_list = views.IncidentTagViewSetV1.as_view({"get": "list", "post": "create"})
+tag_detail = views.IncidentTagViewSetV1.as_view({"get": "retrieve", "delete": "destroy"})
 
 app_name = "incident"
 urlpatterns = [
@@ -31,6 +30,6 @@ urlpatterns = [
     path("<int:incident_pk>/acks/<int:pk>/", ack_detail, name="incident-ack"),
     path("<int:incident_pk>/tags/", tag_list, name="incident-tags"),
     path("<int:incident_pk>/tags/<str:tag>/", tag_detail, name="incident-tag"),
-    path("open/", views_V1.OpenIncidentListV1.as_view(), name="incidents-open"),
-    path("open+unacked/", views_V1.OpenUnAckedIncidentListV1.as_view(), name="incidents-open-unacked"),
+    path("open/", views.OpenIncidentListV1.as_view(), name="incidents-open"),
+    path("open+unacked/", views.OpenUnAckedIncidentListV1.as_view(), name="incidents-open-unacked"),
 ] + router.urls

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -24,7 +24,13 @@ from .serializers import (
 
 
 @extend_schema_view(
+    retrieve=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
     list=extend_schema(
+        deprecated=True,
         parameters=[
             OpenApiParameter(
                 name="acked",
@@ -97,8 +103,8 @@ from .serializers import (
                 description="Fetch stateful (`true`) or stateless (`false`) incidents.",
                 enum=BooleanStringOAEnum,
             ),
-        ]
-    )
+        ],
+    ),
 )
 class IncidentViewSetV1(IncidentViewSet):
     def get_serializer_class(self):
@@ -122,9 +128,15 @@ class IncidentViewSetV1(IncidentViewSet):
 
 
 @extend_schema_view(
+    retrieve=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
     list=extend_schema(
+        deprecated=True,
         parameters=SOURCE_LOCKED_INCIDENT_OPENAPI_PARAMETER_DESCRIPTIONS,
-    )
+    ),
 )
 class SourceLockedIncidentViewSetV1(IncidentViewSetV1):
     """All incidents added by the currently logged in user
@@ -139,15 +151,20 @@ class SourceLockedIncidentViewSetV1(IncidentViewSetV1):
 
 
 @extend_schema_view(
+    list=extend_schema(deprecated=True),
+    retrieve=extend_schema(deprecated=True),
     create=extend_schema(
+        deprecated=True,
         request=AcknowledgementSerializerV1,
         responses={"201": AcknowledgementSerializerV1},
     ),
     update=extend_schema(
+        deprecated=True,
         request=UpdateAcknowledgementSerializerV1,
         responses={"200": AcknowledgementSerializerV1},
     ),
     partial_update=extend_schema(
+        deprecated=True,
         request=UpdateAcknowledgementSerializerV1,
         responses={"200": AcknowledgementSerializerV1},
     ),

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -28,7 +28,7 @@ from .serializers import (
     UpdateAcknowledgementSerializerV1,
 )
 
-# deprecate views unchanged from V2
+# deprecated views unchanged from V2
 
 
 @extend_schema_view(

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -13,7 +13,7 @@ from argus.filter.filters import SOURCE_LOCKED_INCIDENT_OPENAPI_PARAMETER_DESCRI
 
 from ..constants import Level
 from ..models import Incident, SourceSystem
-from ..serializers import IncidentPureDeserializer, SourceSystemSerializer, IncidentTicketUrlSerializer
+from ..serializers import IncidentPureDeserializer, IncidentTicketUrlSerializer, SourceSystemSerializer
 from ..views import (
     EventViewSet,
     IncidentTagViewSet,

--- a/src/argus/incident/V1/views.py
+++ b/src/argus/incident/V1/views.py
@@ -13,14 +13,73 @@ from argus.filter.filters import SOURCE_LOCKED_INCIDENT_OPENAPI_PARAMETER_DESCRI
 
 from ..constants import Level
 from ..models import Incident, SourceSystem
-from ..serializers import IncidentPureDeserializer, SourceSystemSerializer
-from ..views import IncidentViewSet
+from ..serializers import IncidentPureDeserializer, SourceSystemSerializer, IncidentTicketUrlSerializer
+from ..views import (
+    EventViewSet,
+    IncidentTagViewSet,
+    IncidentViewSet,
+    SourceSystemTypeViewSet,
+    SourceSystemViewSet,
+)
 from .serializers import (
     AcknowledgementSerializerV1,
     IncidentSerializerV1,
     MetadataSerializerV1,
     UpdateAcknowledgementSerializerV1,
 )
+
+# deprecate views unchanged from V2
+
+
+@extend_schema_view(
+    retrieve=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    list=extend_schema(deprecated=True),
+)
+class EventViewSetV1(EventViewSet):
+    pass
+
+
+@extend_schema_view(
+    retrieve=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    list=extend_schema(deprecated=True),
+)
+class IncidentTagViewSetV1(IncidentTagViewSet):
+    pass
+
+
+@extend_schema_view(
+    retrieve=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    list=extend_schema(deprecated=True),
+)
+class SourceSystemViewSetV1(SourceSystemViewSet):
+    pass
+
+
+@extend_schema_view(
+    retrieve=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    list=extend_schema(deprecated=True),
+)
+class SourceSystemTypeViewSetV1(SourceSystemTypeViewSet):
+    pass
+
+
+# overridden views
 
 
 @extend_schema_view(
@@ -125,6 +184,15 @@ class IncidentViewSetV1(IncidentViewSet):
             "sourceSystems": source_systems.data,
         }
         return Response(data)
+
+    @extend_schema(
+        deprecated=True,
+        request=IncidentTicketUrlSerializer,
+        responses=IncidentTicketUrlSerializer,
+    )
+    @action(detail=True, methods=["put"])
+    def ticket_url(self, request, pk=None):
+        return super().ticket_url(request, pk)
 
 
 @extend_schema_view(

--- a/src/argus/notificationprofile/V1/urls.py
+++ b/src/argus/notificationprofile/V1/urls.py
@@ -2,13 +2,12 @@ from django.urls import path
 
 from rest_framework import routers
 
-from . import views as views_V1
-from .. import views
+from . import views
 
 router = routers.SimpleRouter()
-router.register(r"timeslots", views.TimeslotViewSet)
-router.register(r"filters", views_V1.FilterViewSetV1)
-router.register(r"", views_V1.NotificationProfileViewSetV1)
+router.register(r"timeslots", views.TimeslotViewSetV1)
+router.register(r"filters", views.FilterViewSetV1)
+router.register(r"", views.NotificationProfileViewSetV1)
 
 app_name = "notification-profile"
 urlpatterns = [

--- a/src/argus/notificationprofile/V1/views.py
+++ b/src/argus/notificationprofile/V1/views.py
@@ -21,6 +21,14 @@ from .serializers import (
 )
 
 
+@extend_schema_view(
+    list=extend_schema(deprecated=True),
+    retrieve=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+)
 class FilterViewSetV1(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsOwner]
     serializer_class = FilterSerializerV1
@@ -53,15 +61,21 @@ class FilterViewSetV1(viewsets.ModelViewSet):
 
 @extend_schema_view(
     create=extend_schema(
+        deprecated=True,
         request=RequestNotificationProfileSerializerV1,
         responses={201: ResponseNotificationProfileSerializerV1},
     ),
     update=extend_schema(
+        deprecated=True,
         request=RequestNotificationProfileSerializerV1,
     ),
     partial_update=extend_schema(
+        deprecated=True,
         request=RequestNotificationProfileSerializerV1,
     ),
+    destroy=extend_schema(deprecated=True),
+    retrieve=extend_schema(deprecated=True),
+    list=extend_schema(deprecated=True),
 )
 class NotificationProfileViewSetV1(rw_viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsOwner]
@@ -78,6 +92,7 @@ class NotificationProfileViewSetV1(rw_viewsets.ModelViewSet):
 
     @extend_schema(
         responses={200: IncidentSerializer(many=True)},
+        deprecated=True,
     )
     @action(methods=["get"], detail=True)
     def incidents(self, request, pk, *args, **kwargs):
@@ -97,6 +112,7 @@ class NotificationProfileViewSetV1(rw_viewsets.ModelViewSet):
     @extend_schema(
         request=FilterPreviewSerializer,
         responses=IncidentSerializer(many=True),
+        deprecated=True,
     )
     @action(methods=["post"], detail=False)
     def preview(self, request, **_):

--- a/src/argus/notificationprofile/V1/views.py
+++ b/src/argus/notificationprofile/V1/views.py
@@ -15,10 +15,39 @@ from argus.filter.V1.serializers import (
 )
 from argus.incident.serializers import IncidentSerializer
 from ..models import Filter, NotificationProfile
+from ..views import TimeslotViewSet, FilterPreviewView
 from .serializers import (
     ResponseNotificationProfileSerializerV1,
     RequestNotificationProfileSerializerV1,
 )
+
+
+# deprecate views unchanged from V2
+
+
+@extend_schema_view(
+    list=extend_schema(deprecated=True),
+    retrieve=extend_schema(deprecated=True),
+    create=extend_schema(deprecated=True),
+    update=extend_schema(deprecated=True),
+    partial_update=extend_schema(deprecated=True),
+    destroy=extend_schema(deprecated=True),
+)
+class TimeslotViewSetV1(TimeslotViewSet):
+    pass
+
+
+@extend_schema_view(
+    post=extend_schema(deprecated=True),
+)
+class FilterPreviewViewV1(FilterPreviewView):
+    pass
+
+
+filter_preview_view = FilterPreviewViewV1.as_view()
+
+
+# overridden views
 
 
 @extend_schema_view(

--- a/src/argus/notificationprofile/V1/views.py
+++ b/src/argus/notificationprofile/V1/views.py
@@ -22,7 +22,7 @@ from .serializers import (
 )
 
 
-# deprecate views unchanged from V2
+# deprecated views unchanged from V2
 
 
 @extend_schema_view(

--- a/src/argus/site/api_v1_urls.py
+++ b/src/argus/site/api_v1_urls.py
@@ -1,11 +1,20 @@
 from django.urls import include, path
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from argus.auth.spa.views import ObtainNewAuthToken
 
+
+@extend_schema_view(
+    get=extend_schema(deprecated=True),
+)
+class SpectacularAPIViewV1(SpectacularAPIView):
+    pass
+
+
 openapi_urls = [
-    path("", SpectacularAPIView.as_view(api_version="v1"), name="schema-v1"),
+    path("", SpectacularAPIViewV1.as_view(api_version="v1"), name="schema-v1"),
     path("swagger-ui/", SpectacularSwaggerView.as_view(url_name="v1:openapi:schema-v1"), name="swagger-ui-v1"),
 ]
 

--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -30,8 +30,8 @@ urlpatterns = [
     path("favicon.ico", RedirectView.as_view(url="/static/favicon.svg", permanent=True)),
     # path(".error/", error),  # Only needed when testing error pages and error behavior
     path("admin/", admin.site.urls),
-    path("api/schema/", SpectacularAPIView.as_view(api_version="v1"), name="schema-v1-old"),
-    path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema-v1-old"), name="swagger-ui-v1-old"),
+    path("api/schema/", SpectacularAPIView.as_view(api_version="v2"), name="schema-v2"),
+    path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema-v2"), name="swagger-ui-v2"),
     path("api/v1/", include(("argus.site.api_v1_urls", "api"), namespace="v1")),
     path("api/v2/", include(("argus.site.api_v2_urls", "api"), namespace="v2")),
     # path('api/sessionauth/', include('rest_framework.urls', namespace='rest_framework')),

--- a/src/argus/site/views.py
+++ b/src/argus/site/views.py
@@ -110,11 +110,11 @@ class MetadataView(APIView):
         metadata = {
             "server-version": get_version(),
             "api-version": {
-                "stable": "v1",
-                "unstable": "v2",
+                "deprecated": "v1",
+                "stable": "v2",
             },
             "jsonapi-schema": {
-                "stable": reverse("schema-v1-old"),
+                "stable": reverse("schema-v2"),
                 "v1": "/api/v1/schema/",
                 "v2": "/api/v2/schema/",
             },


### PR DESCRIPTION
## Scope and purpose

Depends on #1235

Mark all V1 OpenAPI endpoints as deprecated, in anticipation of removing the entire thing.

### This pull request
* changes the API

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
   Luckily this doesn't change any code, only sneakily duplicates lots of it to have a place to put the "deprecated"-attribute.
* [x] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done