### PR TITLE
Use simple email defaults in base, tls in prod

### DIFF
--- a/changelog.d/1395.changed.md
+++ b/changelog.d/1395.changed.md
@@ -1,0 +1,1 @@
+Update email settings to use port 25 by default, override defaults in prod.py

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -168,8 +168,8 @@ SILENCED_SYSTEM_CHECKS = [
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_HOST = get_str_env("EMAIL_HOST", "localhost")
 EMAIL_HOST_USER = get_str_env("EMAIL_HOST_USER")
-EMAIL_PORT = get_int_env("EMAIL_PORT", 587)
-EMAIL_USE_TLS = True
+EMAIL_PORT = get_int_env("EMAIL_PORT", 25)
+EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=False)
 EMAIL_HOST_PASSWORD = get_str_env("EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = get_str_env("DEFAULT_FROM_EMAIL", "argus@localhost")
 

--- a/src/argus/site/settings/prod.py
+++ b/src/argus/site/settings/prod.py
@@ -2,3 +2,5 @@ from argus.spa.settings import *
 
 # Beware: setting this to something else in production has security implications
 INTERNAL_IPS = []  # Don't alter me, please
+EMAIL_PORT = get_int_env("EMAIL_PORT", 587)
+EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=True)


### PR DESCRIPTION
## Scope and purpose

Argus uses SMTPS 587 for email by default (in `settings/base.py`). This is a non-obvious default which may confuse third party developers/users (it confused me). This PR sets the default to the more obvious default SMTP 25 (which are also the django settings) and instead sets the Sikt Argus specific defaults (SMTPS 587) in `settings/prod.py`

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
