### PR TITLE
Pin ruff in GitHub actions to v0.11.0 

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,6 +14,7 @@ jobs:
 
     - uses: astral-sh/ruff-action@v3
       with:
+        version: "0.11.0"
         args: "format --check"
 
   djlint:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.11.0"
 
   djlint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         exclude: &exclude_pattern '^changelog.d/'
     -   id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
         # Run the linter
     -   id: ruff


### PR DESCRIPTION
## Scope and purpose

This is to avoid constantly having to change the ruff version in pre-commit. It should still be updated at least on mayor and minor version releases.

<!-- remove things that do not apply -->
### This pull request
* changes a dependency in GitHub actions

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
  - not relevant due to it only being devex things
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
