### PR TITLE
Use dependency group for dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dynamic = ["version"]
 "Homepage" = "https://github.com/Uninett/Argus"
 
 [project.optional-dependencies]
-docs = ["sphinx>=2.2.0"]
 htmx = [
     "django-htmx",
     "django-widget-tweaks==1.5.0",
@@ -59,19 +58,31 @@ spa = [
     "channels[daphne]>=4.0.0,<5",
     "channels-redis>=4",
 ]
+
+[dependency-groups]
 dev = [
     "django-debug-toolbar",
-    "coverage",
     "django-extensions",
     "ruff",
     "djlint",
     "ipython",
     "pre-commit",
     "python-dotenv",
-    "towncrier",
     "werkzeug",
+    "towncrier",
+    {include-group = "build"},
+    {include-group = "docs"},
+    {include-group = "test"},
+]
+test = [
+    "coverage",
     "tox>=4",
+]
+build = [
     "build",  # for debugging builds/installs
+]
+docs = [
+    "sphinx>=2.2.0",
 ]
 
 [tool.djlint]


### PR DESCRIPTION
## Scope and purpose

This moves dev dependencies out of `[project.optional-dependencies]` and into `[dependency-groups]`. Now we just need to wait for tooling support.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/changed documentation
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
