### PR TITLE
Move navbar notification links to user menu

### DIFF
--- a/changelog.d/+move-header-nav-items.changed.md
+++ b/changelog.d/+move-header-nav-items.changed.md
@@ -1,0 +1,2 @@
+Moved notification links into the user menu, and removed the now sole remaining
+link that redundantly points to the incident list.

--- a/src/argus/htmx/templates/htmx/base.html
+++ b/src/argus/htmx/templates/htmx/base.html
@@ -15,15 +15,12 @@
       <div class="navbar-center flex">
         <ul class="menu menu-horizontal px-1">
           {% block navlinks %}
+            {% comment %}
+            <!-- example link -->
             <li>
               <a href="{% url 'htmx:incident-list' %}">Incidents</a>
             </li>
-            <li>
-              <a href="{% url 'htmx:timeslot-list' %}">Timeslots</a>
-            </li>
-            <li>
-              <a href="{% url 'htmx:notificationprofile-list' %}">Profiles</a>
-            </li>
+            {% endcomment %}
           {% endblock navlinks %}
         </ul>
       </div>

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -7,7 +7,9 @@
     <li>{% include "htmx/user/_theme_dropdown.html" %}</li>
     <li>{% include "htmx/user/_dateformat_dropdown.html" %}</li>
     <li>{% include "htmx/user/_user_menu_preferences.html" %}</li>
-    <li>{% include "htmx/user/_user_menu_destinations.html" %}</li>
+    {% block notification_links %}
+      {% include "htmx/user/_user_menu_notification_config.html" %}
+    {% endblock notification_links %}
     <li>{% include "htmx/user/_user_menu_logout.html" %}</li>
   {% endblock items %}
 </ul>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_destinations.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_destinations.html
@@ -1,1 +1,0 @@
-<a href="{% url 'htmx:destination-list' %}">Destinations</a>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_notification_config.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_notification_config.html
@@ -1,0 +1,14 @@
+<li>
+  <h2 class="menu-title">Notification config</h2>
+  <ul>
+    <li>
+      <a href="{% url 'htmx:timeslot-list' %}">Timeslots</a>
+    </li>
+    <li>
+      <a href="{% url 'htmx:notificationprofile-list' %}">Profiles</a>
+    </li>
+    <li>
+      <a href="{% url 'htmx:destination-list' %}">Destinations</a>
+    </li>
+  </ul>
+</li>


### PR DESCRIPTION
## Scope and purpose

The links to "timeslots" and "profiles" are part of the notification subsystem and only relevant together with "destinations". Therefore, we want to keep them all in the same spot.

Moving these left only one link behind, the redundant link to "incidents" which is also reachable via clicking the logo. This did not look good, so that link was also removed, emptying the navbar save for the logo and user icon.
    
A commented out example is left behind to show what customized links in the navbar is expected to look like.

## Screenshots

Before:

![Screenshot 2025-03-13 at 15-58-01 Argus Server Incidents](https://github.com/user-attachments/assets/58871c4f-ba6a-4a53-bdfe-7b3855ac7f56)

After:

![Screenshot 2025-03-13 at 16-01-25 Argus Server Incidents](https://github.com/user-attachments/assets/48680d4f-a509-4890-a3b6-ac280404e02f)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If this results in changes in the UI: Added screenshots of the before and after