### PR TITLE
Use hatchling+versioningit for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-graft src
-
-prune .github
-global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "versioningit>=3.0.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "argus-server"
@@ -77,32 +77,26 @@ dev = [
     "build",  # for debugging builds/installs
 ]
 
+[tool.hatch.version]
+source = "versioningit"
+
+[tool.hatch.build]
+artifacts = ["src/argus/version.py"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/argus"]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["/.github"]
+
+[tool.versioningit.write]
+file = "src/argus/version.py"
+
 [tool.djlint]
 profile="django"
 indent = 2
 ignore="H006"
 use_gitignore=true
-
-[tool.setuptools]
-include-package-data = true
-zip-safe = false
-platforms = ["any"]
-
-[tool.setuptools.packages.find]
-where = ["src"]
-exclude = ["tests*"]
-
-[tool.setuptools.package-data]
-"*" = [
-    "templates/",
-    "*.rst",
-]
-
-[tool.setuptools.exclude-package-data]
-"*" = ["tests/"]
-
-[tool.setuptools_scm]
-write_to = "src/argus/version.py"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Scope and purpose

Switch from `setuptools` to `hatchling` for packaging.

Uses `versioningit` instead of `setuptols-scm` to set the version.

This leads to a smaller `pyproject.toml` and we no longer need `MANIFEST.in`.

How to test:
 1. build packages on master, save the list of contents:
   ```
   zipinfo -1 dist/*.whl > master-wheel.txt
   tar tzf dist/*.gz | cut -d '/' -f 2- | sort -u > master-sdist.txt
   ```
2. build packages on this branch, save the list of contents:
   ```
   zipinfo -1 dist/*.whl > hatch-wheel.txt
   tar tzf dist/*.gz | cut -d '/' -f 2- | sort -u > hatch-sdist.txt
   ```
3. Diff wheel-lists and diff sdist lists. Filenames should be the same but hatch sdist does not include directories, only files.

(The sed-magic above removes the first directory from each line, which contains version-info. The `-1` lists only filenames and hides dates, sizes, permissions and zip-file metadata.)

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/changed documentation
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
