### PR TITLE
Add CLI command to close incidents

### DIFF
--- a/changelog.d/1450.added.md
+++ b/changelog.d/1450.added.md
@@ -1,0 +1,1 @@
+Add CLI command to close incidents

--- a/docs/development/management-commands.rst
+++ b/docs/development/management-commands.rst
@@ -132,6 +132,68 @@ And if the incident should be stateless add the flag `--stateless`:
 a filter that matches fake incidents, for instance by setting `source` to
 `argus`, and create a single fake incident.)
 
+.. _close-incident:
+
+Close incident
+--------------
+
+To close one or more incidents one can use the command `close_incident`:
+
+    .. code:: console
+
+        $ python manage.py close_incident
+
+See the inbuilt help for flags and toggles:
+
+    .. code:: console
+
+        $ python manage.py close_incident --help
+
+This command takes either the id of the incident that should be closed as an
+argument:
+
+    .. code:: console
+
+        $ python manage.py close_incident --id 1234
+
+Or the source and the source incident id that can be used to find the incident:
+
+    .. code:: console
+
+        $ python manage.py close_incident --source "argus" --source-incident-id 1234
+
+To only close the incident if it is older than a given duration add the
+`--duration` flag to the command as such:
+
+    .. code:: console
+
+        $ python manage.py close_incident --id 1234 --duration "01:05:00"
+
+To add a specific message to the closing event add the `--closing-message` flag
+to the command as such:
+
+    .. code:: console
+
+        $ python manage.py close_incident --id 1234 --closing-message "Testing that closing works"
+
+You can also close one or multiple incidents by giving a list of json files
+that contain the information, at least id or source + source incident id need
+to be included. An example file would look as such:
+
+    .. code-block:: JSON
+
+        {
+            "source_incident_id": "1234",
+            "source": "source name",
+            "duration": "01:05:00"
+        }
+
+And the flag `--files` would be used as such:
+
+    .. code:: console
+
+        $ python manage.py close_incident --files path-to-json-file.json path-to-other-json-file.json
+
 
 .. _create-source:
 

--- a/src/argus/dev/management/commands/close_incident.py
+++ b/src/argus/dev/management/commands/close_incident.py
@@ -1,0 +1,138 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+from django.core.management import CommandError
+from django.core.management.base import BaseCommand
+from django.db.models.query import QuerySet
+from django.utils import timezone
+from django.utils.dateparse import parse_duration
+
+from argus.dev.utils import get_json_from_file
+from argus.incident.models import Incident
+
+COMMAND_ARGUMENTS = ["id", "source", "source_incident_id", "duration", "closing_message"]
+LOG = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Close one or multiple incidents"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--id", type=int, help="Close the incident with the id <id>")
+        parser.add_argument(
+            "--source",
+            type=str,
+            help="Close the incident from the source <source>, needs source_incident_id to find the right incident",
+        )
+        parser.add_argument(
+            "--source-incident-id",
+            type=int,
+            help="Close the incident with the id from the source system <source_incident_id>",
+        )
+        parser.add_argument(
+            "--duration",
+            type=str,
+            help="Only close the incident after it has been open for the duration <duration>, duration should be in the format 'DD HH:MM:SS.uuuuuu'",
+        )
+        parser.add_argument(
+            "--closing-message",
+            type=str,
+            help="Close the incident with the message <closing-message>",
+        )
+        parser.add_argument(
+            "-f",
+            "--files",
+            nargs="+",
+            type=str,
+            help="List of paths to json-file containing all data needed to find the incidents that should be closed (id or source + source_incident_id) and optional duration",
+        )
+
+    def get_incident_data_from_arguments(self, options: dict) -> Optional[dict]:
+        incident_data = {}
+        incident_data["incident_id"] = options.get("id") or None
+        incident_data["source"] = options.get("source") or None
+        incident_data["source_incident_id"] = options.get("source_incident_id") or None
+        incident_data["closing_message"] = options.get("closing_message") or ""
+
+        if duration := options.get("duration"):
+            try:
+                incident_data["duration"] = parse_duration(duration)
+            except ValueError:
+                incident_data["duration"] = None
+            if not incident_data.get("duration"):
+                self.stderr.write(self.style.ERROR(f"Could not parse duration {duration}."))
+                return
+        else:
+            incident_data["duration"] = None
+
+        return incident_data
+
+    def get_incident_data_from_file(self, file_path: str) -> Optional[dict]:
+        file_content = get_json_from_file(base_command=self, file_path=Path(file_path).absolute())
+
+        if not file_content:
+            return None
+
+        incident_data = {}
+        incident_data["incident_id"] = file_content.get("id")
+        incident_data["source"] = file_content.get("source")
+        incident_data["source_incident_id"] = file_content.get("source_incident_id")
+        incident_data["closing_message"] = file_content.get("closing_message", "")
+        incident_data["file_path"] = file_path
+
+        if duration := file_content.get("duration"):
+            try:
+                incident_data["duration"] = parse_duration(duration)
+            except ValueError:
+                incident_data["duration"] = None
+            if not incident_data.get("duration"):
+                self.stderr.write(self.style.ERROR(f"Could not parse duration {duration} from file {file_path}."))
+                return
+        else:
+            incident_data["duration"] = None
+
+        return incident_data
+
+    def get_incident_qs(self, incident_data: dict) -> QuerySet:
+        """Returns an incident queryset containing one incident described in the given incident data"""
+        incident_qs = None
+        if incident_data["incident_id"]:
+            incident_qs = Incident.objects.filter(id=incident_data["incident_id"])
+        # is not None is important here since 0 is a valid value for source_incident_id
+        elif incident_data["source"] and incident_data["source_incident_id"] is not None:
+            incident_qs = Incident.objects.filter(
+                source__name=incident_data["source"], source_incident_id=incident_data["source_incident_id"]
+            )
+        return incident_qs
+
+    def handle(self, *args, **options):
+        if (file_paths := options.get("files", [])) and any(options.get(name, None) for name in COMMAND_ARGUMENTS):
+            raise CommandError("If argument 'files' is given no other arguments are allowed")
+
+        incident_list = []
+        if file_paths:
+            for file_path in file_paths:
+                incident_list.append(self.get_incident_data_from_file(file_path))
+        else:
+            incident_list.append(self.get_incident_data_from_arguments(options))
+
+        # Filter out None elements from list (e.g. file could not be found)
+        incident_list = list(filter(None, incident_list))
+
+        for incident_data in incident_list:
+            incident_qs = self.get_incident_qs(incident_data)
+
+            if not incident_qs or not incident_qs.exists():
+                error = "Could not find incident"
+                if incident_data.get("file_path"):
+                    error += " from file " + incident_data.get("file_path")
+                self.stderr.write(self.style.ERROR(error + "."))
+                return
+
+            incident = incident_qs.first()
+
+            if incident.open and (
+                not incident_data["duration"] or (timezone.now() - incident.start_time) >= incident_data["duration"]
+            ):
+                incident_qs.close(actor=incident.source.user, description=incident_data["closing_message"])

--- a/src/argus/dev/utils.py
+++ b/src/argus/dev/utils.py
@@ -1,10 +1,26 @@
-from datetime import datetime, timedelta
-from urllib.parse import urljoin
 import asyncio
 import itertools
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, AnyStr
+from urllib.parse import urljoin
+from typing import Optional
 
-from httpx import AsyncClient, TimeoutException, HTTPStatusError, post
+from httpx import AsyncClient, HTTPStatusError, TimeoutException, post
+from django.core.management.base import BaseCommand
+
+
+def get_json_from_file(base_command: BaseCommand, file_path: Path) -> Optional[dict]:
+    """
+    Opens a json file and returns its content as a dict
+    Catches exceptions and writes them to stderr and returns None in that case
+    """
+    try:
+        with file_path.open() as jsonfile:
+            return json.load(jsonfile)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        base_command.stderr.write(base_command.style.ERROR(f"Could not find/open/read file '{file_path}': {e}"))
 
 
 class DatabaseMismatchError(Exception):

--- a/tests/dev/test_close_incident.py
+++ b/tests/dev/test_close_incident.py
@@ -1,0 +1,286 @@
+from datetime import timedelta
+from unittest.mock import patch
+import json
+
+from django.core.files.temp import NamedTemporaryFile
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from argus.incident.factories import StatefulIncidentFactory, StatelessIncidentFactory
+from argus.incident.models import Event, Incident, get_or_create_default_instances
+from argus.util.testing import connect_signals, disconnect_signals
+
+
+class CloseIncidentArgumentsTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        _, _, self.argus_source_system = get_or_create_default_instances()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_closes_incident_using_id(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        call_command("close_incident", id=incident.id)
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_closes_incident_using_source_and_source_incident_id(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        call_command("close_incident", source=incident.source.name, source_incident_id=incident.source_incident_id)
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_does_not_close_stateless_incident(self):
+        incident = StatelessIncidentFactory(source=self.argus_source_system)
+
+        call_command("close_incident", id=incident.id)
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.stateful)
+        self.assertFalse(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_closes_incident_older_than_duration(self):
+        incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=10), source=self.argus_source_system
+        )
+
+        call_command("close_incident", id=incident.id, duration="00:01:00")
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_does_not_close_incident_younger_than_duration(self):
+        incident = StatefulIncidentFactory(start_time=timezone.now(), source=self.argus_source_system)
+
+        call_command("close_incident", id=incident.id, duration="20:00:00")
+
+        incident.refresh_from_db()
+
+        self.assertTrue(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_closes_incident_with_set_closing_message(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+        closing_message = "Box back up"
+
+        call_command("close_incident", id=incident.id, closing_message=closing_message)
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+
+        closing_event = incident.events.filter(type=Event.Type.CLOSE).first()
+        self.assertEqual(closing_event.description, closing_message)
+
+    def test_does_not_fail_on_non_existent_incident_using_id(self):
+        last_incident_pk = Incident.objects.last().id if Incident.objects.exists() else 0
+        call_command("close_incident", id=last_incident_pk + 1)
+
+    def test_does_not_fail_on_non_existent_incident_using_source_and_source_incident_id(self):
+        call_command("close_incident", source="non-existent", source_incident_id=11111145)
+
+    def test_does_not_close_incident_on_badly_formatted_duration(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        call_command("close_incident", id=incident.id, duration="invalid-format")
+
+        incident.refresh_from_db()
+
+        self.assertTrue(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    @patch("django.utils.dateparse.parse_duration", side_effect=ValueError)
+    def test_does_not_close_incident_on_invalid_duration(self, mock_parse_duration):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        call_command("close_incident", id=incident.id, duration="invalid-format")
+
+        incident.refresh_from_db()
+
+        self.assertTrue(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+
+class CloseIncidentFilesTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        _, _, self.argus_source_system = get_or_create_default_instances()
+
+    def tearDown(self):
+        connect_signals()
+
+    @staticmethod
+    def create_file(data: dict) -> str:
+        """Creates a NamedTemporaryFile containing the given data and returns it"""
+
+        data = json.dumps(data).encode("utf-8")
+        file = NamedTemporaryFile(delete=True)
+        file.write(data)
+        file.flush()
+        return file
+
+    def test_closes_incident_with_set_id(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        incident_data = {"id": incident.id}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_closes_incident_with_set_source_and_source_incident_id(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        incident_data = {"source": self.argus_source_system.name, "source_incident_id": incident.source_incident_id}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_closes_incidents_with_one_set_id_and_one_source_and_source_incident_id(self):
+        incident_1 = StatefulIncidentFactory(source=self.argus_source_system)
+        incident_2 = StatefulIncidentFactory(source=self.argus_source_system)
+
+        incident_data_1 = {"id": incident_1.id}
+        file_1 = self.create_file(incident_data_1)
+        incident_data_2 = {"source": incident_2.source.name, "source_incident_id": incident_2.source_incident_id}
+        file_2 = self.create_file(incident_data_2)
+
+        call_command("close_incident", files=[file_1.name, file_2.name])
+
+        incident_1.refresh_from_db()
+        incident_2.refresh_from_db()
+
+        self.assertFalse(incident_1.open)
+        self.assertTrue(incident_1.events.filter(type=Event.Type.CLOSE).exists())
+        self.assertFalse(incident_2.open)
+        self.assertTrue(incident_2.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_raises_error_for_additional_arguments_to_files(self):
+        with self.assertRaises(CommandError):
+            call_command("close_incident", files=["file-name"], id=1111)
+
+    def test_does_not_raise_error_for_non_existent_file(self):
+        call_command("close_incident", files=["invalid"])
+
+    def test_closes_incident_with_longer_duration(self):
+        incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=10), source=self.argus_source_system
+        )
+
+        incident_data = {"id": incident.id, "duration": "00:01:00"}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_does_not_close_incident_with_shorter_duration(self):
+        incident = StatefulIncidentFactory(start_time=timezone.now(), source=self.argus_source_system)
+
+        incident_data = {"id": incident.id, "duration": "20:00:00"}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertTrue(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_does_not_close_incident_on_badly_formatted_duration(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        incident_data = {"id": incident.id, "duration": "invalid-format"}
+
+        file = self.create_file(incident_data)
+
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertTrue(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    @patch("django.utils.dateparse.parse_duration", side_effect=ValueError)
+    def test_does_not_close_incident_on_invalid_duration(self, mock_parse_duration):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        incident_data = {"id": incident.id, "duration": "invalid-format"}
+
+        file = self.create_file(incident_data)
+
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertTrue(incident.open)
+        self.assertFalse(incident.events.filter(type=Event.Type.CLOSE).exists())
+
+    def test_closes_incident_with_closing_message(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+        closing_message = "Box back up"
+
+        incident_data = {"id": incident.id, "closing_message": closing_message}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+
+        closing_event = incident.events.filter(type=Event.Type.CLOSE).first()
+        self.assertEqual(closing_event.description, closing_message)
+
+    def test_does_not_fail_on_non_existent_incident_using_id(self):
+        last_incident_pk = Incident.objects.last().id if Incident.objects.exists() else 0
+
+        incident_data = {"id": last_incident_pk + 1}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+    def test_does_not_fail_on_non_existent_incident_using_source_and_source_incident_id(self):
+        incident_data = {"source": "non-existent", "source_incident_id": 11111145}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+    def test_ignores_extra_data(self):
+        incident = StatefulIncidentFactory(source=self.argus_source_system)
+
+        incident_data = {"id": incident.id, "extra_info": "abc"}
+
+        file = self.create_file(incident_data)
+        call_command("close_incident", files=[file.name])
+
+        incident.refresh_from_db()
+
+        self.assertFalse(incident.open)
+        self.assertTrue(incident.events.filter(type=Event.Type.CLOSE).exists())


### PR DESCRIPTION
## Scope and purpose

Fixes #1450.

Reference for `parse_duration`: https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.dateparse.parse_duration

One test that is lacking is one that covers `parse_duration` raising a `ValueError`, but I don't know how to trigger that, any ideas?

## Contributor Checklist

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
