### PR TITLE
Pagination improvements

### DIFF
--- a/changelog.d/+pagination-improvements.changed.md
+++ b/changelog.d/+pagination-improvements.changed.md
@@ -1,0 +1,1 @@
+Modularized the incident pagination and improved it as per user feedback.

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -215,6 +215,7 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         base_template = "htmx/incident/responses/_incident_list_refresh.html"
     else:
         base_template = "htmx/incident/_base.html"
+    last_page_num = page.paginator.num_pages
     context = {
         "columns": columns,
         "filtered_count": filtered_count,
@@ -223,6 +224,8 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         "page_title": "Incidents",
         "base": base_template,
         "page": page,
+        "last_page_num": last_page_num,
+        "second_to_last_page": last_page_num - 1,
         "last_refreshed": last_refreshed,
     }
 

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4102,6 +4102,10 @@ details.collapse summary::-webkit-details-marker {
   border-width: 0;
 }
 
+.pointer-events-none {
+  pointer-events: none;
+}
+
 .visible {
   visibility: visible;
 }

--- a/src/argus/htmx/templates/htmx/incident/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table.html
@@ -43,66 +43,15 @@
           {% block refresh_info %}
             {% include "htmx/incident/_incident_list_refresh_info.html" %}
           {% endblock refresh_info %}
-          <!--
-                The htmx attributes set on the nav here are inherited by the child links.
-                hx-target tells where htmx to swap the fetched content in, and hx-swap
-                tells it how to swap it - by replacing the 'outerHTML' attribute of the
-                target, i.e. replacing the target's actual DOM node. hx-push-url tells
-                htmx to push the fetched URL into the browser history, so we can use
-                the backwards/forwards buttons to navigate these subpages.
-                -->
-          <ul class="join"
-              hx-target="#table"
-              hx-swap="outerHTML"
-              hx-push-url="true">
-            {% if page.number != 1 %}
+          {% if page.paginator.num_pages > 1 %}
+            {% include "./_incident_table_paginator.html" %}
+          {% else %}
+            <ul class="join">
               <li>
-                <!--
-                              For each link we use hx-get to tell htmx to fetch that URL and
-                              swap it in. We also repeat the URL in the href attribute so the
-                              page works without JavaScript, and to ensure the link is
-                              displayed as clickable.
-                            -->
-                <a hx-get="?page=1"
-                   href="?page=1"
-                   hx-indicator="#incident-list .htmx-indicator"
-                   class="join-item btn btn-neutral">« First</a>
+                <button class="btn btn-active btn-neutral">1</button>
               </li>
-            {% endif %}
-            {% if page.has_previous %}
-              <li>
-                <a hx-get="?page={{ page.previous_page_number }}"
-                   href="?page={{ page.previous_page_number }}"
-                   hx-indicator="#incident-list .htmx-indicator"
-                   class="join-item btn btn-neutral">{{ page.previous_page_number }}</a>
-              </li>
-            {% endif %}
-            {% if page.paginator.num_pages > 1 %}
-              <li>
-                <button class="join-item btn btn-active btn-neutral">{{ page.number }}</button>
-              </li>
-            {% else %}
-              <li>
-                <button class="btn btn-active btn-neutral">{{ page.number }}</button>
-              </li>
-            {% endif %}
-            {% if page.has_next %}
-              <li>
-                <a hx-get="?page={{ page.next_page_number }}"
-                   href="?page={{ page.next_page_number }}"
-                   hx-indicator="#incident-list .htmx-indicator"
-                   class="join-item btn btn-neutral">{{ page.next_page_number }}</a>
-              </li>
-            {% endif %}
-            {% if page.number != page.paginator.num_pages %}
-              <li>
-                <a hx-get="?page={{ page.paginator.num_pages }}"
-                   href="?page={{ page.paginator.num_pages }}"
-                   hx-indicator="#incident-list .htmx-indicator"
-                   class="join-item btn btn-neutral">» Last</a>
-              </li>
-            {% endif %}
-          </ul>
+            </ul>
+          {% endif %}
         </div>
       </td>
     </tr>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -24,11 +24,11 @@ the backwards/forwards buttons to navigate these subpages.
   <li>
     <button class="join-item btn btn-active btn-neutral pointer-events-none">{{ page.number }}</button>
   </li>
-  {% if page.has_next %}
+  {% if page.has_next and page.number != second_to_last_page %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
   {% endif %}
   {% if page.number != last_page_num %}
-    {% if page.number != second_to_last_page %}
+    {% if page.next_page_number < second_to_last_page %}
       <li>
         <button class="join-item btn btn-neutral pointer-events-none">…</button>
       </li>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -14,7 +14,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_name="« First" %}
     {% if page.number > 3 %}
       <li>
-        <button class="join-item btn btn-neutral">…</button>
+        <button class="join-item btn btn-neutral pointer-events-none">…</button>
       </li>
     {% endif %}
   {% endif %}
@@ -22,7 +22,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number %}
   {% endif %}
   <li>
-    <button class="join-item btn btn-active btn-neutral">{{ page.number }}</button>
+    <button class="join-item btn btn-active btn-neutral pointer-events-none">{{ page.number }}</button>
   </li>
   {% if page.has_next %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number %}
@@ -30,7 +30,7 @@ the backwards/forwards buttons to navigate these subpages.
   {% if page.number != last_page_num %}
     {% if page.number != second_to_last_page %}
       <li>
-        <button class="join-item btn btn-neutral">…</button>
+        <button class="join-item btn btn-neutral pointer-events-none">…</button>
       </li>
     {% endif %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name="» Last" %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -11,7 +11,7 @@ the backwards/forwards buttons to navigate these subpages.
     hx-swap="outerHTML"
     hx-push-url="true">
   {% if page.number != 1 %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_name="« First" %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_prefix="« " page_name="1" %}
     {% if page.number > 3 %}
       <li>
         <button class="join-item btn btn-neutral pointer-events-none">…</button>
@@ -19,13 +19,13 @@ the backwards/forwards buttons to navigate these subpages.
     {% endif %}
   {% endif %}
   {% if page.has_previous and page.number != 2 %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number page_prefix="‹ " page_name=page.previous_page_number %}
   {% endif %}
   <li>
     <button class="join-item btn btn-active btn-neutral pointer-events-none">{{ page.number }}</button>
   </li>
   {% if page.has_next %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
   {% endif %}
   {% if page.number != last_page_num %}
     {% if page.number != second_to_last_page %}
@@ -33,6 +33,6 @@ the backwards/forwards buttons to navigate these subpages.
         <button class="join-item btn btn-neutral pointer-events-none">…</button>
       </li>
     {% endif %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name="» Last" %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name=last_page_number page_suffix=" »" %}
   {% endif %}
 </ul>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -1,0 +1,38 @@
+<!--
+The htmx attributes set on the nav here are inherited by the child links.
+hx-target tells where htmx to swap the fetched content in, and hx-swap
+tells it how to swap it - by replacing the 'outerHTML' attribute of the
+target, i.e. replacing the target's actual DOM node. hx-push-url tells
+htmx to push the fetched URL into the browser history, so we can use
+the backwards/forwards buttons to navigate these subpages.
+-->
+<ul class="join"
+    hx-target="#table"
+    hx-swap="outerHTML"
+    hx-push-url="true">
+  {% if page.number != 1 %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_name="« First" %}
+    {% if page.number > 3 %}
+      <li>
+        <button class="join-item btn btn-neutral">…</button>
+      </li>
+    {% endif %}
+  {% endif %}
+  {% if page.has_previous and page.number != 2 %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number %}
+  {% endif %}
+  <li>
+    <button class="join-item btn btn-active btn-neutral">{{ page.number }}</button>
+  </li>
+  {% if page.has_next %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number %}
+  {% endif %}
+  {% if page.number != last_page_num %}
+    {% if page.number != second_to_last_page %}
+      <li>
+        <button class="join-item btn btn-neutral">…</button>
+      </li>
+    {% endif %}
+    {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name="» Last" %}
+  {% endif %}
+</ul>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -1,0 +1,12 @@
+<!--
+For each link we use hx-get to tell htmx to fetch that URL and
+swap it in. We also repeat the URL in the href attribute so the
+page works without JavaScript, and to ensure the link is
+displayed as clickable.
+-->
+<li>
+  <a hx-get="?page={{ page_number }}"
+     href="?page={{ page_number }}"
+     hx-indicator="#incident-list .htmx-indicator"
+     class="join-item btn btn-neutral">{{ page_name|default:page_number }}</a>
+</li>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -8,5 +8,6 @@ displayed as clickable.
   <a hx-get="?page={{ page_number }}"
      href="?page={{ page_number }}"
      hx-indicator="#incident-list .htmx-indicator"
+     hx-include=".incident-list-param"
      class="join-item btn btn-neutral">{{ page_name|default:page_number }}</a>
 </li>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -9,5 +9,5 @@ displayed as clickable.
      href="?page={{ page_number }}"
      hx-indicator="#incident-list .htmx-indicator"
      hx-include=".incident-list-param"
-     class="join-item btn btn-neutral">{{ page_name|default:page_number }}</a>
+     class="join-item btn btn-neutral">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
 </li>


### PR DESCRIPTION
## Scope and purpose

Fixes #1252.
Fixes #1287.

Changed the incident list paginator as per poorly documented feedback. In the process, modularized it so it is more easily changed later.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/eb961d47-b003-4d8c-a94a-bcb2d1ecfc79)
![image](https://github.com/user-attachments/assets/24f84188-7256-45f7-bf35-1f5ccc775595)
![image](https://github.com/user-attachments/assets/5d32b8c5-4f90-402d-8336-54317641325f)

After:
![image](https://github.com/user-attachments/assets/b2159e4d-f5a9-42ce-8152-ee348d9be215)
![image](https://github.com/user-attachments/assets/872880ff-b655-4e23-92b7-a4b15491f22e)
![image](https://github.com/user-attachments/assets/41493722-f382-44c5-bca4-450218fe6f15)

Latest:
![image](https://github.com/user-attachments/assets/b98d8ddd-4634-4c7a-8fbb-0f5036638558)


The ellipsis won't show up on a single page or if there are too few pages.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
