### PR TITLE
Use neutral-content as temporary fix for tag badges contrast problems

### DIFF
--- a/changelog.d/1375.fixed.md
+++ b/changelog.d/1375.fixed.md
@@ -1,0 +1,1 @@
+Fixed color contrast for incident tags badges (temporary fix)

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -35,7 +35,7 @@
             <h2 class="card-title pl-8">Tags</h2>
             <p class="card-body flex-row flex-wrap gap-0.5">
               {% for tag in incident.deprecated_tags %}
-                <span class="badge badge-content badge-outline  h-auto text-wrap break-all text-center text-xs">
+                <span class="badge badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
                   {# djlint:off #}
                   {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
                   {# djlint:on #}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -35,7 +35,7 @@
             <h2 class="card-title pl-8">Tags</h2>
             <p class="card-body flex-row flex-wrap gap-0.5">
               {% for tag in incident.deprecated_tags %}
-                <span class="badge badge-neutral badge-outline  h-auto text-wrap break-all text-center text-xs">
+                <span class="badge badge-content badge-outline  h-auto text-wrap break-all text-center text-xs">
                   {# djlint:off #}
                   {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
                   {# djlint:on #}


### PR DESCRIPTION
## Scope and purpose

Temporary fix for part of #1386

Changes the colors for tag badges to neutral-content which will contrast well against the background, but isnt a perfect fix. We will probably need custom colors this on a per-theme basis for it to be perfect.

The problem was that the tags very pretty much unreadable in dark theme, so that has the biggest change. Argus theme goes from blue to black (Which might be a good thing? we did change from the colorful primary/secondary at some point). Light theme is pretty much unchanged so I didnt include images for that

Argus theme

Before:
![image](https://github.com/user-attachments/assets/1418790a-ad02-4241-94e4-ffdf735c5d6f)

After:
![image](https://github.com/user-attachments/assets/a8ea7839-10c2-4109-b3e2-dabeffdb0ac0)

Dark theme:

Before:
![image](https://github.com/user-attachments/assets/da222c5f-1f30-4be9-a770-bf10767f1097)

After:
![image](https://github.com/user-attachments/assets/8e4c367d-c5ca-49e2-86ae-8aa4722cc465)



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
