### PR TITLE
Add font-awesome icon pack as a dependency

### DIFF
--- a/changelog.d/1389.added.md
+++ b/changelog.d/1389.added.md
@@ -1,0 +1,1 @@
+Add font-awesome icon pack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ docs = ["sphinx>=2.2.0"]
 htmx = [
     "django-htmx",
     "django-widget-tweaks==1.5.0",
+    "fontawesomefree~=6.6",
     "social-auth-core>=4.1",
     "social-auth-app-django>=5.0",
 ]

--- a/requirements-django42.txt
+++ b/requirements-django42.txt
@@ -103,6 +103,8 @@ factory-boy==3.3.3
     # via argus-server (pyproject.toml)
 faker==37.1.0
     # via factory-boy
+fontawesomefree==6.6.0
+    # via argus-server (pyproject.toml)
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7

--- a/requirements-django50.txt
+++ b/requirements-django50.txt
@@ -103,6 +103,8 @@ factory-boy==3.3.3
     # via argus-server (pyproject.toml)
 faker==37.1.0
     # via factory-boy
+fontawesomefree==6.6.0
+    # via argus-server (pyproject.toml)
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7

--- a/requirements-django51.txt
+++ b/requirements-django51.txt
@@ -103,6 +103,8 @@ factory-boy==3.3.3
     # via argus-server (pyproject.toml)
 faker==37.1.0
     # via factory-boy
+fontawesomefree==6.6.0
+    # via argus-server (pyproject.toml)
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7

--- a/requirements-django52.txt
+++ b/requirements-django52.txt
@@ -99,6 +99,8 @@ factory-boy==3.3.3
     # via argus-server (pyproject.toml)
 faker==37.1.0
     # via factory-boy
+fontawesomefree==6.6.0
+    # via argus-server (pyproject.toml)
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,6 +103,8 @@ factory-boy==3.3.3
     # via argus-server (pyproject.toml)
 faker==37.1.0
     # via factory-boy
+fontawesomefree==6.6.0
+    # via argus-server (pyproject.toml)
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7

--- a/src/argus/htmx/appconfig.py
+++ b/src/argus/htmx/appconfig.py
@@ -46,6 +46,9 @@ _app_settings = [
         "app_name": "django.forms",
         "settings": {"FORM_RENDERER": "django.forms.renderers.TemplatesSetting"},
     },
+    {
+        "app_name": "fontawesomefree",
+    },
 ]
 
 APP_SETTINGS = ListAppSetting(_app_settings).root

--- a/src/argus/htmx/templates/htmx_base.html
+++ b/src/argus/htmx/templates/htmx_base.html
@@ -15,6 +15,12 @@
     <script src="{% static htmx_path %}"></script>
     <script src="{% static hyperscript_path %}"></script>
     <link rel="stylesheet" href="{% static stylesheet_path %}">
+    <link href="{% static 'fontawesomefree/css/fontawesome.css' %}"
+          rel="stylesheet"
+          type="text/css">
+    <link href="{% static 'fontawesomefree/css/solid.css' %}"
+          rel="stylesheet"
+          type="text/css">
     {% block head %}
     {% endblock head %}
   </head>


### PR DESCRIPTION
## Scope and purpose

Fixes #1009. 

Add font-awesome 6.6 as an icon pack so that we can use proper icons instead of rely on unicode icons. It uses the `fontawesomefree` python package, which is very easily installed. Unfortunately it does not have a treeshaking option to only include the icons that we use. However, such a feature would introduce significant extra complexity, similar to what we do with tailwind_config and source file discovery. The benefit is minor since the font-awesome css files can be easily cached client side.

### This pull request
* adds/changes/removes a dependency


## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
