### PR TITLE
add logout modal button to global context

### DIFF
--- a/src/argus/htmx/appconfig.py
+++ b/src/argus/htmx/appconfig.py
@@ -36,6 +36,7 @@ _app_settings = [
         "context_processors": [
             "argus.auth.context_processors.preferences",
             "argus.htmx.context_processors.static_paths",
+            "argus.htmx.user.context_processors.logout_context",
         ],
         "middleware": {
             "argus.htmx.middleware.LoginRequiredMiddleware": "end",

--- a/src/argus/htmx/templates/htmx/user/_user_menu_logout.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_logout.html
@@ -1,3 +1,4 @@
+{% include logout_modal.template_name with modal=logout_modal %}
 <form class="flex" action="{% url "htmx:logout" %}" method="post">
   {% csrf_token %}
   <button class="flex-1 text-start" type="submit">Log out</button>

--- a/src/argus/htmx/user/context_processors.py
+++ b/src/argus/htmx/user/context_processors.py
@@ -1,0 +1,21 @@
+"""
+How to use:
+
+Append the "context_processors" list for the TEMPLATES-backend
+``django.template.backends.django.DjangoTemplates`` with the full dotted path.
+
+See django settings for ``TEMPLATES``.
+"""
+
+from django.urls import reverse
+
+from .views import LogoutModal
+
+
+def logout_context(request):
+    return {
+        "logout_modal": LogoutModal(
+            endpoint=reverse("htmx:logout"),
+            dialog_id="logout-dialog",
+        ),
+    }

--- a/src/argus/htmx/user/views.py
+++ b/src/argus/htmx/user/views.py
@@ -6,6 +6,14 @@ from django_htmx.http import HttpResponseClientRefresh
 
 from argus.auth.utils import get_preference_obj, save_preferences
 from argus.htmx.incident.views import HtmxHttpRequest
+from argus.htmx.modals import ConfirmationModal
+
+
+class LogoutModal(ConfirmationModal):
+    header: str = "Log out"
+    submit_text: str = header
+    button_title: str = header
+    explanation: str = "Log out of Argus?"
 
 
 @require_GET


### PR DESCRIPTION
## Scope and purpose

Fixes #1352

This is an attempt at making a *component*. The goal is that the same template works everywhere and that any dialog-specific changes are in python.

Currently this *adds* a log out button in addition to the link, since we need to figure out what things should look like.

Should the button be moved up to be next to the username? Should it look like a button?
![image](https://github.com/user-attachments/assets/c0d90894-dc5d-413b-90b9-e9cca1236702)

How to fix the dialog so that it has no scroll bar and is centered?
![image](https://github.com/user-attachments/assets/acb505da-44d9-4370-8ebc-af28ca809b99)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
