### PR TITLE
Convert filterable column unicode search icon to fontawesome

### DIFF
--- a/changelog.d/1390.added.md
+++ b/changelog.d/1390.added.md
@@ -1,0 +1,1 @@
+Convert filterable column unicode search icon to fontawesome

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header.html
@@ -5,8 +5,10 @@
       {{ column.label }}
       <span>
         <button type="button"
-                class="btn btn-xs {% if filter_value %} btn-primary {% else %} btn-ghost {% endif %} min-h-4 h-4"
-                _="on click toggle .hidden on next .column-filter">🔍</button>
+                class="btn btn-xs {% if filter_value %} btn-primary {% else %} btn-ghost text-primary {% endif %} min-h-4 h-4"
+                _="on click toggle .hidden on next .column-filter">
+          <i class="fa-solid fa-magnifying-glass"></i>
+        </button>
       </span>
     </div>
     <div class="absolute flex gap-2 column-filter hidden bg-base-100 border-primary border p-2 rounded-lg w-72 top-5 z-10"


### PR DESCRIPTION
## Scope and purpose

Dependent on #1389.

Convert the filterable column unicode search icon to font awesome `magnifying-glass`. The unicode symbol is dependent on browser/os on how it renders and may not render properly at all on some os's. For example, I've heard that it renders as a grey blob on macos.

### How to manually test:

Make your own `INCIDENT_TABLE_COLUMNS` in the same place:

```
...
from argus.htmx.incident.customization import IncidentTableColumn
...

INCIDENT_TABLE_COLUMNS [
    ...
    IncidentTableColumn(                                                        
        "description",                                                          
        label="Description",                                                    
        cell_template="htmx/incident/cells/_incident_description.html",                     
        filter_field="maxlevel",                                                
    ), 
   ...
]                                                                         
```

This will show the icon but does *not* make search on description work, for that see `docs/customization/htmx-frontend.rst`.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

Before (on windows, ymmv):
![image](https://github.com/user-attachments/assets/470c6e61-a0af-4958-948b-b2180d2beec5)
![image](https://github.com/user-attachments/assets/b6abce2a-d9c5-4144-a43e-ed3468e7a201)

After:
![image](https://github.com/user-attachments/assets/daeca117-e18c-4639-a4a4-08849903cb6e)
![image](https://github.com/user-attachments/assets/096e6a44-2c34-4fe8-bba1-1561afd277c6)

