### PR TITLE
Add tests for `htmx/incident/customization.py`

### DIFF
--- a/tests/htmx/incident/test_customization.py
+++ b/tests/htmx/incident/test_customization.py
@@ -1,0 +1,28 @@
+from django import test
+
+from argus.htmx.incident.customization import IncidentTableColumn, get_incident_table_columns
+
+
+class TestGetIncidentTableColumns(test.TestCase):
+    @test.override_settings(INCIDENT_TABLE_COLUMNS=["status"])
+    def test_it_should_return_correct_builtin_columns_based_on_name(self):
+        columns = get_incident_table_columns()
+        assert columns[0].name == "status"
+
+    @test.override_settings(INCIDENT_TABLE_COLUMNS=["not_real"])
+    def test_it_should_raise_exception_if_settings_contain_name_for_nonexisting_builtin(self):
+        with self.assertRaises(ValueError):
+            get_incident_table_columns()
+
+    @test.override_settings(
+        INCIDENT_TABLE_COLUMNS=[
+            IncidentTableColumn(
+                "custom_column",
+                label="Custom Column",
+                cell_template="htmx/incidents/_custom_template.html",
+            ),
+        ],
+    )
+    def test_it_should_return_custom_column(self):
+        columns = get_incident_table_columns()
+        assert columns[0].name == "custom_column"


### PR DESCRIPTION
## Scope and purpose

Fixes #1247

Adds tests for htmx/incident/customization.py

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
   * Not needed, not visible to end user
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
