### PR TITLE
Call `create_source` management command in `create_fake_incident` if doesn't exist

### DIFF
--- a/changelog.d/1422.added.md
+++ b/changelog.d/1422.added.md
@@ -1,0 +1,1 @@
+Create source in create_fake_incident if it does not exist

--- a/src/argus/dev/management/commands/create_fake_incident.py
+++ b/src/argus/dev/management/commands/create_fake_incident.py
@@ -2,12 +2,15 @@ import argparse
 import json
 from pathlib import Path
 
-from django.core.management import CommandError
-from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.core.management import CommandError, call_command
+from django.core.management.base import BaseCommand
 
 from argus.incident.constants import Level
 from argus.incident.models import create_fake_incident
+
+User = get_user_model()
 
 
 class Range(argparse.Action):
@@ -73,6 +76,9 @@ class Command(BaseCommand):
             if metadata_path:
                 with metadata_path.open() as jsonfile:
                     metadata = json.load(jsonfile)
+
+        call_command("create_source", [source, f"-t={source}"])
+
         for i in range(batch_size):
             try:
                 create_fake_incident(

--- a/tests/dev/test_create_fake_incident.py
+++ b/tests/dev/test_create_fake_incident.py
@@ -3,7 +3,6 @@ from io import StringIO
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 
-from argus.incident.factories import SourceSystemFactory, SourceSystemTypeFactory, SourceUserFactory
 from argus.incident.models import Incident, SourceSystem, Tag
 from argus.util.testing import connect_signals, disconnect_signals
 
@@ -72,9 +71,6 @@ class CreateFakeIncidentTests(TestCase):
         previous_incidents_pks = [incident.id for incident in Incident.objects.all()]
 
         source_name = "notargus"
-        sst = SourceSystemTypeFactory(name="source_type")
-        user = SourceUserFactory(username=source_name)
-        SourceSystemFactory(name=source_name, type=sst, user=user)
 
         out = self.call_command(f"--source={source_name}")
 

--- a/tests/dev/test_create_source.py
+++ b/tests/dev/test_create_source.py
@@ -1,7 +1,8 @@
 from django.core.management import call_command
 from django.test import TestCase
 
-from argus.incident.models import SourceSystem
+from argus.auth.models import User
+from argus.incident.models import SourceSystem, SourceSystemType
 from argus.util.testing import connect_signals, disconnect_signals
 
 
@@ -26,3 +27,40 @@ class CreateSourceTests(TestCase):
         call_command("create_source", source_name, source_type=source_type)
 
         self.assertTrue(SourceSystem.objects.exclude(id__in=previous_source_pks).filter(type_id=source_type).exists())
+
+    def test_create_source_will_use_already_existing_user(self):
+        previous_source_pks = [source.id for source in SourceSystem.objects.all()]
+        source_name = "source name"
+        existing_user = User.objects.create(username=source_name, is_staff=False, is_superuser=False)
+
+        call_command("create_source", source_name)
+
+        source = SourceSystem.objects.exclude(id__in=previous_source_pks).filter(name=source_name).first()
+        self.assertTrue(source)
+        self.assertEqual(source.user_id, existing_user.id)
+
+    def test_create_source_will_use_already_existing_source_system_type(self):
+        previous_source_pks = [source.id for source in SourceSystem.objects.all()]
+        source_name = "source name"
+        source_type_name = "source type name"
+        existing_source_type = SourceSystemType.objects.create(name=source_type_name)
+
+        call_command("create_source", source_name, source_type=source_type_name)
+
+        source = SourceSystem.objects.exclude(id__in=previous_source_pks).filter(name=source_name).first()
+        self.assertTrue(source)
+        self.assertEqual(source.type_id, existing_source_type.name)
+
+    def test_create_source_will_use_already_existing_source_system(self):
+        previous_source_pks = [source.id for source in SourceSystem.objects.all()]
+        source_name = "source name"
+        source_type_name = "source type name"
+        source_user = User.objects.create(username=source_name, is_staff=False, is_superuser=False)
+        source_type = SourceSystemType.objects.create(name=source_type_name)
+        source = SourceSystem.objects.create(name=source_name, type=source_type, user=source_user)
+
+        call_command("create_source", source_name)
+
+        cli_source = SourceSystem.objects.exclude(id__in=previous_source_pks).filter(name=source_name).first()
+        self.assertTrue(cli_source)
+        self.assertEqual(cli_source.id, source.id)

--- a/tests/incident/test_create_fake_incident.py
+++ b/tests/incident/test_create_fake_incident.py
@@ -1,11 +1,12 @@
 from django.test import TestCase
 
-
+from argus.auth.factories import SourceUserFactory
+from argus.incident.factories import SourceSystemFactory, SourceSystemTypeFactory
 from argus.incident.models import IncidentTagRelation, create_fake_incident
 from argus.util.testing import disconnect_signals, connect_signals
 
 
-class EventViewSetTestCase(TestCase):
+class CreateFakeIncidentTestCase(TestCase):
     def setUp(self):
         disconnect_signals()
 
@@ -37,3 +38,16 @@ class EventViewSetTestCase(TestCase):
         incident = create_fake_incident(level=level)
 
         self.assertEqual(incident.level, level)
+
+    def test_create_fake_incident_creates_incident_with_set_existing_source(self):
+        source_name = "source_a"
+        sst = SourceSystemTypeFactory(name=source_name)
+        user = SourceUserFactory(username=source_name)
+        SourceSystemFactory(name=source_name, type=sst, user=user)
+        incident = create_fake_incident(source=source_name)
+
+        self.assertEqual(incident.source.name, source_name)
+
+    def test_create_fake_incident_raises_error_on_non_existent_source(self):
+        with self.assertRaises(ValueError):
+            create_fake_incident(source="non-existent")


### PR DESCRIPTION
## Scope and purpose

Another part of working on #1210.

This will create a source before calling the `Incident.create_fake_incident` method if it doesn't exist. 

Reference to how to run a management command from within Python code: https://docs.djangoproject.com/en/5.2/ref/django-admin/#running-management-commands-from-your-code

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
  Not needed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
