### PR TITLE
Make basic inputs in forms use a universal design

### DIFF
--- a/changelog.d/1311.changed.md
+++ b/changelog.d/1311.changed.md
@@ -1,0 +1,1 @@
+Fixed styling of input fields in modals. Made all basic inputs (text, date, email etc) on the incidents, timeslots and destinations pages have the same universal design.

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4303,14 +4303,6 @@ details.collapse summary::-webkit-details-marker {
   max-width: 30%;
 }
 
-.max-w-lg {
-  max-width: 32rem;
-}
-
-.max-w-md {
-  max-width: 28rem;
-}
-
 .max-w-xs {
   max-width: 20rem;
 }
@@ -4339,10 +4331,6 @@ details.collapse summary::-webkit-details-marker {
   flex-basis: 25%;
 }
 
-.border-collapse {
-  border-collapse: collapse;
-}
-
 .border-separate {
   border-collapse: separate;
 }
@@ -4355,12 +4343,6 @@ details.collapse summary::-webkit-details-marker {
 
 .cursor-pointer {
   cursor: pointer;
-}
-
-.appearance-none {
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
 }
 
 .flex-row {

--- a/src/argus/htmx/templates/htmx/destination/_collapse_with_forms.html
+++ b/src/argus/htmx/templates/htmx/destination/_collapse_with_forms.html
@@ -1,12 +1,14 @@
-<details class="collapse bg-base-200 collapse-arrow" open="">
-  <summary class="collapse-title text-xl font-medium">{{ media.name }} ({{ forms|length }})</summary>
-  <div class="collapse-content">
-    {% if error_msg %}<p class="text-error">{{ error_msg }}</p>{% endif %}
-    {% for form in forms %}
-      <div class="flex w-full h-fit items-center justify-center">
-        {% include "htmx/destination/_edit_form.html" %}
-        {% include "htmx/destination/_delete_form.html" %}
-      </div>
-    {% endfor %}
-  </div>
-</details>
+<div class="card shadow-2xl">
+  <details class="collapse collapse-arrow" open="">
+    <summary class="collapse-title text-xl font-medium">{{ media.name }} ({{ forms|length }})</summary>
+    <div class="collapse-content">
+      {% if error_msg %}<p class="text-error">{{ error_msg }}</p>{% endif %}
+      {% for form in forms %}
+        <div class="flex w-full h-fit items-center justify-center">
+          {% include "htmx/destination/_edit_form.html" %}
+          {% include "htmx/destination/_delete_form.html" %}
+        </div>
+      {% endfor %}
+    </div>
+  </details>
+</div>

--- a/src/argus/htmx/templates/htmx/destination/_collapse_with_forms.html
+++ b/src/argus/htmx/templates/htmx/destination/_collapse_with_forms.html
@@ -1,4 +1,4 @@
-<div class="card shadow-2xl">
+<div class="card shadow-xl">
   <details class="collapse collapse-arrow" open="">
     <summary class="collapse-title text-xl font-medium">{{ media.name }} ({{ forms|length }})</summary>
     <div class="collapse-content">

--- a/src/argus/htmx/templates/htmx/destination/_create_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_create_form.html
@@ -2,7 +2,7 @@
       hx-trigger="submit"
       hx-target="#destination-content"
       hx-swap="outerHTML"
-      class="max-w-4xl w-full card mt-4 mb-8 bg-base-200/40 shadow-2xl p-2">
+      class="max-w-4xl w-full card mt-4 mb-8 bg-base-200/40 shadow-xl p-2">
   {% csrf_token %}
   <fieldset class="p-2 border rounded-box border-primary items-center gap-4 flex items-end justify-center">
     <legend class="menu-title">Create destination</legend>

--- a/src/argus/htmx/templates/htmx/destination/_create_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_create_form.html
@@ -7,23 +7,11 @@
   <fieldset class="p-2 border rounded-box border-primary items-center gap-4 flex items-end justify-center">
     <legend class="menu-title">Create destination</legend>
     {% for field in create_form %}
-      <label class="form-control max-w-xs mb-auto">
-        <div class="label">
-          <span class="label-text">{{ field.label }}</span>
-        </div>
-        {% if field.name == "media" %}
-          {{ field }}
-        {% else %}
-          <div class="input input-bordered flex items-center gap-2">{{ field }}</div>
-        {% endif %}
-        <div class="label">
-          <span class="label-text-alt min-h-4">
-            {% if field.errors %}
-              {% for error in field.errors %}<p class="text-error">{{ error }}</p>{% endfor %}
-            {% endif %}
-          </span>
-        </div>
-      </label>
+      {% if field.errors %}
+        {% include "htmx/forms/input_field.html" with label=field.label wrapper_classes="form_control mb-auto" field=field errors=field.errors %}
+      {% else %}
+        {% include "htmx/forms/input_field.html" with label=field.label wrapper_classes="form_control mb-8" field=field %}
+      {% endif %}
     {% empty %}
       <p>Something went wrong</p>
     {% endfor %}

--- a/src/argus/htmx/templates/htmx/destination/_create_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_create_form.html
@@ -2,7 +2,7 @@
       hx-trigger="submit"
       hx-target="#destination-content"
       hx-swap="outerHTML"
-      class="max-w-4xl w-full">
+      class="max-w-4xl w-full card mt-4 mb-8 bg-base-200/40 shadow-2xl p-2">
   {% csrf_token %}
   <fieldset class="p-2 border rounded-box border-primary items-center gap-4 flex items-end justify-center">
     <legend class="menu-title">Create destination</legend>

--- a/src/argus/htmx/templates/htmx/destination/_edit_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_edit_form.html
@@ -7,19 +7,11 @@
   <fieldset class="flex flex-nowrap items-center gap-4">
     {% for hidden_field in form.hidden_fields %}{{ hidden_field }}{% endfor %}
     {% for field in form.visible_fields %}
-      <label class="form-control max-w-xs mb-auto">
-        <div class="label">
-          <span class="label-text">{{ field.label }}</span>
-        </div>
-        <div class="input input-bordered flex items-center gap-2">{{ field }}</div>
-        <div class="label">
-          <span class="label-text-alt min-h-4">
-            {% if field.errors %}
-              {% for error in field.errors %}<p class="text-error">{{ error }}</p>{% endfor %}
-            {% endif %}
-          </span>
-        </div>
-      </label>
+      {% if field.errors %}
+        {% include "htmx/forms/input_field.html" with label=field.label wrapper_classes="form_control mb-auto" field=field errors=field.errors %}
+      {% else %}
+        {% include "htmx/forms/input_field.html" with label=field.label wrapper_classes="form_control mb-8" field=field %}
+      {% endif %}
     {% empty %}
       <p>Something went wrong</p>
     {% endfor %}

--- a/src/argus/htmx/templates/htmx/forms/input_field.html
+++ b/src/argus/htmx/templates/htmx/forms/input_field.html
@@ -6,8 +6,7 @@
   {% block input_rendering %}
     <div class="indicator w-full">
       {% if is_required %}
-        <span
-            class="indicator-item indicator-top indicator-end badge border-none mask mask-circle text-warning text-base">＊</span>
+        <span class="indicator-item indicator-top indicator-end badge border-none mask mask-circle text-warning text-base">＊</span>
       {% endif %}
       {% if field %}
         {% render_field field class+="input input-bordered border-b w-full" %}
@@ -18,18 +17,16 @@
                value="{{ value|default:"" }}"
                {% if is_required %}required{% endif %}
                autocomplete="off"
-               class="input input-bordered border-b w-full"/>
+               class="input input-bordered border-b w-full" />
       {% endif %}
     </div>
   {% endblock input_rendering %}
   {% if help_text or errors %}
     <label class="label">
-    {% if help_text %}
-      <span class="label-text-alt">{{ help_text }}</span>
+      {% if help_text %}<span class="label-text-alt">{{ help_text }}</span>{% endif %}
+      {% if errors %}
+        {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
+      {% endif %}
     {% endif %}
-    {% if errors %}
-      {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
-    {% endif %}
-  {% endif %}
   </label>
 </div>

--- a/src/argus/htmx/templates/htmx/forms/input_field.html
+++ b/src/argus/htmx/templates/htmx/forms/input_field.html
@@ -24,9 +24,7 @@
   {% if help_text or errors %}
     <label class="label">
       {% if help_text %}<span class="label-text-alt">{{ help_text }}</span>{% endif %}
-      {% if errors %}
-        {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
-      {% endif %}
+      {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
     {% endif %}
   </label>
 </div>

--- a/src/argus/htmx/templates/htmx/forms/input_field.html
+++ b/src/argus/htmx/templates/htmx/forms/input_field.html
@@ -1,0 +1,35 @@
+{% load widget_tweaks %}
+<div class="{{ wrapper_classes|default:"form-control w-full" }} max-w-{{ max_width|default:"xs" }}">
+  <label class="label">
+    <span class="label-text italic">{{ label }}</span>
+  </label>
+  {% block input_rendering %}
+    <div class="indicator w-full">
+      {% if is_required %}
+        <span
+            class="indicator-item indicator-top indicator-end badge border-none mask mask-circle text-warning text-base">＊</span>
+      {% endif %}
+      {% if field %}
+        {% render_field field class+="input input-bordered border-b w-full" %}
+      {% else %}
+        <input name="{{ name }}"
+               type="{{ type|default:"" }}"
+               placeholder="{{ placeholder|default:"" }}"
+               value="{{ value|default:"" }}"
+               {% if is_required %}required{% endif %}
+               autocomplete="off"
+               class="input input-bordered border-b w-full"/>
+      {% endif %}
+    </div>
+  {% endblock input_rendering %}
+  {% if help_text or errors %}
+    <label class="label">
+    {% if help_text %}
+      <span class="label-text-alt">{{ help_text }}</span>
+    {% endif %}
+    {% if errors %}
+      {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
+    {% endif %}
+  {% endif %}
+  </label>
+</div>

--- a/src/argus/htmx/templates/htmx/forms/input_field.html
+++ b/src/argus/htmx/templates/htmx/forms/input_field.html
@@ -25,6 +25,6 @@
     <label class="label">
       {% if help_text %}<span class="label-text-alt">{{ help_text }}</span>{% endif %}
       {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
-    {% endif %}
-  </label>
+    </label>
+  {% endif %}
 </div>

--- a/src/argus/htmx/templates/htmx/incident/_filter_create_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_filter_create_modal.html
@@ -4,12 +4,5 @@
   hx-include="#incident-filter-box fieldset, [name='filter_name']"
 {% endblock form_control %}
 {% block dialogform %}
-  <label class="indicator input input-bordered flex items-center gap-2 w-full">
-    Filter name
-    <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
-    <input name="filter_name"
-           type="text"
-           required
-           class="appearance-none grow border-none" />
-  </label>
+  {% include "htmx/forms/input_field.html" with label=" Filter name" is_required="true" name="filter_name" type="text" %}
 {% endblock dialogform %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_acknowledge_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_acknowledge_modal.html
@@ -1,19 +1,5 @@
 {% extends "htmx/incident/_base_incident_update_modal.html" %}
 {% block dialogform %}
-  <label class="indicator input input-bordered flex items-center gap-2 w-full">
-    Message
-    <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
-    <input name="description"
-           type="text"
-           placeholder="Acknowledgment message"
-           required
-           class="appearance-none grow border-none" />
-  </label>
-  <label class="input input-bordered flex items-center gap-2 w-full">
-    Expiration
-    <input name="expiration"
-           type="date"
-           placeholder="Expiry date"
-           class="appearance-none grow border-none" />
-  </label>
+  {% include "htmx/forms/input_field.html" with label="Message" is_required="true" name="description" type="text" placeholder="Acknowledgment message" %}
+  {% include "htmx/forms/input_field.html" with label="Expiration" name="expiration" type="date" placeholder="Expiry date" %}
 {% endblock dialogform %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_close_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_close_modal.html
@@ -1,10 +1,4 @@
 {% extends "htmx/incident/_base_incident_update_modal.html" %}
 {% block dialogform %}
-  <label>
-    Reason for closing
-    <input name="description"
-           type="text"
-           placeholder="Closing message"
-           class="input input-bordered w-full max-w-xs" />
-  </label>
+  {% include "htmx/forms/input_field.html" with label="Reason for closing" name="description" type="text" placeholder="Closing message" %}
 {% endblock dialogform %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_reopen_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_reopen_modal.html
@@ -1,10 +1,4 @@
 {% extends "htmx/incident/_base_incident_update_modal.html" %}
 {% block dialogform %}
-  <label>
-    Reason for reopening
-    <input name="description"
-           type="text"
-           placeholder="Reopening message"
-           class="input input-bordered w-full max-w-xs" />
-  </label>
+  {% include "htmx/forms/input_field.html" with label="Reason for reopening" name="description" type="text" placeholder="Reopening message" %}
 {% endblock dialogform %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_ticket_edit_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_ticket_edit_modal.html
@@ -1,11 +1,8 @@
 {% extends "htmx/incident/_base_incident_update_modal.html" %}
 {% block dialogform %}
-  <label>
-    Change ticket
-    <input name="ticket_url"
-           type="url"
-           value="{{ incident.ticket_url|default:"" }}"
-           placeholder="valid url or nothing"
-           class="input input-bordered w-full max-w-xs" />
-  </label>
+  {% if incident.ticket_url %}
+    {% include "htmx/forms/input_field.html" with label="Ticket URL" is_required="true" name="ticket_url" type="url" placeholder="Valid URL or nothing" value=incident.ticket_url %}
+  {% else %}
+    {% include "htmx/forms/input_field.html" with label="Ticket URL" is_required="true" name="ticket_url" type="url" placeholder="Valid URL or nothing" %}
+  {% endif %}
 {% endblock dialogform %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_ticket_manual_create_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_ticket_manual_create_modal.html
@@ -1,11 +1,4 @@
 {% extends "htmx/incident/_base_incident_update_modal.html" %}
 {% block dialogform %}
-  <label>
-    Ticket url
-    <input name="ticket_url"
-           type="url"
-           required
-           placeholder="Ticket url"
-           class="input input-bordered w-full max-w-xs" />
-  </label>
+  {% include "htmx/forms/input_field.html" with label="Ticket URL" is_required="true" name="ticket_url" type="url" placeholder="Valid URL or nothing" %}
 {% endblock dialogform %}

--- a/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
+++ b/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
@@ -7,12 +7,7 @@
       <div class="flex gap-16 justify-between">
         <div>
           {% with form.name as field %}
-            <label class="form-control w-full max-w-md">
-              <div class="label">
-                <span class="label-text">{{ field.label }}</span>
-              </div>
-              {{ field|add_class:"input input-bordered border-b" }}
-            </label>
+            {% include "htmx/forms/input_field.html" with label=field.label max_width="md" field=field %}
           {% endwith %}
         </div>
         <div class="card-actions flex items-end">

--- a/src/argus/htmx/templates/htmx/timeslot/timerecurrence_div.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timerecurrence_div.html
@@ -12,22 +12,12 @@
       </label>
     </div>
     <div class="flex gap-2 w-full flex-nowrap max-sm:flex-wrap">
-      <label class="form-control w-full max-w-md">
-        <div class="label">
-          <span class="label-text">{{ form.start.label }}</span>
-        </div>
-        {% render_field form.start class+="input input-bordered border-b" %}
-      </label>
-      <label class="form-control w-full max-w-lg">
-        <div class="label">
-          <span class="label-text">{{ form.end.label }}</span>
-        </div>
-        {% render_field form.end class+="input input-bordered border-b" %}
-      </label>
+      {% include "htmx/forms/input_field.html" with label=form.start.label max_width="md" field=form.start %}
+      {% include "htmx/forms/input_field.html" with label=form.end.label max_width="md" field=form.end %}
     </div>
     <label class="form-control w-full self-center">
       <div class="label">
-        <span class="label-text">{{ form.days.label }}</span>
+        <span class="label-text italic">{{ form.days.label }}</span>
       </div>
       {% render_field form.days %}
     </label>


### PR DESCRIPTION
## Scope and purpose

Fixes #1051, #994

Also updates following forms:

- all inputs in modals on the incidents or incident detail pages use a newly added universal input template
- timeslots inputs use a newly added universal input template
- destinations inputs use a newly added universal input template
- destinations form is brought closer in style to the rest of the forms in Argus (timeslots, profiles)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done: #1312 
* [x] If this results in changes in the UI: Added screenshots of the before and after
    * Modals before (corresponding change was applied to every single modal on the incidents pages, dashboard or details):
       <img width="536" alt="Screenshot 2025-03-26 at 15 51 54" src="https://github.com/user-attachments/assets/4d9b9c45-258a-42da-bdb4-8d3457d9acfb" />
    * Modals after (corresponding change was applied to every single modal on the incidents pages, dashboard or details):
       <img width="523" alt="Screenshot 2025-03-26 at 15 50 23" src="https://github.com/user-attachments/assets/47de82a4-76eb-4401-9314-00521d5c5e86" />
    * Destinations page before:
       <img width="927" alt="Screenshot 2025-03-26 at 15 52 04" src="https://github.com/user-attachments/assets/e921e7f8-6dc9-4764-8339-f3599e10d279" />
    * Destinations page after:
       <img width="922" alt="Screenshot 2025-03-26 at 15 50 46" src="https://github.com/user-attachments/assets/748a8f00-cadc-4214-8935-3eccbf955048" />
<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
