### PR TITLE
Death to autocomplete

### DIFF
--- a/changelog.d/+death-to-autocomplete.changed.md
+++ b/changelog.d/+death-to-autocomplete.changed.md
@@ -1,0 +1,3 @@
+Made sure all non-button form inputs have `autocomplete="off"` set which fixes
+some annoying behavior in Firefox when filling in forms. This is documented in
+the troubleshooting guide.

--- a/docs/development/howtos/htmx-frontend/custom-incident-actions.rst
+++ b/docs/development/howtos/htmx-frontend/custom-incident-actions.rst
@@ -95,7 +95,7 @@ create a ``Form`` for the action and register it together with the action handle
           views.INCIDENT_UPDATE_ACTIONS['custom-action'] = (CustomActionForm, custom_action_handler)
 
 
-The UI part is aslo a little different. You need to override and extend the
+The UI part is also a little different. You need to override and extend the
 ``htmx/incident/_incident_list_update_menu.html`` template::
 
   {% extends "htmx/incident/_incident_list_update_menu.html" %}
@@ -115,6 +115,7 @@ Create the following template ``htmx/incident/_my_custom_action_modal.html``::
       Custom Field
       <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
       <input name="custom_field"
+             autocomplete="off"
              type="text"
              placeholder="Custom placeholder"
              required

--- a/src/argus/htmx/templates/django/forms/widgets/attrs.html
+++ b/src/argus/htmx/templates/django/forms/widgets/attrs.html
@@ -1,0 +1,7 @@
+{% if not "autocomplete" in widget.attrs.keys %}autocomplete="off"{% endif %}
+{% for name, value in widget.attrs.items %}
+  {% if value is not False %}
+    {{ name }}
+    {% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}
+  {% endif %}
+{% endfor %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_list_menubar.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_list_menubar.html
@@ -2,6 +2,7 @@
   {% block menu_tabs %}
     <input type="radio"
            name="incident_menus"
+           autocomplete="off"
            role="tab"
            class="tab [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)] text-nowrap min-h-fit"
            aria-label="Filter Incidents"
@@ -15,6 +16,7 @@
     </div>
     <input type="radio"
            name="incident_menus"
+           autocomplete="off"
            role="tab"
            class="tab tab-select [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)] text-nowrap min-h-fit"
            aria-label="Update Incidents" />

--- a/src/argus/htmx/templates/htmx/user/_dateformat_dropdown.html
+++ b/src/argus/htmx/templates/htmx/user/_dateformat_dropdown.html
@@ -11,6 +11,7 @@
                value="{{ item }}"
                aria-label="{{ item }}"
                name="datetime_format_name"
+               autocomplete="off"
                hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"
                hx-trigger="change"
                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' />

--- a/src/argus/htmx/templates/htmx/user/_page_size_dropdown.html
+++ b/src/argus/htmx/templates/htmx/user/_page_size_dropdown.html
@@ -11,6 +11,7 @@
                value="{{ item }}"
                aria-label="{{ item }}"
                name="page_size"
+               autocomplete="off"
                hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"
                hx-trigger="change"
                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' />

--- a/src/argus/htmx/templates/htmx/user/_theme_dropdown.html
+++ b/src/argus/htmx/templates/htmx/user/_theme_dropdown.html
@@ -11,6 +11,7 @@
                value="{{ item }}"
                aria-label="{{ item }}"
                name="theme"
+               autocomplete="off"
                hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"
                hx-trigger="change"
                hx-swap="outerHTML"

--- a/src/argus/htmx/templates/htmx/user/_update_interval_dropdown.html
+++ b/src/argus/htmx/templates/htmx/user/_update_interval_dropdown.html
@@ -11,6 +11,7 @@
                value="{{ item }}"
                aria-label="{{ item }}"
                name="update_interval"
+               autocomplete="off"
                hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"
                hx-trigger="change"
                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' />


### PR DESCRIPTION
## Scope and purpose

Fixes #1229, #983 hopefully.

Specifically on Firefox, if you use a form more than once it will remember the values from last time and prefill them, which is annoying behavior for most of the forms in argus frontend. So, this code  turns that "feature" off.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
