### PR TITLE
Use neutral-content as temporary fix for table separator contrast problems

### DIFF
--- a/changelog.d/1376.fixed.md
+++ b/changelog.d/1376.fixed.md
@@ -1,0 +1,1 @@
+Fixed color contrast for table separators (temporary fix)

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_cell_wrapper_default.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_cell_wrapper_default.html
@@ -1,4 +1,4 @@
-<td class="border-b-1 border-base-200 group-last:border-b-0">
+<td class="border-b-1 border-neutral-content group-last:border-b-0">
   {% if column.cell_template %}
     {% include column.cell_template %}
   {% else %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_cell_wrapper_link_to_details.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_cell_wrapper_link_to_details.html
@@ -1,4 +1,4 @@
-<td class="border-b-1 border-base-200 group-last:border-b-0">
+<td class="border-b-1 border-neutral-content group-last:border-b-0">
   <a class="block" href="{% url 'htmx:incident-detail' pk=incident.pk %}">
     {% if column.cell_template %}
       {% include column.cell_template %}


### PR DESCRIPTION
## Scope and purpose

Temporary fix for part of #1386 and #1321. 

Changes the colors for separators to neutral-content which will contrast well against the background, but isnt a perfect fix. We will probably need custom colors for this on a per-theme basis for it to be perfect.

<!-- remove things that do not apply -->
### This pull request
* adds/changes/removes a dependency
* changes the database
* changes the API <!-- Ensure that v1 is backwards compatible, v2 can be changing things -->


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
