### PR TITLE
Fix days field

### DIFF
--- a/src/argus/htmx/timeslot/urls.py
+++ b/src/argus/htmx/timeslot/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path("create/", views.TimeslotCreateView.as_view(), name="timeslot-create"),
     path("<pk>/", views.TimeslotDetailView.as_view(), name="timeslot-detail"),
     path("<pk>/update/", views.TimeslotUpdateView.as_view(), name="timeslot-update"),
+    path("<pk>/<tr_pk>/field/days/", views.days_form_view, name="htmx:timeslot-timerecurrence-days-field-update"),
     path("<pk>/delete/", views.TimeslotDeleteView.as_view(), name="timeslot-delete"),
 ]


### PR DESCRIPTION
## Scope and purpose

Continuation of #1276

Odd things happens with the days-field, especially for unsaved forms.

<!-- remove things that do not apply -->
### This pull request
* adds/changes/removes a dependency
* changes the database
* changes the API <!-- Ensure that v1 is backwards compatible, v2 can be changing things -->


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
