### PR TITLE
Fix badge colors

### DIFF
--- a/changelog.d/+fix-badge-colors.changed.md
+++ b/changelog.d/+fix-badge-colors.changed.md
@@ -1,1 +1,3 @@
-Makes the color of status-badges better and shows severity in the "primary" colors.
+In the status-badges use the same color for 'open' and 'unacked' and the same
+for 'closed' and 'acked'. Show severity in the "primary" color to make the
+"argus theme less "red", as mentioned in feedback from users.

--- a/changelog.d/+fix-badge-colors.changed.md
+++ b/changelog.d/+fix-badge-colors.changed.md
@@ -1,0 +1,1 @@
+Makes the color of status-badges better and shows severity in the "primary" colors.

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_level.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_level.html
@@ -1,2 +1,2 @@
 {% load argus_htmx %}
-<span class="badge badge-accent text-nowrap">{{ incident.level }} - {{ incident.level|pp_level }}</span>
+<span class="badge badge-primary text-nowrap">{{ incident.level }} - {{ incident.level|pp_level }}</span>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_status.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_status.html
@@ -1,5 +1,5 @@
 {% if incident.open %}
-  <span class="badge badge-primary">Open</span>
+  <span class="badge badge-accent">Open</span>
 {% else %}
-  <span class="badge badge-accent">Closed</span>
+  <span class="badge badge-primary">Closed</span>
 {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -13,9 +13,9 @@
             <h2 class="card-title">Status</h2>
             <p class="card-body flex-row flex-wrap gap-0.5">
               {% if incident.open %}
-                <span class="badge badge-primary">Open</span>
+                <span class="badge badge-accent">Open</span>
               {% else %}
-                <span class="badge badge-accent">Closed</span>
+                <span class="badge badge-primary">Closed</span>
               {% endif %}
               {% if incident.acked %}
                 <span class="badge badge-primary">Acknowledged</span>


### PR DESCRIPTION
## Scope and purpose

While we wait for severity colors: This will make open+unacked look the same, closed+acked look the same, and severities not "red" in the "argus" theme.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/11b28e53-ad69-445b-bc77-acbbfb90fe5d)

After:

![image](https://github.com/user-attachments/assets/3a59c27c-b624-492d-a86a-94c0c5694c36)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
