### PR TITLE
Catch ticket system trouble in frontend

### DIFF
--- a/changelog.d/+htmx-catch-ticket-exception.changed.md
+++ b/changelog.d/+htmx-catch-ticket-exception.changed.md
@@ -1,0 +1,1 @@
+Show better messages when handling errors when autocreating tickets.

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -18,6 +18,7 @@ from django_htmx.http import HttpResponseClientRefresh, retarget
 from argus.auth.utils import get_or_update_preference
 from argus.incident.models import Incident
 from argus.incident.ticket.utils import get_ticket_plugin_path
+from argus.incident.ticket.base import TicketPluginException
 from argus.notificationprofile.models import Filter
 from argus.util.datetime_utils import make_aware
 
@@ -96,7 +97,10 @@ def incident_update(request: HtmxHttpRequest, action: str):
         return HttpResponseClientRefresh()
 
     if action == "autocreate-ticket":
-        single_autocreate_ticket_url_queryset(request.user, incident_ids, {"timestamp": tznow()})
+        try:
+            single_autocreate_ticket_url_queryset(request.user, incident_ids, {"timestamp": tznow()})
+        except TicketPluginException as e:
+            messages.error(request, str(e))
         return HttpResponseClientRefresh()
 
     form = get_form(request, formclass)


### PR DESCRIPTION
## Scope and purpose

Useful for #1400 

Turns out if automatic ticket creation fails, we get an unadorned 500 Server Error put in a toast.

This catches *known* ticket creation errors and shows them properly to the frontend. The actual error message as returned from the plugin instead of "500 Server Error".

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
Hard to test without making a ticket plugin that always fails, out of scope.
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If this results in changes in the UI: Added screenshots of the before and after
A text string changes and hopefully there's one less exception in the logs, it is tricky to provoke the error though.

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
