### PR TITLE
Make table footer styles more blended in

### DIFF
--- a/changelog.d/1363.changed.md
+++ b/changelog.d/1363.changed.md
@@ -1,0 +1,1 @@
+Made styling of the elements in the footer more blended in.

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -2168,10 +2168,6 @@ input.tab:checked + .tab-content,
   .btn-secondary {
     --btn-color: var(--fallback-s);
   }
-
-  .btn-neutral {
-    --btn-color: var(--fallback-n);
-  }
 }
 
 @supports (color: color-mix(in oklab, black, black)) {
@@ -2244,22 +2240,12 @@ input.tab:checked + .tab-content,
   .btn-secondary {
     --btn-color: var(--s);
   }
-
-  .btn-neutral {
-    --btn-color: var(--n);
-  }
 }
 
 .btn-secondary {
   --tw-text-opacity: 1;
   color: var(--fallback-sc,oklch(var(--sc)/var(--tw-text-opacity)));
   outline-color: var(--fallback-s,oklch(var(--s)/1));
-}
-
-.btn-neutral {
-  --tw-text-opacity: 1;
-  color: var(--fallback-nc,oklch(var(--nc)/var(--tw-text-opacity)));
-  outline-color: var(--fallback-n,oklch(var(--n)/1));
 }
 
 .btn.glass {

--- a/src/argus/htmx/templates/htmx/incident/_incident_list_refresh_info.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_list_refresh_info.html
@@ -1,21 +1,21 @@
 {% load argus_htmx %}
 <div id="table-refresh-info">
-  <dl class="stats stats-horizontal shadow leading-none overflow-x-auto font-medium bg-neutral text-neutral-content">
+  <dl class="stats stats-horizontal leading-none overflow-x-auto font-medium bg-base-100">
     <div class="stat py-2">
-      <dt class="stat-title text-neutral-content/80">Total, all time</dt>
-      <dd class="stat-value text-base">
+      <dt class="stat-title text-inherit/80">Total, all time</dt>
+      <dd class="stat-value text-base font-medium">
         {{ count }}
       </dd>
     </div>
     <div class="stat py-2">
-      <dt class="stat-title text-neutral-content/80">After filtering</dt>
-      <dd class="stat-value text-base">
+      <dt class="stat-title text-inherit/80">After filtering</dt>
+      <dd class="stat-value text-base font-medium">
         {{ filtered_count }}
       </dd>
     </div>
     <div class="stat py-2">
-      <dt class="stat-title text-neutral-content/80">Per page</dt>
-      <dd class="stat-value text-base">
+      <dt class="stat-title text-inherit/80">Per page</dt>
+      <dd class="stat-value text-base font-medium">
         <select class="select select-xs bg-transparent text-base border-none -ml-2 incident-list-param"
                 name="page_size"
                 hx-get="{% url 'htmx:incident-list' %}"
@@ -34,14 +34,14 @@
       </dd>
     </div>
     <div class="stat py-2">
-      <dt class="stat-title text-neutral-content/80">Last refreshed</dt>
-      <dd class="stat-value text-base">
+      <dt class="stat-title text-inherit/80">Last refreshed</dt>
+      <dd class="stat-value text-base font-medium">
         {{ last_refreshed|date:preferences.argus_htmx.datetime_format|default:"?" }}
       </dd>
     </div>
     <div class="stat py-2">
-      <dt class="stat-title text-neutral-content/80">Updating every</dt>
-      <dd class="stat-value text-base">
+      <dt class="stat-title text-inherit/80">Updating every</dt>
+      <dd class="stat-value text-base font-medium">
         <select class="select select-xs bg-transparent text-base border-none -ml-2"
                 name="update_interval"
                 hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"

--- a/src/argus/htmx/templates/htmx/incident/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table.html
@@ -48,7 +48,7 @@
           {% else %}
             <ul class="join">
               <li>
-                <button class="btn btn-active">1</button>
+                <button class="btn btn-sm btn-active">1</button>
               </li>
             </ul>
           {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table.html
@@ -48,7 +48,7 @@
           {% else %}
             <ul class="join">
               <li>
-                <button class="btn btn-active btn-neutral">1</button>
+                <button class="btn btn-active">1</button>
               </li>
             </ul>
           {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table.html
@@ -43,15 +43,7 @@
           {% block refresh_info %}
             {% include "htmx/incident/_incident_list_refresh_info.html" %}
           {% endblock refresh_info %}
-          {% if page.paginator.num_pages > 1 %}
-            {% include "./_incident_table_paginator.html" %}
-          {% else %}
-            <ul class="join">
-              <li>
-                <button class="btn btn-sm btn-active">1</button>
-              </li>
-            </ul>
-          {% endif %}
+          {% include "./_incident_table_paginator.html" %}
         </div>
       </td>
     </tr>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -15,7 +15,7 @@ the backwards/forwards buttons to navigate these subpages.
       {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_prefix="« " page_name="1" %}
       {% if page.number > 3 %}
         <li>
-          <button class="join-item btn btn-sm pointer-events-none">…</button>
+          <button class="join-item btn pointer-events-none">…</button>
         </li>
       {% endif %}
     {% endif %}
@@ -23,7 +23,7 @@ the backwards/forwards buttons to navigate these subpages.
       {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number page_prefix="‹ " page_name=page.previous_page_number %}
     {% endif %}
     <li>
-      <button class="join-item btn btn-sm btn-active pointer-events-none">{{ page.number }}</button>
+      <button class="join-item btn btn-active pointer-events-none">{{ page.number }}</button>
     </li>
     {% if page.has_next and page.number != second_to_last_page %}
       {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
@@ -31,7 +31,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% if page.number != last_page_num %}
       {% if page.next_page_number < second_to_last_page %}
         <li>
-          <button class="join-item btn btn-sm pointer-events-none">…</button>
+          <button class="join-item btn pointer-events-none">…</button>
         </li>
       {% endif %}
       {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name=last_page_number page_suffix=" »" %}
@@ -40,7 +40,7 @@ the backwards/forwards buttons to navigate these subpages.
 {% else %}
   <ul class="join">
     <li>
-      <button class="btn btn-sm btn-active">1</button>
+      <button class="btn btn-active">1</button>
     </li>
   </ul>
 {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -6,33 +6,41 @@ target, i.e. replacing the target's actual DOM node. hx-push-url tells
 htmx to push the fetched URL into the browser history, so we can use
 the backwards/forwards buttons to navigate these subpages.
 -->
-<ul class="join"
-    hx-target="#table"
-    hx-swap="outerHTML"
-    hx-push-url="true">
-  {% if page.number != 1 %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_prefix="« " page_name="1" %}
-    {% if page.number > 3 %}
-      <li>
-        <button class="join-item btn btn-sm pointer-events-none">…</button>
-      </li>
+{% if page.paginator.num_pages > 1 %}
+  <ul class="join"
+      hx-target="#table"
+      hx-swap="outerHTML"
+      hx-push-url="true">
+    {% if page.number != 1 %}
+      {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_prefix="« " page_name="1" %}
+      {% if page.number > 3 %}
+        <li>
+          <button class="join-item btn btn-sm pointer-events-none">…</button>
+        </li>
+      {% endif %}
     {% endif %}
-  {% endif %}
-  {% if page.has_previous and page.number != 2 %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number page_prefix="‹ " page_name=page.previous_page_number %}
-  {% endif %}
-  <li>
-    <button class="join-item btn btn-sm btn-active pointer-events-none">{{ page.number }}</button>
-  </li>
-  {% if page.has_next and page.number != second_to_last_page %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
-  {% endif %}
-  {% if page.number != last_page_num %}
-    {% if page.next_page_number < second_to_last_page %}
-      <li>
-        <button class="join-item btn btn-sm pointer-events-none">…</button>
-      </li>
+    {% if page.has_previous and page.number != 2 %}
+      {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number page_prefix="‹ " page_name=page.previous_page_number %}
     {% endif %}
-    {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name=last_page_number page_suffix=" »" %}
-  {% endif %}
-</ul>
+    <li>
+      <button class="join-item btn btn-sm btn-active pointer-events-none">{{ page.number }}</button>
+    </li>
+    {% if page.has_next and page.number != second_to_last_page %}
+      {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
+    {% endif %}
+    {% if page.number != last_page_num %}
+      {% if page.next_page_number < second_to_last_page %}
+        <li>
+          <button class="join-item btn btn-sm pointer-events-none">…</button>
+        </li>
+      {% endif %}
+      {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name=last_page_number page_suffix=" »" %}
+    {% endif %}
+  </ul>
+{% else %}
+  <ul class="join">
+    <li>
+      <button class="btn btn-sm btn-active">1</button>
+    </li>
+  </ul>
+{% endif %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -14,7 +14,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_prefix="« " page_name="1" %}
     {% if page.number > 3 %}
       <li>
-        <button class="join-item btn pointer-events-none">…</button>
+        <button class="join-item btn btn-sm pointer-events-none">…</button>
       </li>
     {% endif %}
   {% endif %}
@@ -22,7 +22,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number page_prefix="‹ " page_name=page.previous_page_number %}
   {% endif %}
   <li>
-    <button class="join-item btn btn-active pointer-events-none">{{ page.number }}</button>
+    <button class="join-item btn btn-sm btn-active pointer-events-none">{{ page.number }}</button>
   </li>
   {% if page.has_next and page.number != second_to_last_page %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
@@ -30,7 +30,7 @@ the backwards/forwards buttons to navigate these subpages.
   {% if page.number != last_page_num %}
     {% if page.next_page_number < second_to_last_page %}
       <li>
-        <button class="join-item btn pointer-events-none">…</button>
+        <button class="join-item btn btn-sm pointer-events-none">…</button>
       </li>
     {% endif %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name=last_page_number page_suffix=" »" %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator.html
@@ -14,7 +14,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% include "./_incident_table_paginator_pageitem.html" with page_number=1 page_prefix="« " page_name="1" %}
     {% if page.number > 3 %}
       <li>
-        <button class="join-item btn btn-neutral pointer-events-none">…</button>
+        <button class="join-item btn pointer-events-none">…</button>
       </li>
     {% endif %}
   {% endif %}
@@ -22,7 +22,7 @@ the backwards/forwards buttons to navigate these subpages.
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.previous_page_number page_prefix="‹ " page_name=page.previous_page_number %}
   {% endif %}
   <li>
-    <button class="join-item btn btn-active btn-neutral pointer-events-none">{{ page.number }}</button>
+    <button class="join-item btn btn-active pointer-events-none">{{ page.number }}</button>
   </li>
   {% if page.has_next and page.number != second_to_last_page %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=page.next_page_number page_suffix=" ›" %}
@@ -30,7 +30,7 @@ the backwards/forwards buttons to navigate these subpages.
   {% if page.number != last_page_num %}
     {% if page.next_page_number < second_to_last_page %}
       <li>
-        <button class="join-item btn btn-neutral pointer-events-none">…</button>
+        <button class="join-item btn pointer-events-none">…</button>
       </li>
     {% endif %}
     {% include "./_incident_table_paginator_pageitem.html" with page_number=last_page_num page_name=last_page_number page_suffix=" »" %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -9,5 +9,5 @@ displayed as clickable.
      href="?page={{ page_number }}"
      hx-indicator="#incident-list .htmx-indicator"
      hx-include=".incident-list-param"
-     class="join-item btn">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
+     class="join-item btn btn-sm">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
 </li>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -9,5 +9,5 @@ displayed as clickable.
      href="?page={{ page_number }}"
      hx-indicator="#incident-list .htmx-indicator"
      hx-include=".incident-list-param"
-     class="join-item btn btn-neutral">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
+     class="join-item btn">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
 </li>

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -9,5 +9,5 @@ displayed as clickable.
      href="?page={{ page_number }}"
      hx-indicator="#incident-list .htmx-indicator"
      hx-include=".incident-list-param"
-     class="join-item btn btn-sm">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
+     class="join-item btn">{{ page_prefix }}{{ page_name|default:page_number }}{{ page_suffix }}</a>
 </li>


### PR DESCRIPTION
## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
    * Before:
       <img width="1512" alt="Screenshot 2025-04-07 at 14 59 11" src="https://github.com/user-attachments/assets/025bb546-06b3-407f-921c-f802db5ffb7e" />
    * After (option 1: base colors, small buttons):
       <img width="1512" alt="Screenshot 2025-04-07 at 14 59 47" src="https://github.com/user-attachments/assets/9e8b0d2b-06ef-47aa-9b2b-a66da051b10d" />
    * After (option 2: base stats, medium buttons):
       <img width="1512" alt="Screenshot 2025-04-08 at 09 17 19" src="https://github.com/user-attachments/assets/06d6065e-87e2-4d26-a7ab-7c5cb1355907" />
    * After (option 3: base colors stats only):
       <img width="1512" alt="Screenshot 2025-04-08 at 09 18 08" src="https://github.com/user-attachments/assets/95d91a9d-3b53-4a10-8ab8-b57aaeb18e71" />

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
