### PR TITLE
Remove validation requiring tags to exist

### DIFF
--- a/changelog.d/1302.changed.md
+++ b/changelog.d/1302.changed.md
@@ -1,0 +1,1 @@
+Show empty list instead of error if tags do not match any incidents.

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -79,17 +79,10 @@ class IncidentFilterForm(forms.Form):
             return None
 
         try:
-            tags_list = set(tag.strip() for tag in tags.split(","))
-            tags_qss = Tag.objects.parse(*tags_list)
+            for tag in tags.split(","):
+                Tag.split(tag.strip())
         except ValueError:
             raise forms.ValidationError("Tags need to have the format key=value, key2=value2")
-
-        existing_tags = set()
-        for tags_qs in tags_qss:
-            existing_tags.update(set(str(tag) for tag in tags_qs))
-        missing_tags = tags_list - existing_tags
-        if missing_tags:
-            raise forms.ValidationError(f"The following tags could not be found: {', '.join(missing_tags)}")
 
         return tags
 


### PR DESCRIPTION
This should make it so it no longer shows an error message if you enter a tag that doesnt match any existing incidents. Instead you will get an empty list of incidents

## Scope and purpose

Fixes #1302. 

Previously, if you tried to filter on tags that did not match any incidents, it would show you the normal list of incidents without any filtering, and an error stating no such tags exist. This changes it so it shows an empty list of incidents instead.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
