### PR TITLE
Center header text on incident details page

### DIFF
--- a/changelog.d/1298.fixed.md
+++ b/changelog.d/1298.fixed.md
@@ -1,0 +1,1 @@
+Center header text on incident details page

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -3,7 +3,7 @@
 {% block main %}
   <div class="flex flex-col items-center gap-4 m-4">
     {% block incident_detail %}
-      <h1 class="text-xl font-bold">{{ incident.pk }}: {{ incident.description }}</h1>
+      <h1 class="text-xl font-bold text-center">{{ incident.pk }}: {{ incident.description }}</h1>
       <div class="flex gap-4 justify-center">
         <section id="incident-detail"
                  class="flex flex-col gap-4 basis-1/4 shrink-0 max-w-[30%]">


### PR DESCRIPTION
## Scope and purpose

Fixes #1298.

Before:
![image](https://github.com/user-attachments/assets/1c23a112-9cde-4d13-b9b9-246dddf2af2b)

After:
![image](https://github.com/user-attachments/assets/df200bf5-fe86-4a8c-a84b-d08076b21dec)


## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [X] If this results in changes in the UI: Added screenshots of the before and after
