### PR TITLE
Allow removing timerecurrences from a timeslot

### DIFF
--- a/changelog.d/+delete-timerecurrences.added.md
+++ b/changelog.d/+delete-timerecurrences.added.md
@@ -1,0 +1,1 @@
+Htmx: Made it possible to delete one or more timerecurrences from a timeslot

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -61,7 +61,9 @@ class TimeslotForm(forms.ModelForm):
 
 
 def make_timerecurrence_formset(data: Optional[dict] = None, timeslot: Optional[Timeslot] = None):
-    extra = 0 if not timeslot else 1
+    extra = 1
+    if not timeslot or not timeslot.time_recurrences.exists():
+        extra = 0
     TimeRecurrenceFormSet = forms.inlineformset_factory(
         Timeslot, TimeRecurrence, form=TimeRecurrenceForm, fields="__all__", extra=extra, can_delete=True, min_num=1
     )
@@ -118,7 +120,8 @@ class FormsetMixin:
         for error in [form.errors] + formset.errors:
             if error:
                 errors.append(error.as_text())
-        messages.warning(self.request, f"Couldn't save timeslot: {errors}")
+        if errors:
+            messages.warning(self.request, f"Couldn't save timeslot: {errors}")
         return self.render_to_response(self.get_context_data(form=form, formset=formset))
 
     def form_valid(self, form, formset):

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -59,7 +59,7 @@ class TimeslotForm(forms.ModelForm):
 def make_timerecurrence_formset(data: Optional[dict] = None, timeslot: Optional[Timeslot] = None):
     extra = 0 if not timeslot else 1
     TimeRecurrenceFormSet = forms.inlineformset_factory(
-        Timeslot, TimeRecurrence, form=TimeRecurrenceForm, fields="__all__", extra=extra, can_delete=False, min_num=1
+        Timeslot, TimeRecurrence, form=TimeRecurrenceForm, fields="__all__", extra=extra, can_delete=True, min_num=1
     )
     prefix = f"timerecurrenceform-{timeslot.pk}" if timeslot else ""
     return TimeRecurrenceFormSet(data=data, instance=timeslot, prefix=prefix)
@@ -122,6 +122,8 @@ class FormsetMixin:
         self.object.user = self.request.user
         self.object.save()
         trs = formset.save(commit=False)
+        for tr in formset.deleted_objects:
+            tr.delete()
         for tr in trs:
             tr.timeslot = self.object
             tr.save()


### PR DESCRIPTION
This uses a Django formset feature to delete timrecurrences connected to a timeslot. It need not be the final UI.

## Scope and purpose

Fixes #1232 with the absolute minimum of code possible.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/1015577b-228c-4339-8ee2-0ff166b1dbf8)

After:
![image](https://github.com/user-attachments/assets/6dcccced-695f-4b0e-83be-d9b4a65d37c5)


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
