### PR TITLE
Tweak select dropdowns in incident list table footer

### DIFF
--- a/changelog.d/1393.changed.md
+++ b/changelog.d/1393.changed.md
@@ -1,1 +1,1 @@
-Tweak select dropdowns in incident list table footer
+Made select dropdowns in incident list table footer more consistent with rest of footer

--- a/changelog.d/1393.changed.md
+++ b/changelog.d/1393.changed.md
@@ -1,0 +1,1 @@
+Tweak select dropdowns in incident list table footer

--- a/src/argus/htmx/templates/htmx/incident/_incident_list_refresh_info.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_list_refresh_info.html
@@ -26,8 +26,7 @@
                 hx-include=".incident-list-param"
                 hx-indicator="#incident-list .htmx-indicator">
           {% for ps in preferences_choices.argus_htmx.page_size %}
-            <option class="bg-neutral"
-                    value="{{ ps }}"
+            <option value="{{ ps }}"
                     {% if ps == preferences.argus_htmx.page_size %}selected{% endif %}>{{ ps }}</option>
           {% endfor %}
         </select>
@@ -49,8 +48,7 @@
                 hx-indicator="#incident-list .htmx-indicator"
                 autocomplete="off">
           {% for interval in preferences_choices.argus_htmx.update_interval %}
-            <option class="bg-neutral"
-                    value="{{ interval|default:'never' }}"
+            <option value="{{ interval|default:'never' }}"
                     {% if interval == preferences.argus_htmx.update_interval %}selected{% endif %}>
               {{ interval|update_interval_string }}
             </option>
@@ -59,8 +57,8 @@
       </dd>
     </div>
     <div class="stat py-2">
-      <dt class="stat-title text-neutral-content/80">Timeframe</dt>
-      <dd class="stat-value text-base">
+      <dt class="stat-title text-inherit/80">Timeframe</dt>
+      <dd class="stat-value text-base font-medium">
         {{ timeframe_form.timeframe }}
       </dd>
     </div>


### PR DESCRIPTION
## Scope and purpose

Adjust some styling to make the refresh info dropdowns prettier and more consistent. Affects the Per Page, Update Interval and Timeframe selectors

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
Before:
![image](https://github.com/user-attachments/assets/428246b2-477f-4388-9e14-3f6296e46ba1)

After:
![image](https://github.com/user-attachments/assets/2a1192ca-eec9-4e85-a022-c53dae08bb7e)