### PR TITLE
Add divider before logout in user menu dropdown

### DIFF
--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4408,10 +4408,6 @@ details.collapse summary::-webkit-details-marker {
   flex-basis: 20%;
 }
 
-.border-collapse {
-  border-collapse: collapse;
-}
-
 .border-separate {
   border-collapse: separate;
 }
@@ -4749,8 +4745,16 @@ details.collapse summary::-webkit-details-marker {
   padding-bottom: 0.125rem;
 }
 
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
 .pl-8 {
   padding-left: 2rem;
+}
+
+.pr-4 {
+  padding-right: 1rem;
 }
 
 .pt-0 {

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -15,6 +15,9 @@
         <a href="{% url 'admin:index' %}" target="_blank">Admin</a>
       </li>
     {% endif %}
-    <li>{% include "htmx/user/_user_menu_logout.html" %}</li>
+    <li>
+      <div class="divider divider-secondary pl-2 pr-4 my-0"></div>
+      {% include "htmx/user/_user_menu_logout.html" %}
+    </li>
   {% endblock items %}
 </ul>

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -1,7 +1,7 @@
 <ul class="menu menu-md dropdown-content bg-base-200 text-base-content rounded-box z-[1] mt-3 w-52 p-2 shadow max-h-svh">
   <li class="menu-title">
     Logged in as: <span class="text-info">{{ request.user }}</span>
-    <div class="divider divider-secondary my-0"></div>
+    <div class="divider divider-secondary my-0 pointer-events-none"></div>
   </li>
   {% block items %}
     {% block user_preferences_links %}
@@ -16,7 +16,7 @@
       </li>
     {% endif %}
     <li>
-      <div class="divider divider-secondary pl-2 pr-4 my-0"></div>
+      <div class="divider divider-secondary pl-2 pr-4 my-0 pointer-events-none"></div>
       {% include "htmx/user/_user_menu_logout.html" %}
     </li>
   {% endblock items %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1257

Before: 
![image](https://github.com/user-attachments/assets/d5e9da0f-7c5a-46b5-a666-2d72dfd2ec16)

After: 
![image](https://github.com/user-attachments/assets/c73b7fe9-f59b-4e34-baef-2c5491c6200b)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [X] If this results in changes in the UI: Added screenshots of the before and after

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
