### PR TITLE
Make column for showing status as color fill

### DIFF
--- a/changelog.d/+color-status-column.added.md
+++ b/changelog.d/+color-status-column.added.md
@@ -1,0 +1,2 @@
+Added column to show combined status (openness+ackedness) as a color, for
+feature parity with the old frontend incident list.

--- a/docs/customization/htmx-frontend.rst
+++ b/docs/customization/htmx-frontend.rst
@@ -146,7 +146,10 @@ There are several optional attributes to ``IncidentTableColumn``:
   ``cell_template`` and wraps it in a ``<td>``-tag. This makes it possible to
   add attributes to the ``<td>``-tag or skip including the ``cell_template``
   altogether.
-* ``context``: Additional hardcoded context for every cell of its type, as a dictionary.
+* ``column_classes``: Additional classes to set on ``<th>``, handy for
+  controlling width.
+* ``context``: Additional hardcoded context for every cell of its type, as
+  a dictionary.
 * ``header_template``: A template overriding the default ``<th>`` for the column.
 
 For inbuilt support for other types of columns see the

--- a/docs/customization/htmx-frontend.rst
+++ b/docs/customization/htmx-frontend.rst
@@ -134,14 +134,20 @@ example::
         BUILTIN_COLUMNS["description"], # equivalent to just "description"
         IncidentTableColumn( # a new column definition
             name="name",
-            label="Custom"
-            cell_template="/path/to/template.html"
-            context={
-                "additional": "value"
-            }
+            label="Custom",
+            cell_template="/path/to/template.html",  # contents of cell
         ),
 
     ]
+
+There are several optional attributes to ``IncidentTableColumn``:
+
+* ``cell_wrapper_template``: A template that by default includes the
+  ``cell_template`` and wraps it in a ``<td>``-tag. This makes it possible to
+  add attributes to the ``<td>``-tag or skip including the ``cell_template``
+  altogether.
+* ``context``: Additional hardcoded context for every cell of its type, as a dictionary.
+* ``header_template``: A template overriding the default ``<th>`` for the column.
 
 For inbuilt support for other types of columns see the
 :ref:`HTMX HowTos`.

--- a/src/argus/htmx/defaults.py
+++ b/src/argus/htmx/defaults.py
@@ -8,6 +8,7 @@ from argus.site.settings import get_json_env, get_str_env
 HTMX_PATH_DEFAULT = "htmx-2.0.2.min.js"
 HYPERSCRIPT_PATH_DEFAULT = "hyperscript-0.9.13.min.js"
 INCIDENT_TABLE_COLUMNS = [
+    "color_status",
     "row_select",
     "id",
     "start_time",

--- a/src/argus/htmx/incident/customization.py
+++ b/src/argus/htmx/incident/customization.py
@@ -34,6 +34,7 @@ class IncidentTableColumn:
     context: Optional[dict] = None
     filter_field: Optional[str] = None
     cell_wrapper_template: str = "htmx/incident/_incident_table_cell.html"
+    column_classes: str = ""
 
 
 _BUILTIN_COLUMN_LIST = [
@@ -42,7 +43,7 @@ _BUILTIN_COLUMN_LIST = [
         "",
         "htmx/incident/cells/_incident_color_status.html",
         cell_wrapper_template="htmx/incident/cells/_incident_color_status.html",
-        context={"column_classes": "w-4 p-0"},
+        column_classes="w-4 p-0",
     ),
     IncidentTableColumn(
         "row_select",

--- a/src/argus/htmx/incident/customization.py
+++ b/src/argus/htmx/incident/customization.py
@@ -31,23 +31,31 @@ class IncidentTableColumn:
     label: str  # display value
     cell_template: str
     header_template: Optional[str] = None
+    cell_wrapper_template: Optional[str] = None
     context: Optional[dict] = None
     filter_field: Optional[str] = None
+    cell_wrapper_template: str = "htmx/incident/_incident_table_cell.html"
 
 
 _BUILTIN_COLUMN_LIST = [
     IncidentTableColumn(
+        "color_status",
+        "",
+        "htmx/incident/cells/_incident_color_status.html",
+        cell_wrapper_template="htmx/incident/cells/_incident_color_status.html",
+    ),
+    IncidentTableColumn(
         "row_select",
         "Selected",
         "htmx/incident/cells/_incident_checkbox.html",
-        "htmx/incident/cells/_incident_list_select_all_checkbox_header.html",
+        header_template="htmx/incident/cells/_incident_list_select_all_checkbox_header.html",
     ),
     IncidentTableColumn("id", "ID", "htmx/incident/cells/_incident_pk.html"),
     IncidentTableColumn(
         "start_time",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time.html",
-        "htmx/incident/cells/_incident_start_time_header.html",
+        header_template="htmx/incident/cells/_incident_start_time_header.html",
     ),
     IncidentTableColumn("status", "Status", "htmx/incident/cells/_incident_status.html"),
     IncidentTableColumn("level", "Severity level", "htmx/incident/cells/_incident_level.html"),

--- a/src/argus/htmx/incident/customization.py
+++ b/src/argus/htmx/incident/customization.py
@@ -42,6 +42,7 @@ _BUILTIN_COLUMN_LIST = [
         "",
         "htmx/incident/cells/_incident_color_status.html",
         cell_wrapper_template="htmx/incident/cells/_incident_color_status.html",
+        context={"column_classes": "w-4 p-0"},
     ),
     IncidentTableColumn(
         "row_select",

--- a/src/argus/htmx/incident/customization.py
+++ b/src/argus/htmx/incident/customization.py
@@ -31,7 +31,6 @@ class IncidentTableColumn:
     label: str  # display value
     cell_template: str
     header_template: Optional[str] = None
-    cell_wrapper_template: Optional[str] = None
     context: Optional[dict] = None
     filter_field: Optional[str] = None
     cell_wrapper_template: str = "htmx/incident/_incident_table_cell.html"

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4139,12 +4139,12 @@ details.collapse summary::-webkit-details-marker {
   order: -9999;
 }
 
-.m-4 {
-  margin: 1rem;
-}
-
 .m-1 {
   margin: 0.25rem;
+}
+
+.m-4 {
+  margin: 1rem;
 }
 
 .my-0 {
@@ -4168,6 +4168,10 @@ details.collapse summary::-webkit-details-marker {
 
 .mb-auto {
   margin-bottom: auto;
+}
+
+.ml-1 {
+  margin-left: 0.25rem;
 }
 
 .ml-2 {
@@ -4438,6 +4442,10 @@ details.collapse summary::-webkit-details-marker {
   overflow-y: auto;
 }
 
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
 .overflow-y-scroll {
   overflow-y: scroll;
 }
@@ -4464,12 +4472,9 @@ details.collapse summary::-webkit-details-marker {
   border-radius: 0.5rem;
 }
 
-.\!rounded-ee-\[inherit\] {
-  border-end-end-radius: inherit !important;
-}
-
-.\!rounded-se-\[inherit\] {
-  border-start-end-radius: inherit !important;
+.\!rounded-l-none {
+  border-top-left-radius: 0px !important;
+  border-bottom-left-radius: 0px !important;
 }
 
 .border {
@@ -4510,6 +4515,11 @@ details.collapse summary::-webkit-details-marker {
   --tw-border-opacity: 1;
 }
 
+.bg-accent {
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-a,oklch(var(--a)/var(--tw-bg-opacity, 1)));
+}
+
 .bg-base-100 {
   --tw-bg-opacity: 1;
   background-color: var(--fallback-b1,oklch(var(--b1)/var(--tw-bg-opacity, 1)));
@@ -4523,6 +4533,11 @@ details.collapse summary::-webkit-details-marker {
 .bg-neutral {
   --tw-bg-opacity: 1;
   background-color: var(--fallback-n,oklch(var(--n)/var(--tw-bg-opacity, 1)));
+}
+
+.bg-primary {
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-p,oklch(var(--p)/var(--tw-bg-opacity, 1)));
 }
 
 .bg-transparent {
@@ -4626,12 +4641,12 @@ details.collapse summary::-webkit-details-marker {
   font-weight: 500;
 }
 
-.font-semibold {
-  font-weight: 600;
-}
-
 .font-normal {
   font-weight: 400;
+}
+
+.font-semibold {
+  font-weight: 600;
 }
 
 .capitalize {
@@ -4687,6 +4702,11 @@ details.collapse summary::-webkit-details-marker {
   color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity, 1)));
 }
 
+.text-primary-content {
+  --tw-text-opacity: 1;
+  color: var(--fallback-pc,oklch(var(--pc)/var(--tw-text-opacity, 1)));
+}
+
 .text-warning {
   --tw-text-opacity: 1;
   color: var(--fallback-wa,oklch(var(--wa)/var(--tw-text-opacity, 1)));
@@ -4709,15 +4729,15 @@ details.collapse summary::-webkit-details-marker {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.shadow-xl {
-  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.shadow-sm {
-  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4282,6 +4282,10 @@ details.collapse summary::-webkit-details-marker {
   width: 6rem;
 }
 
+.w-4 {
+  width: 1rem;
+}
+
 .w-52 {
   width: 13rem;
 }
@@ -4553,6 +4557,10 @@ details.collapse summary::-webkit-details-marker {
      object-fit: scale-down;
 }
 
+.p-0 {
+  padding: 0px;
+}
+
 .p-1 {
   padding: 0.25rem;
 }
@@ -4700,11 +4708,6 @@ details.collapse summary::-webkit-details-marker {
 .text-primary {
   --tw-text-opacity: 1;
   color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity, 1)));
-}
-
-.text-primary-content {
-  --tw-text-opacity: 1;
-  color: var(--fallback-pc,oklch(var(--pc)/var(--tw-text-opacity, 1)));
 }
 
 .text-warning {

--- a/src/argus/htmx/templates/htmx/incident/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table.html
@@ -16,7 +16,7 @@
     <tr class="border-b border-primary">
       {% block columns %}
         {% for col in columns %}
-          <th class="border-b border-primary {{ col.context.column_classes }}">
+          <th class="border-b border-primary {{ col.column_classes }}">
             {% if col.header_template %}
               {% include col.header_template with label=col.label %}
             {% elif col.filter_field %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table.html
@@ -16,7 +16,7 @@
     <tr class="border-b border-primary">
       {% block columns %}
         {% for col in columns %}
-          <th class="border-b border-primary">
+          <th class="border-b border-primary {{ col.context.column_classes }}">
             {% if col.header_template %}
               {% include col.header_template with label=col.label %}
             {% elif col.filter_field %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_cell.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_cell.html
@@ -1,0 +1,7 @@
+<td>
+  {% if column.cell_template %}
+    {% include column.cell_template %}
+  {% else %}
+    UNDEFINED
+  {% endif %}
+</td>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_row.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_row.html
@@ -1,13 +1,7 @@
 <tr id="incident-{{ incident.pk }}-row" class="hover">
   {% block columns %}
-    {% for col in columns %}
-      <td>
-        {% if col.cell_template %}
-          {% include col.cell_template with column=col %}
-        {% else %}
-          UNDEFINED
-        {% endif %}
-      </td>
+    {% for column in columns %}
+      {% include column.cell_wrapper_template %}
     {% endfor %}
   {% endblock columns %}
 </tr>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_color_status.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_color_status.html
@@ -1,2 +1,2 @@
-<td class="{% if incident.open and not incident.acked %}bg-primary{% elif not incident.open and incident.acked %}bg-accent{% endif %}">
+<td class="w-4 p-0 {% if incident.open and not incident.acked %}bg-primary{% elif not incident.open and incident.acked %}bg-accent{% endif %}">
 </td>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_color_status.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_color_status.html
@@ -1,0 +1,2 @@
+<td class="{% if incident.open and not incident.acked %}bg-primary{% elif not incident.open and incident.acked %}bg-accent{% endif %}">
+</td>


### PR DESCRIPTION
## Scope and purpose

For feature-parity with the old frontend, discussed at a meeting with users.

Makes the `<td></td>` in the table swappable, defines a default template for the `<td></td>`, and can add some classes to the `<th></td>` of the column.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/5c95e26e-ede4-4283-8e49-efdca4df2260)

After:

![image](https://github.com/user-attachments/assets/5653d32a-573c-4c43-a432-6bce31de4c76)

Without controlling the width of `<th>`:

![image](https://github.com/user-attachments/assets/b585ddc0-0e06-47d5-a794-45e4639e146a)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
      No tests, no new code, only new config
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
