### PR TITLE
Make delete modal

### DIFF
--- a/changelog.d/+make-delete-modal.changed.md
+++ b/changelog.d/+make-delete-modal.changed.md
@@ -1,0 +1,1 @@
+Make an abstraction for modals deleting things, as part of the modal cleanup.

--- a/src/argus/htmx/modals.py
+++ b/src/argus/htmx/modals.py
@@ -32,3 +32,8 @@ class Modal(RenderableMixin, BaseModel):
 
 class ConfirmationModal(Modal):
     pass
+
+
+class DeleteModal(ConfirmationModal):
+    button_title: str = "Delete"
+    submit_text: str = "Delete"

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -13,7 +13,7 @@ from django.views.generic import CreateView, DeleteView, DetailView, ListView, U
 from argus.htmx.request import HtmxHttpRequest
 from argus.htmx.widgets import DropdownMultiSelect
 from argus.notificationprofile.media import MEDIA_CLASSES_DICT
-from argus.htmx.modals import ConfirmationModal
+from argus.htmx.modals import DeleteModal
 from argus.notificationprofile.models import NotificationProfile, Timeslot, Filter, DestinationConfig
 
 
@@ -21,12 +21,6 @@ class NoColonMixin:
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("label_suffix", "")
         super().__init__(*args, **kwargs)
-
-
-class DeleteModal(ConfirmationModal):
-    button_title: str = "Delete"
-    header: str = "Delete notification profile"
-    submit_text: str = "Delete"
 
 
 class DestinationFieldMixin:
@@ -240,6 +234,7 @@ class NotificationProfileListView(NotificationProfileMixin, ListView):
         for obj in self.get_queryset():
             form = NotificationProfileForm(None, prefix=f"npf{obj.pk}", user=self.request.user, instance=obj)
             form.modal = DeleteModal(
+                header="Delete notification profile",
                 explanation=f'Delete the notification profile "{obj}"?',
                 dialog_id=f"delete-modal-{obj.pk}",
                 endpoint=reverse("htmx:notificationprofile-delete", kwargs={"pk": obj.pk}),

--- a/src/argus/htmx/templates/htmx/_base_form_modal_experimental.html
+++ b/src/argus/htmx/templates/htmx/_base_form_modal_experimental.html
@@ -15,7 +15,7 @@
             {% endblock form_control %}>
         {% csrf_token %}
         <fieldset class="menu menu-vertical gap-4">
-          <legend class="antialiased text-base font-bold py-2">{{ modal.explanation }}</legend>
+          <legend class="antialiased text-base font-bold py-2 break-all">{{ modal.explanation }}</legend>
         </fieldset>
       </form>
       <div class="modal-action card-actions">

--- a/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
+++ b/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
@@ -13,7 +13,7 @@
         <div class="card-actions flex items-end">
           {% if form.instance.pk %}
             <input type="submit" class="btn btn-primary" value="Save">
-            {% include "htmx/timeslot/_delete_timeslot_confirm_dialog.html" with item_class="btn btn-primary text-start" dialog_id="timeslot-delete-confirm" item_title=form.instance.name modal_button_name="Delete timeslot" action="Delete timeslot" item_id=form.instance.pk confirmation_message="Are you sure you want to delete this timeslot?" %}
+            {% include form.modal.template_name with modal=form.modal %}
           {% else %}
             <input type="submit" class="btn btn-primary" value="Create">
           {% endif %}

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -9,6 +9,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 
+from argus.htmx.modals import DeleteModal
 from argus.htmx.widgets import BadgeDropdownMultiSelect
 from argus.notificationprofile.models import Timeslot, TimeRecurrence
 
@@ -216,6 +217,13 @@ class TimeslotListView(TimeslotMixin, ListView):
         forms = []
         for obj in self.get_queryset():
             form = TimeslotForm(None, instance=obj, prefix=self._get_prefix(obj.pk))
+            form.modal = DeleteModal(
+                header="Delete timeslot",
+                button_title="Delete timeslot",
+                explanation=f'Delete the timeslot "{obj}"?',
+                dialog_id=f"timeslot-delete-confirm-{obj.pk}",
+                endpoint=reverse("htmx:timeslot-delete", kwargs={"pk": obj.pk}),
+            )
             formset = make_timerecurrence_formset(timeslot=obj)
             forms.append({"form": form, "formset": formset})
         context["form_list"] = forms


### PR DESCRIPTION
.. and use it for profiles, timeslots

## Scope and purpose

Fixes #1354 by accident

Part of the big modal cleanup part 1: confirmation dialogs

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
