### PR TITLE
Use Rest Framework DEFAULT_PERMISSION_CLASSES where possible

### DIFF
--- a/changelog.d/1476.changed.md
+++ b/changelog.d/1476.changed.md
@@ -1,0 +1,1 @@
+Use DRF's DEFAULT_PERMISSION_CLASSES setting for API endpoints' permission checking

--- a/src/argus/auth/views.py
+++ b/src/argus/auth/views.py
@@ -1,5 +1,4 @@
 from rest_framework import generics
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -11,7 +10,6 @@ from .serializers import (
 
 
 class CurrentUserView(APIView):
-    permission_classes = [IsAuthenticated]
     serializer_class = UserSerializer
 
     def get(self, request, *args, **kwargs):
@@ -20,6 +18,5 @@ class CurrentUserView(APIView):
 
 
 class BasicUserDetail(generics.RetrieveAPIView):
-    permission_classes = [IsAuthenticated]
     serializer_class = BasicUserSerializer
     queryset = User.objects.all()

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -16,7 +16,6 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError, PermissionDenied, MethodNotAllowed
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import CursorPagination
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
@@ -87,7 +86,6 @@ class EventPagination(CursorPagination):
 class SourceSystemTypeViewSet(
     mixins.CreateModelMixin, mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
 ):
-    permission_classes = [IsAuthenticated]
     serializer_class = SourceSystemTypeSerializer
     queryset = SourceSystemType.objects.all()
 
@@ -99,7 +97,7 @@ class SourceSystemViewSet(
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):
-    permission_classes = [IsSuperuserOrReadOnly]
+    permission_classes = [*viewsets.GenericViewSet.permission_classes, IsSuperuserOrReadOnly]
     queryset = SourceSystem.objects.all()
     serializer_class = SourceSystemSerializer
 
@@ -137,7 +135,6 @@ class BaseIncidentViewSet(
     viewsets.GenericViewSet,
 ):
     pagination_class = IncidentPagination
-    permission_classes = [IsAuthenticated]
     queryset = Incident.objects.prefetch_default_related()
     search_fields = ["description", "search_text"]
 
@@ -290,7 +287,6 @@ class TicketPluginViewSet(viewsets.ViewSet):
     should be used.
     """
 
-    permission_classes = [IsAuthenticated]
     serializer_class = IncidentTicketUrlSerializer
     queryset = Incident.objects.all()
 
@@ -410,7 +406,6 @@ class IncidentTagViewSet(
 class AllEventsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     pagination_class = EventPagination
     queryset = Event.objects.none()
-    permission_classes = [IsAuthenticated]
     serializer_class = EventSerializer
 
     def get_queryset(self):
@@ -427,7 +422,6 @@ class AllEventsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 )
 class EventViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Incident.objects.none()  # For OpenAPI
-    permission_classes = [IsAuthenticated]
     serializer_class = EventSerializer
 
     def get_queryset(self):
@@ -520,7 +514,6 @@ class EventViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, mixins.Retrie
 )
 class AcknowledgementViewSet(rw_viewsets.ModelViewSet):
     queryset = Incident.objects.none()  # For OpenAPI
-    permission_classes = [IsAuthenticated]
     serializer_class = ResponseAcknowledgementSerializer
     read_serializer_class = ResponseAcknowledgementSerializer
 
@@ -577,7 +570,6 @@ class BulkHelper:
     )
 )
 class BulkAcknowledgementViewSet(BulkHelper, viewsets.ViewSet):
-    permission_classes = [IsAuthenticated]
     serializer_class = ResponseBulkSerializer
     write_serializer_class = RequestBulkAcknowledgementSerializer
     queryset = Incident.objects.all()
@@ -624,7 +616,6 @@ class BulkAcknowledgementViewSet(BulkHelper, viewsets.ViewSet):
     )
 )
 class BulkEventViewSet(BulkHelper, viewsets.ViewSet):
-    permission_classes = [IsAuthenticated]
     serializer_class = ResponseBulkSerializer
     write_serializer_class = RequestBulkEventSerializer
     queryset = Incident.objects.all()
@@ -675,7 +666,6 @@ class BulkEventViewSet(BulkHelper, viewsets.ViewSet):
     )
 )
 class BulkTicketUrlViewSet(BulkHelper, viewsets.ViewSet):
-    permission_classes = [IsAuthenticated]
     serializer_class = ResponseBulkSerializer
     write_serializer_class = RequestBulkTicketUrlSerializer
     queryset = Incident.objects.all()

--- a/src/argus/notificationprofile/views.py
+++ b/src/argus/notificationprofile/views.py
@@ -5,7 +5,6 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.views import APIView
@@ -48,7 +47,7 @@ FilterBlobSerializer = filter_backend.FilterBlobSerializer
     ),
 )
 class NotificationProfileViewSet(rw_viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated, IsOwner]
+    permission_classes = [*rw_viewsets.ModelViewSet.permission_classes, IsOwner]
     serializer_class = ResponseNotificationProfileSerializer
     read_serializer_class = ResponseNotificationProfileSerializer
     write_serializer_class = RequestNotificationProfileSerializer
@@ -123,7 +122,6 @@ class SchemaView(DetailView):
 
 
 class MediaViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated]
     serializer_class = MediaSerializer
     queryset = Media.objects.none()
     http_method_names = ["get", "head"]
@@ -161,7 +159,7 @@ class MediaViewSet(viewsets.ModelViewSet):
     ),
 )
 class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated, IsOwner]
+    permission_classes = [*rw_viewsets.ModelViewSet.permission_classes, IsOwner]
     serializer_class = ResponseDestinationConfigSerializer
     read_serializer_class = ResponseDestinationConfigSerializer
     write_serializer_class = RequestDestinationConfigSerializer
@@ -209,7 +207,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
 
 
 class TimeslotViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated, IsOwner]
+    permission_classes = [*viewsets.ModelViewSet.permission_classes, IsOwner]
     serializer_class = TimeslotSerializer
     queryset = Timeslot.objects.none()
 
@@ -221,7 +219,7 @@ class TimeslotViewSet(viewsets.ModelViewSet):
 
 
 class FilterViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated, IsOwner]
+    permission_classes = [*viewsets.ModelViewSet.permission_classes, IsOwner]
     serializer_class = FilterSerializer
     queryset = Filter.objects.none()
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1475 

It:

* Removes `permission_classes = [IsAuthenticated]` where we can just use the default setting
* Appends additional permission_classes to the base where required
* Does not touch api v1 or spa stuff since that will be deleted anyway


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
