### PR TITLE
Fix days field by simplifying

### DIFF
--- a/changelog.d/+simplify-days-field.changed.md
+++ b/changelog.d/+simplify-days-field.changed.md
@@ -1,0 +1,1 @@
+Replaced the fancy days selector in the timeslots page with checkboxes.

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4474,6 +4474,10 @@ details.collapse summary::-webkit-details-marker {
   gap: 0.125rem;
 }
 
+.gap-1 {
+  gap: 0.25rem;
+}
+
 .gap-16 {
   gap: 4rem;
 }

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4408,6 +4408,10 @@ details.collapse summary::-webkit-details-marker {
   flex-basis: 20%;
 }
 
+.border-collapse {
+  border-collapse: collapse;
+}
+
 .border-separate {
   border-collapse: separate;
 }

--- a/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
+++ b/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
@@ -7,5 +7,6 @@
          {% endif %}
          {% endfor %}
          class="checkbox checkbox-sm checkbox-primary border">
-  <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>
+  <label class="label cursor-pointer"
+         {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>
 </span>

--- a/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
+++ b/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
@@ -1,0 +1,9 @@
+<input type="checkbox"
+       name="{{ widget.name }}"
+       {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
+       {% for name, value in widget.attrs.items %}{% if name != "class" %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}
+       {% endif %}
+       {% endif %}
+       {% endfor %}
+       class="checkbox checkbox-sm checkbox-primary border">
+<label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>

--- a/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
+++ b/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
@@ -1,9 +1,11 @@
-<input type="checkbox"
-       name="{{ widget.name }}"
-       {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
-       {% for name, value in widget.attrs.items %}{% if name != "class" %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}
-       {% endif %}
-       {% endif %}
-       {% endfor %}
-       class="checkbox checkbox-sm checkbox-primary border">
-<label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>
+<span class="flex flex-nowrap items-center gap-2">
+  <input type="checkbox"
+         name="{{ widget.name }}"
+         {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
+         {% for name, value in widget.attrs.items %}{% if name != "class" %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}
+         {% endif %}
+         {% endif %}
+         {% endfor %}
+         class="checkbox checkbox-sm checkbox-primary border">
+  <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>
+</span>

--- a/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
+++ b/src/argus/htmx/templates/htmx/timeslot/checkbox_option.html
@@ -1,4 +1,4 @@
-<span class="flex flex-nowrap items-center gap-2">
+<span class="flex flex-nowrap items-center gap-1">
   <input type="checkbox"
          name="{{ widget.name }}"
          {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -10,7 +10,6 @@ from django.urls import reverse
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 
 from argus.htmx.modals import DeleteModal
-from argus.htmx.widgets import BadgeDropdownMultiSelect
 from argus.notificationprofile.models import Timeslot, TimeRecurrence
 
 
@@ -18,6 +17,9 @@ LOG = logging.getLogger(__name__)
 
 
 class DaysMultipleChoiceField(forms.MultipleChoiceField):
+    widget = forms.CheckboxSelectMultiple
+    widget.option_template_name = "htmx/timeslot/checkbox_option.html"
+
     def to_python(self, value):
         value = super().to_python(value)
         return [int(day) for day in value]
@@ -50,21 +52,7 @@ class TimeRecurrenceForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.instance.id:
-            partial_get = reverse(
-                "htmx:timeslot-update",
-                kwargs={"pk": self.instance.timeslot.id},
-            )
-        else:
-            partial_get = reverse("htmx:timeslot-create")
-
-        self.fields["days"].widget = BadgeDropdownMultiSelect(
-            partial_get=partial_get,
-            attrs={
-                "placeholder": "select days...",
-                "field_styles": "input input-bordered border-b max-w-full justify-center",
-            },
-        )
+        self.fields["days"].widget.attrs["class"] = "flex flex-row justify-between"
         self.fields["days"].choices = TimeRecurrence.Day.choices
 
     def clean_start(self):

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -52,7 +52,7 @@ class TimeRecurrenceForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["days"].widget.attrs["class"] = "flex flex-row justify-between"
+        self.fields["days"].widget.attrs["class"] = "flex flex-row flex-wrap justify-between gap-2"
         self.fields["days"].choices = TimeRecurrence.Day.choices
 
     def clean_start(self):


### PR DESCRIPTION
## Scope and purpose

Continuation of #1276

Makes the days-field robust, simple, snappy, happy, and working.

Also reduces amount of needed clicks by one and increases ARIA score.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/6c8ec712-42d2-4679-8376-82956dfc1e45)

After:
![image](https://github.com/user-attachments/assets/4f14ec1f-26be-46b2-8f85-7edaa688aee5)


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
