### PR TITLE
Make feed sections max height conform to the max height of details section

### DIFF
--- a/changelog.d/1327.fixed.md
+++ b/changelog.d/1327.fixed.md
@@ -1,0 +1,1 @@
+Made the height of the feeds on details page always conform to the max height of the details section. Any vertical overflow in the feed will now be scrollable.

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4126,8 +4126,20 @@ details.collapse summary::-webkit-details-marker {
   position: relative;
 }
 
+.sticky {
+  position: sticky;
+}
+
 .top-5 {
   top: 1.25rem;
+}
+
+.top-0 {
+  top: 0px;
+}
+
+.top-10 {
+  top: 2.5rem;
 }
 
 .z-10 {

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4366,6 +4366,9 @@ details.collapse summary::-webkit-details-marker {
 .basis-1\/5 {
   flex-basis: 20%;
 }
+
+.basis-0 {
+  flex-basis: 0px;
 }
 
 .border-separate {

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -132,9 +132,9 @@
         <section id="acknowledgements"
                  class="flex flex-col basis-1/4 max-w-[30%] card shadow-md">
           <div class="basis-0 grow overflow-y-scroll">
-            <h2 class="card-title pl-8">Acknowledgements</h2>
+            <h2 class="card-title pl-8 sticky top-0">Acknowledgements</h2>
             <div class="card-body gap-4 grow-0">
-              <div class="card-actions grow-0">
+              <div class="card-actions grow-0 sticky top-10">
                 {% include "htmx/incident/_incident_acknowledge_modal.html" with action="ack" dialog_id="create-acknowledgment-dialog" button_title="Create acknowledgment" header="Submit acknowledgment" explanation="Write a message describing why this incident was acknowledged" cancel_text="Cancel" submit_text="Submit" %}
               </div>
               {% for ack in incident.acks %}
@@ -155,9 +155,9 @@
         <section id="events"
                  class="flex flex-col basis-1/4 max-w-[30%] card shadow-md">
           <div class="basis-0 grow overflow-y-scroll overflow-x-auto">
-            <h2 class="card-title pl-8">Related events</h2>
+            <h2 class="card-title pl-8 sticky top-0">Related events</h2>
             <div class="gap-4 card-body flex-none">
-              <div class="card-actions grow-0">
+              <div class="card-actions grow-0 sticky top-10">
                 {% if incident.stateful %}
                   {% if incident.open %}
                     {% include "htmx/incident/_incident_close_modal.html" with action="close" dialog_id="close-incident-dialog" button_title="Close incident" header="Manually close incident" explanation="Write a message describing why the incident was manually closed" cancel_text="Cancel" submit_text="Close now" %}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -129,54 +129,60 @@
             </div>
           </section>
         </section>
-        <section id="acknowledgements" class="basis-1/4 max-w-[30%] card shadow-md">
-          <h2 class="card-title pl-8">Acknowledgements</h2>
-          <div class="card-body gap-4 grow-0">
-            <div class="card-actions grow-0">
-              {% include "htmx/incident/_incident_acknowledge_modal.html" with action="ack" dialog_id="create-acknowledgment-dialog" button_title="Create acknowledgment" header="Submit acknowledgment" explanation="Write a message describing why this incident was acknowledged" cancel_text="Cancel" submit_text="Submit" %}
-            </div>
-            {% for ack in incident.acks %}
-              <div class="px-2 space-y-2">
-                <p class="whitespace-pre-line break-all">{{ ack.event.description }}</p>
-                <p>
-                  {{ ack.event.actor }}
-                  @
-                  {{ ack.event.timestamp|date:preferences.argus_htmx.datetime_format }}
-                </p>
-                {% if ack.expiration %}<p>Expires: {{ ack.expiration|date:preferences.argus_htmx.datetime_format }}</p>{% endif %}
+        <section id="acknowledgements"
+                 class="flex flex-col basis-1/4 max-w-[30%] card shadow-md">
+          <div class="basis-0 grow overflow-y-scroll">
+            <h2 class="card-title pl-8">Acknowledgements</h2>
+            <div class="card-body gap-4 grow-0">
+              <div class="card-actions grow-0">
+                {% include "htmx/incident/_incident_acknowledge_modal.html" with action="ack" dialog_id="create-acknowledgment-dialog" button_title="Create acknowledgment" header="Submit acknowledgment" explanation="Write a message describing why this incident was acknowledged" cancel_text="Cancel" submit_text="Submit" %}
               </div>
-              {% if not forloop.last %}<hr />{% endif %}
-            {% endfor %}
-          </div>
-        </section>
-        <section id="events" class="basis-1/4 max-w-[30%] card shadow-md">
-          <h2 class="card-title pl-8">Related events</h2>
-          <div class="gap-4 card-body flex-none">
-            <div class="card-actions grow-0">
-              {% if incident.stateful %}
-                {% if incident.open %}
-                  {% include "htmx/incident/_incident_close_modal.html" with action="close" dialog_id="close-incident-dialog" button_title="Close incident" header="Manually close incident" explanation="Write a message describing why the incident was manually closed" cancel_text="Cancel" submit_text="Close now" %}
-                {% else %}
-                  {% include "htmx/incident/_incident_reopen_modal.html" with action="reopen" dialog_id="reopen-incident-dialog" button_title="Reopen incident" header="Manually reopen incident" explanation="Write a message describing why the incident was manually reopend" cancel_text="Cancel" submit_text="Reopen now" %}
-                {% endif %}
-              {% endif %}
-            </div>
-            {% for event in incident.events.all %}
-              {% if not event.ack %}
+              {% for ack in incident.acks %}
                 <div class="px-2 space-y-2">
+                  <p class="whitespace-pre-line break-all">{{ ack.event.description }}</p>
                   <p>
-                    <strong>{{ event.get_type_display }}</strong>
-                  </p>
-                  <p class="whitespace-pre-line break-all">{{ event.description }}</p>
-                  <p>
-                    {{ event.actor }}
+                    {{ ack.event.actor }}
                     @
-                    {{ event.timestamp|date:preferences.argus_htmx.datetime_format }}
+                    {{ ack.event.timestamp|date:preferences.argus_htmx.datetime_format }}
                   </p>
+                  {% if ack.expiration %}<p>Expires: {{ ack.expiration|date:preferences.argus_htmx.datetime_format }}</p>{% endif %}
                 </div>
                 {% if not forloop.last %}<hr />{% endif %}
-              {% endif %}
-            {% endfor %}
+              {% endfor %}
+            </div>
+          </div>
+        </section>
+        <section id="events"
+                 class="flex flex-col basis-1/4 max-w-[30%] card shadow-md">
+          <div class="basis-0 grow overflow-y-scroll overflow-x-auto">
+            <h2 class="card-title pl-8">Related events</h2>
+            <div class="gap-4 card-body flex-none">
+              <div class="card-actions grow-0">
+                {% if incident.stateful %}
+                  {% if incident.open %}
+                    {% include "htmx/incident/_incident_close_modal.html" with action="close" dialog_id="close-incident-dialog" button_title="Close incident" header="Manually close incident" explanation="Write a message describing why the incident was manually closed" cancel_text="Cancel" submit_text="Close now" %}
+                  {% else %}
+                    {% include "htmx/incident/_incident_reopen_modal.html" with action="reopen" dialog_id="reopen-incident-dialog" button_title="Reopen incident" header="Manually reopen incident" explanation="Write a message describing why the incident was manually reopend" cancel_text="Cancel" submit_text="Reopen now" %}
+                  {% endif %}
+                {% endif %}
+              </div>
+              {% for event in incident.events.all %}
+                {% if not event.ack %}
+                  <div class="px-2 space-y-2">
+                    <p>
+                      <strong>{{ event.get_type_display }}</strong>
+                    </p>
+                    <p class="whitespace-pre-line break-all">{{ event.description }}</p>
+                    <p>
+                      {{ event.actor }}
+                      @
+                      {{ event.timestamp|date:preferences.argus_htmx.datetime_format }}
+                    </p>
+                  </div>
+                  {% if not forloop.last %}<hr />{% endif %}
+                {% endif %}
+              {% endfor %}
+            </div>
           </div>
         </section>
       </div>

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -154,7 +154,7 @@
         </section>
         <section id="events"
                  class="flex flex-col basis-1/4 max-w-[30%] card shadow-md">
-          <div class="basis-0 grow overflow-y-scroll overflow-x-auto">
+          <div class="basis-0 grow overflow-y-scroll">
             <h2 class="card-title pl-8 sticky top-0">Related events</h2>
             <div class="gap-4 card-body flex-none">
               <div class="card-actions grow-0 sticky top-10">


### PR DESCRIPTION
## Scope and purpose

Fixes #1327 with a UX touch of making feed title and action buttons always showing when scrolling.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
    * Before (zoomed out):
       <img width="1512" alt="Screenshot 2025-04-03 at 13 54 01" src="https://github.com/user-attachments/assets/9aa4d58c-0ea3-4032-a681-e0155d1ef30a" />
    * After (zoomed out):
       <img width="1512" alt="Screenshot 2025-04-03 at 14 16 20" src="https://github.com/user-attachments/assets/a1368232-8c6f-4e93-9168-77e6f6d3f458" />

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
