### PR TITLE
Fix badges on details page

### DIFF
--- a/changelog.d/1244.fixed.md
+++ b/changelog.d/1244.fixed.md
@@ -1,0 +1,1 @@
+Bug with very long text in badges on the details page overflowing and becoming unreadable.

--- a/changelog.d/1314.changed.md
+++ b/changelog.d/1314.changed.md
@@ -1,0 +1,1 @@
+Made styling of the tag badges on the details page more subtle.

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -2079,6 +2079,13 @@ input.tab:checked + .tab-content,
   color: var(--fallback-erc,oklch(var(--erc)/var(--tw-text-opacity)));
 }
 
+.badge-outline {
+  border-color: currentColor;
+  --tw-border-opacity: 0.5;
+  background-color: transparent;
+  color: currentColor;
+}
+
 .badge-outline.badge-neutral {
   --tw-text-opacity: 1;
   color: var(--fallback-n,oklch(var(--n)/var(--tw-text-opacity)));
@@ -2089,9 +2096,29 @@ input.tab:checked + .tab-content,
   color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity)));
 }
 
+.badge-outline.badge-secondary {
+  --tw-text-opacity: 1;
+  color: var(--fallback-s,oklch(var(--s)/var(--tw-text-opacity)));
+}
+
+.badge-outline.badge-accent {
+  --tw-text-opacity: 1;
+  color: var(--fallback-a,oklch(var(--a)/var(--tw-text-opacity)));
+}
+
+.badge-outline.badge-info {
+  --tw-text-opacity: 1;
+  color: var(--fallback-in,oklch(var(--in)/var(--tw-text-opacity)));
+}
+
 .badge-outline.badge-success {
   --tw-text-opacity: 1;
   color: var(--fallback-su,oklch(var(--su)/var(--tw-text-opacity)));
+}
+
+.badge-outline.badge-warning {
+  --tw-text-opacity: 1;
+  color: var(--fallback-wa,oklch(var(--wa)/var(--tw-text-opacity)));
 }
 
 .badge-outline.badge-error {

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4463,8 +4463,16 @@ details.collapse summary::-webkit-details-marker {
   white-space: nowrap;
 }
 
+.text-wrap {
+  text-wrap: wrap;
+}
+
 .text-nowrap {
   text-wrap: nowrap;
+}
+
+.break-all {
+  word-break: break-all;
 }
 
 .rounded-box {

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -23,7 +23,7 @@
                 <span class="badge badge-error">Unacknowledged</span>
               {% endif %}
               {% if incident.ticket_url %}
-                <span class="badge badge-success"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
+                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
               {% else %}
                 <span class="badge badge-error">No ticket</span>
               {% endif %}
@@ -32,7 +32,9 @@
           <section id="tags" class="card">
             <h2 class="card-title">Tags</h2>
             <p class="card-body flex-row flex-wrap gap-0.5">
-              {% for tag in incident.deprecated_tags %}<span class="badge badge-neutral">{{ tag }}</span>{% endfor %}
+              {% for tag in incident.deprecated_tags %}
+                <span class="badge badge-neutral h-auto text-wrap break-all text-center">{{ tag }}</span>
+              {% endfor %}
             </p>
           </section>
           <section id="primary-details" class="card">

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -33,7 +33,7 @@
             <h2 class="card-title">Tags</h2>
             <p class="card-body flex-row flex-wrap gap-0.5">
               {% for tag in incident.deprecated_tags %}
-                <span class="badge badge-neutral h-auto text-wrap break-all text-center">{{ tag }}</span>
+                <span class="badge badge-neutral h-auto text-wrap break-all text-center text-xs">{{ tag }}</span>
               {% endfor %}
             </p>
           </section>

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -33,7 +33,7 @@
             <h2 class="card-title">Tags</h2>
             <p class="card-body flex-row flex-wrap gap-0.5">
               {% for tag in incident.deprecated_tags %}
-                <span class="badge badge-neutral h-auto text-wrap break-all text-center text-xs">{{ tag }}</span>
+                <span class="badge badge-neutral badge-outline  h-auto text-wrap break-all text-center text-xs">{{ tag }}</span>
               {% endfor %}
             </p>
           </section>


### PR DESCRIPTION
## Scope and purpose

Fixes #1244. Also makes the styling of the tag badges more subtle.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
    * Before:
       <img width="361" alt="Screenshot 2025-03-27 at 13 40 35" src="https://github.com/user-attachments/assets/6fd645cb-3f62-4f6a-b41a-3f6b25ea4646" />
    * After:
       <img width="390" alt="Screenshot 2025-03-27 at 13 38 46" src="https://github.com/user-attachments/assets/35db801d-6984-4bc9-871b-2190f0d109e6" />
<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
