### PR TITLE
Remove spa-specific settings from docs

### DIFF
--- a/docs/reference/site-specific-settings.rst
+++ b/docs/reference/site-specific-settings.rst
@@ -17,6 +17,11 @@ See :ref:`howto-change-settings`
 List of settings and environment variables
 ==========================================
 
+.. warning:: Environment variables and Argus settings may contain sensitive data, such
+  as login credentials, secrets and passwords.
+  Be mindful when setting these variables, and use appropriate safety precautions.
+  For example, do not check your ``localsettings.py`` files into version control.
+
 Django-specific settings
 ------------------------
 
@@ -321,22 +326,3 @@ Debugging settings
 
 * :setting:`TEMPLATE_DEBUG` (optional) provides a convenient way to turn debugging on and off
   for templates. If undefined it will default to the value of :setting:`DEBUG`.
-
-Other settings
---------------
-
-Normally, you shouldn't need to ever change these. If you do need to touch
-them, do it via a new settings file containing overrides.
-
-.. setting:: ARGUS_SPA_TOKEN_COOKIE_NAME
-
-* :setting:`ARGUS_SPA_TOKEN_COOKIE_NAME` is to control the name of the cookie that
-  contains a copy of the authentication token which is used when logging in via
-  the frontend. The default is ``token``, and you can change this to
-  something else if something you cannot change in the same system also creates
-  a cookie with the name ``token``.
-
-.. warning:: Environment variables and Argus settings may contain sensitive data, such
-  as login credentials, secrets and passwords.
-  Be mindful when setting these variables, and use appropriate safety precautions.
-  For example, do not check your ``localsettings.py`` files into version control.


### PR DESCRIPTION
## Scope and purpose

Fixes #1426

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
  _Handled at the end, not here_
* [x] Added/changed documentation
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
