### PR TITLE
Make incident duration more human readable

### DIFF
--- a/changelog.d/1196.fixed.md
+++ b/changelog.d/1196.fixed.md
@@ -1,0 +1,1 @@
+Make incident duration on details page more human readable

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -63,14 +63,6 @@ def prefetch_incident_daughters():
 @require_GET
 def incident_detail(request, pk: int):
     incident = get_object_or_404(Incident, id=pk)
-    duration = None
-    now = tznow()
-    if incident.end_time:
-        if incident.end_time <= now:
-            duration = incident.end_time - incident.start_time
-        else:
-            duration = now - incident.start_time
-    incident.duration = duration
     context = {
         "incident": incident,
         "page_title": str(incident),

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -64,7 +64,7 @@
                   </section>
                   <section>
                     <h3 class="font-bold">Current duration</h3>
-                    <p>{{ incident.duration }}</p>
+                    <p>{{ incident.start_time|timesince }}</p>
                   </section>
                 {% else %}
                   <section>
@@ -75,7 +75,7 @@
                   </section>
                   <section>
                     <h3 class="font-bold">Total duration</h3>
-                    <p>{{ incident.duration }}</p>
+                    <p>{{ incident.start_time|timesince:incident.end_time }}</p>
                   </section>
                 {% endif %}
               {% else %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1196. It does not influence stateless incidents, I've checked. 

For open incidents:
Before:
![image](https://github.com/user-attachments/assets/76a836f1-ccea-4343-bcb7-7ec3717f36e6)

After:
![image](https://github.com/user-attachments/assets/126e4fa9-2ac8-4a81-ab77-bc122da1deec)

For closed incidents:
Before:
![image](https://github.com/user-attachments/assets/626a9711-993b-4aae-892e-0842e3cd0b9c)

After:
![image](https://github.com/user-attachments/assets/02eba2b3-2d59-4b94-89dd-6ebb574245f4)

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [X] If this results in changes in the UI: Added screenshots of the before and after
