### PR TITLE
Group user preferences in user menu dropdown

### DIFF
--- a/changelog.d/1256.changed.md
+++ b/changelog.d/1256.changed.md
@@ -1,0 +1,1 @@
+Grouped user preferences in user menu dropdown

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -4,14 +4,9 @@
     <div class="divider divider-secondary my-0"></div>
   </li>
   {% block items %}
-    <li>{% include "htmx/user/_theme_dropdown.html" %}</li>
-    <li>{% include "htmx/user/_dateformat_dropdown.html" %}</li>
-    {% if request.user.is_staff %}
-      <li>
-        <a href="{% url 'admin:index' %}" target="_blank">Admin</a>
-      </li>
-    {% endif %}
-    <li>{% include "htmx/user/_user_menu_preferences.html" %}</li>
+    {% block user_preferences_links %}
+      {% include "htmx/user/_user_menu_user_preferences.html" %}
+    {% endblock user_preferences_links %}
     {% block notification_links %}
       {% include "htmx/user/_user_menu_notification_config.html" %}
     {% endblock notification_links %}

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -10,6 +10,11 @@
     {% block notification_links %}
       {% include "htmx/user/_user_menu_notification_config.html" %}
     {% endblock notification_links %}
+    {% if request.user.is_staff %}
+      <li>
+        <a href="{% url 'admin:index' %}" target="_blank">Admin</a>
+      </li>
+    {% endif %}
     <li>{% include "htmx/user/_user_menu_logout.html" %}</li>
   {% endblock items %}
 </ul>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_preferences.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_preferences.html
@@ -1,1 +1,0 @@
-<a href="{% url 'htmx:user-preferences' %}">Preferences…</a>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_user_preferences.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_user_preferences.html
@@ -3,11 +3,6 @@
   <ul>
     <li>{% include "htmx/user/_theme_dropdown.html" %}</li>
     <li>{% include "htmx/user/_dateformat_dropdown.html" %}</li>
-    {% if request.user.is_staff %}
-      <li>
-        <a href="{% url 'admin:index' %}" target="_blank">Admin</a>
-      </li>
-    {% endif %}
     <li>
       <a href="{% url 'htmx:user-preferences' %}">More preferences…</a>
     </li>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_user_preferences.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_user_preferences.html
@@ -1,0 +1,15 @@
+<li>
+  <h2 class="menu-title">User preferences</h2>
+  <ul>
+    <li>{% include "htmx/user/_theme_dropdown.html" %}</li>
+    <li>{% include "htmx/user/_dateformat_dropdown.html" %}</li>
+    {% if request.user.is_staff %}
+      <li>
+        <a href="{% url 'admin:index' %}" target="_blank">Admin</a>
+      </li>
+    {% endif %}
+    <li>
+      <a href="{% url 'htmx:user-preferences' %}">More preferences…</a>
+    </li>
+  </ul>
+</li>


### PR DESCRIPTION
## Scope and purpose

Fixes #1256. Dependent on #1345. <!-- Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Before:
![image](https://github.com/user-attachments/assets/bac1f1ca-057b-41a7-b408-dfdfef2d1c18)

After:
![image](https://github.com/user-attachments/assets/a51246fb-1cdb-4666-b0f9-eae014bb8203)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [X] If this results in changes in the UI: Added screenshots of the before and after

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
