### PR TITLE
Use `gap` instead of `px` between severity levels in range selector

### DIFF
--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -4470,6 +4470,10 @@ details.collapse summary::-webkit-details-marker {
   justify-content: space-between;
 }
 
+.justify-around {
+  justify-content: space-around;
+}
+
 .gap-0\.5 {
   gap: 0.125rem;
 }

--- a/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
@@ -58,7 +58,7 @@
                 {% elif field.name == "maxlevel" %}
                   <div class="pt-4">
                     {{ field|add_class:"range range-primary range-xs" }}
-                    <div class="flex w-full justify-between px-2 text-xs">
+                    <div class="flex w-full justify-around gap-2 text-xs">
                       {% for tick in "12345" %}<span>{{ tick }}</span>{% endfor %}
                     </div>
                   </div>


### PR DESCRIPTION
## Scope and purpose

Fixes #1369. Works as a good fallback on small screens


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
