### PR TITLE
Merge argus.htmx settings with default settings

### DIFF
--- a/changelog.d/+merge-settings.changed.md
+++ b/changelog.d/+merge-settings.changed.md
@@ -1,0 +1,5 @@
+The settings files have changed, since the HTMx frontend app is now included by
+default. The frontend settings has been merged in and no longer need the
+settings overriding machinery. It is no longer necessary to install the
+frontend with `pip install argus-server[htmx]`, just `pip install argus-server`
+will do.

--- a/docs/development/howtos/change-settings.rst
+++ b/docs/development/howtos/change-settings.rst
@@ -6,6 +6,12 @@ How to change site-specific settings
 
 Two ways to define these site-specific settings follow.
 
+The management command ``print_settings`` (which depends on the app
+``django-extensions``, a ``dev``-dependency installable via ``pip
+install argus-server[dev]``) will print out the complete
+settings that will be used.
+
+
 Variant 1: Using environment variables in the shell
 ===================================================
 
@@ -25,22 +31,52 @@ own way of setting environment variables.
 Variant 2: Using a ``settings.py`` file
 =======================================
 
-A settings file is a regular Python file.
+A settings file is a regular importable Python file. The filename MUST start
+with a letter, MUST only contain letters, numbers or underscores ("_"), and
+MUST end with ".py".
+
 This allows the use of more complex Python data types than environment variables.
-A settings file will override any environment variables.
+A settings file may override anything set via environment variable.
 
-``argus.site.settings.dev`` and ``argus.site.settings.prod`` provide reasonable defaults
-for development and production environments. You can use and/or override them by
-importing them to your ``localsettings.py`` as follows::
+``argus.site.settings.dev`` has reasonable defaults for development while
+``argus.site.settings.prod`` is a good starting point for production.
 
-  from argus.site.settings.prod import *
+.. note:: The development settings file assumes that the optional development
+   dependencies are installed. You can get them via ``pip install argus-server[dev]``.
 
-Now define variables like::
+Development
+~~~~~~~~~~~
 
-  DEBUG = True
+Do this in your working directory, which could be the checked out `argus-server
+<https://github.com/Uninett/Argus>`_ repo.
 
-Settings can be tested in ``localsettings.py`` and moved to the other settings files
+This assumes that you have a local settings file (we recommend calling it
+"localsettings.py" since that is hidden by .gitignore) as a sibling of
+``src/``.
+
+At the top of this local settings file you should have::
+
+   from argus.site.settings.dev import *
+
+There, now you can alter anything.
+
+If you don't want to use any of the development dependencies you can import
+from ``argus.htmx.settings`` instead.
+
+Settings can be tested in ``localsettings.py`` and moved to other settings files
 later.
-Use an expressive name for your ``settings.py`` file, such as ``prod-settings.py``.
+
+Production
+~~~~~~~~~~
+
+Copy the contents of ``argus.site.settings.prod`` to your own settings-file.
+It does not depend on any development dependencies. It will also turn on some
+extra nagging for settings that MUST be set for production.
+
+For production you MUST set :setting::`ALLOWED_HOSTS`, note how it's
+commented out in ``argus.site.settings.prod``.
+
+Use an expressive name for your ``settings.py`` file, such as
+``production_settings.py``.
 
 You can combine settings files and environment variables.

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -16,14 +16,14 @@ looks:
 * daisyUI: A component library for Tailwind CSS that provides a set of
   ready-to-use components as well as color themes.
 
-
 Setup
 =====
 
-The app is included in the argus-server codebase and is installed by default.
+The app is included in the argus-server codebase and is installed and
+configured by default.
 
 Install and build Tailwind CSS and daisyUI for UI tweaks
---------------------------------------------------------
+========================================================
 
 .. attention::
    If you want to be able to customize the frontend in any way, including
@@ -33,7 +33,7 @@ Install and build Tailwind CSS and daisyUI for UI tweaks
 Recommended but open for tweaks and adaptations steps:
 
 Install
-~~~~~~~
+-------
 
 1. Get Tailwind standalone CLI bundled with daisyUI from
    https://github.com/dobicinaitis/tailwind-cli-extra
@@ -52,7 +52,7 @@ Install
 2. (Linux/OsX) Move the tailwindcss file to your $PATH, for instance to ``~/bin/`` or ``.local/bin``.
 
 Build
-~~~~~
+-----
 
 1. Go to the repo directory (parent of ``src/``)
 2. Build main stylesheet file using ``tailwindcss`` executable from step 1 and
@@ -73,50 +73,19 @@ Build
 Configure
 ---------
 
-If *all the settings you need to change* can be set via environment variables,
-use ``argus.htmx.settings`` as your settings-file *for development*.
+See :ref:`customize-htmx-frontend`. You will probably need a separate settings
+file, see :ref:`howto-change-settings`.
 
-For *production* you must set :setting::`ALLOWED_HOSTS`, have a look at
-``argus.site.settings.prod``.
+Settings
+========
 
-If you need to override settings not mirrored by environment variables, read
-on.
+See :ref:`howto-change-settings` for the how, see below for what.
 
-Do this in your workdir, which could be the checked out `argus-server
-<https://github.com/Uninett/Argus>`_ repo.
-
-This assumes that you have a local settings file (we recommend calling it
-"localsettings.py" since that is hidden by .gitignore) as a sibling of
-``src/``.
-
-At the top of this local settings file, copy the contents of
-``argus.htmx.settings``. This will base the settings-file on
-``argus.site.settings.base``.
-
-Example, from the start of the settings-file for production::
-
-   from argus.htmx.settings import *
-
-While developing you will probably prefer to swap out
-``argus.htmx.settings`` with ``argus.site.settings.dev``, as the former
-is almost production-ready while the latter is tuned for development and
-depends on the optional dependencies you can install via ``pip install
-argus-server[dev]``.
-
-Example, top of settings-file for development::
-
-   from argus.site.settings.dev import *
-
-The management command ``print_settings`` (which depends on the app
-``django-extensions``, a ``dev``-dependency) will print out the complete
-settings used.
+These settings are needed for various features in the frontend.
 
 Note especially that :setting:`ROOT_URLCONF` is set to
 ``argus.htmx.root_urls``. If you prefer to make your own root ``urls.py``, the
 frontend-specific urls can be imported from ``argus.htmx.htmx_urls``.
-
-Settings
-========
 
 Domain settings
 ---------------

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -7,29 +7,22 @@ HTMx Frontend
 The new frontend is old-new school and uses HTMx to boost HTML pages. See the
 `Github repo of argus-htmx-frontend <https://github.com/uninett/argus-htmx-frontend>`_
 
-It has its own specific settings and currently depends on an app.
-
 It is not needed if running headless.
 
-It uses Tailwind CSS and daisyUI for looks and layout.
+It uses Tailwind CSS and daisyUI for looks and layout but you need not install
+anything extra for the frontend to work.
 
 * Tailwind CSS: A utility-first CSS framework for rapidly building custom user interfaces.
-* daisyUI: A component library for Tailwind CSS that provides a set of ready-to-use components as well as color themes.
+* daisyUI: A component library for Tailwind CSS that provides a set of
+  ready-to-use components as well as color themes.
 
 
 Setup
 =====
 
-The app is included in the argus-server codebase, but it is optional to use.
+The app is included in the argus-server codebase.
 
-Install Python dependencies
----------------------------
-
-Install the dependencies::
-
-    pip install argus-server[htmx]
-
-(The generated requirements-files include the dependencies already.)
+The generated requirements-files include the dependencies already.
 
 Install and build Tailwind CSS and daisyUI
 ------------------------------------------
@@ -82,7 +75,13 @@ Configure
 ---------
 
 If *all the settings you need to change* can be set via environment variables,
-use ``argus.htmx.settings`` as your settings-file. Otherwise, read on.
+use ``argus.htmx.settings`` as your settings-file *for development*.
+
+For *production* you must set :setting::`ALLOWED_HOSTS`, have a look at
+``argus.site.settings.prod``.
+
+If you need to override settings not mirrored by environment variables, read
+on.
 
 Do this in your workdir, which could be the checked out `argus-server
 <https://github.com/Uninett/Argus>`_ repo.
@@ -93,24 +92,14 @@ This assumes that you have a local settings file (we recommend calling it
 
 At the top of this local settings file, copy the contents of
 ``argus.htmx.settings``. This will base the settings-file on
-``argus.site.settings.backend`` and automatically use
-``argus.site.utils.update_settings`` with
-``argus.htmx.appconfig.APP_SETTINGS`` to set/overwrite some settings and
-mutate others. Note the usage of ``globals()``; due to this, inheriting from
-``argus.htmx.settings`` will probably not work as expected.
+``argus.site.settings.base``.
 
-Example, top of settings-file for production::
+Example, from the start of the settings-file for production::
 
-   from argus.site.settings.backend import *
-   from argus.site.utils import update_settings
-   from argus.htmx.appconfig import APP_SETTINGS
-
-   update_settings(globals(), APP_SETTINGS)
-
-   ROOT_URLCONF = "argus.htmx.root_urls"
+   from argus.htmx.settings import *
 
 While developing you will probably prefer to swap out
-``argus.site.settings.backend`` with ``argus.site.settings.dev``, as the former
+``argus.htmx.settings`` with ``argus.site.settings.dev``, as the former
 is almost production-ready while the latter is tuned for development and
 depends on the optional dependencies you can install via ``pip install
 argus-server[dev]``.
@@ -118,26 +107,6 @@ argus-server[dev]``.
 Example, top of settings-file for development::
 
    from argus.site.settings.dev import *
-   from argus.site.utils import update_settings
-   from argus.htmx.appconfig import APP_SETTINGS
-
-   update_settings(globals(), APP_SETTINGS)
-
-   ROOT_URLCONF = "argus.htmx.root_urls"
-
-The ``argus.site.utils.update_settings`` function will add or change the settings
-
-* INSTALLED_APPS
-* LOGIN_REDIRECT_URL
-* LOGIN_URL
-* LOGOUT_REDIRECT_URL
-* LOGOUT_URL
-* MIDDLEWARE
-* PUBLIC_URLS
-* ROOT_URLCONF
-* TEMPLATES
-
-See ``argus.htmx.appconfig._app_settings`` for what is being set.
 
 The management command ``print_settings`` (which depends on the app
 ``django-extensions``, a ``dev``-dependency) will print out the complete

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -4,13 +4,13 @@
 HTMx Frontend
 =============
 
-The new frontend is old-new school and uses HTMx to boost HTML pages. See the
-`Github repo of argus-htmx-frontend <https://github.com/uninett/argus-htmx-frontend>`_
+The new frontend is old-new school and uses HTMx to boost HTML pages.
 
-It is not needed if running headless.
+It uses Tailwind CSS and daisyUI for looks and layout, but you do not need to
+install anything extra for the frontend to work.
 
-It uses Tailwind CSS and daisyUI for looks and layout but you need not install
-anything extra for the frontend to work.
+You *do* need to have both in order to add a new theme or otherwise change the
+looks:
 
 * Tailwind CSS: A utility-first CSS framework for rapidly building custom user interfaces.
 * daisyUI: A component library for Tailwind CSS that provides a set of
@@ -20,16 +20,15 @@ anything extra for the frontend to work.
 Setup
 =====
 
-The app is included in the argus-server codebase.
+The app is included in the argus-server codebase and is installed by default.
 
-The generated requirements-files include the dependencies already.
+Install and build Tailwind CSS and daisyUI for UI tweaks
+--------------------------------------------------------
 
-Install and build Tailwind CSS and daisyUI
-------------------------------------------
-
-If you want to be able to customize the frontend in any way, including changing
-or adding themes, you need to install the support for Tailwind CSS and daisyUI.
-They are not Python packages so it cannot be streamlined much.
+.. attention::
+   If you want to be able to customize the frontend in any way, including
+   changing or adding themes, you need to install the support for Tailwind CSS
+   and daisyUI. They are not Python packages so it cannot be streamlined much.
 
 Recommended but open for tweaks and adaptations steps:
 
@@ -128,7 +127,9 @@ Domain settings
   to incidents in the dashboard, or whenever else an absolute url is needed.
 
 The setting must point to the publicly visible domain where the frontend is
-running. This might be different from where the backend is running.
+running. This might be different from where the backend is running. If the
+backend is running on multiple addresses (for replication/robustness) they must
+share the same :setting:`ARGUS_FRONTEND_URL`.
 
 Depending on how Argus is deployed this is the only surefire way to get hold
 of the externally visible hostname in the code in all cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dependencies = [
     "httpx",
     "pydantic>=2",
     "django-rest-knox",
+    "django-htmx",
+    "django-widget-tweaks==1.5.0",
+    "fontawesomefree~=6.6",
+    "social-auth-core>=4.1",
+    "social-auth-app-django>=5.0",
 ]
 dynamic = ["version"]
 
@@ -49,13 +54,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 docs = ["sphinx>=2.2.0"]
-htmx = [
-    "django-htmx",
-    "django-widget-tweaks==1.5.0",
-    "fontawesomefree~=6.6",
-    "social-auth-core>=4.1",
-    "social-auth-app-django>=5.0",
-]
 dev = [
     "django-debug-toolbar",
     "coverage",

--- a/src/argus/htmx/settings.py
+++ b/src/argus/htmx/settings.py
@@ -1,9 +1,14 @@
-from argus.site.settings.backend import *
-from argus.site.utils import update_settings
-
-from argus.htmx.appconfig import APP_SETTINGS
-
-
-update_settings(globals(), APP_SETTINGS)
+from argus.site.settings.base import *
 
 ROOT_URLCONF = "argus.htmx.root_urls"
+
+PUBLIC_URLS = [
+    "/accounts/login/",
+    "/api/",
+    "/oidc/",
+]
+
+LOGIN_URL = "/accounts/login/"
+LOGOUT_URL = "/accounts/logout/"
+LOGIN_REDIRECT_URL = "/incidents/"
+LOGOUT_REDIRECT_URL = "/incidents/"

--- a/src/argus/site/settings/backend.py
+++ b/src/argus/site/settings/backend.py
@@ -1,28 +1,5 @@
-from django.core.exceptions import ImproperlyConfigured
-
 from .base import *
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = get_str_env("SECRET_KEY", required=True)
-STATIC_ROOT = get_str_env("STATIC_ROOT", required=True)
-STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-
-# You must set this: ip-addresses, hostnames and domain names allowed
-# ALLOWED_HOSTS = [
-#     "127.0.0.1",
-#     "localhost",
-# ]
-
-if not FRONTEND_URL:
-    raise ImproperlyConfigured('"FRONTEND_URL" has not been set in production!')
-
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = get_str_env("EMAIL_HOST", required=True)
-DEFAULT_FROM_EMAIL = get_str_env("DEFAULT_FROM_EMAIL", required=True)
-
-SEND_NOTIFICATIONS = get_bool_env("ARGUS_SEND_NOTIFICATIONS", default=True)
-
-# Paths to plugins
-MEDIA_PLUGINS = [
-    "argus.notificationprofile.media.email.EmailNotification",
+PUBLIC_URLS = [
+    "/api/",
 ]

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -29,12 +29,17 @@ INTERNAL_IPS = []
 # fmt: off
 # fsck off, black
 INSTALLED_APPS = [
+    # overrides others. must come first
+    "argus.htmx",
+
+    # Django 1st party apps
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.forms",
 
     # 3rd party apps
     "corsheaders",
@@ -45,6 +50,9 @@ INSTALLED_APPS = [
     "django_filters",
     "phonenumber_field",
     "knox",  # token auth
+    "django_htmx",
+    "widget_tweaks",
+    "fontawesomefree",
 
     # Argus apps
     "argus.auth",
@@ -68,9 +76,14 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
     "django.contrib.auth.middleware.RemoteUserMiddleware",
+    "django_htmx.middleware.HtmxMiddleware",
+    "argus.htmx.middleware.LoginRequiredMiddleware",
+    "argus.htmx.middleware.HtmxMessageMiddleware",
 ]
 
 ROOT_URLCONF = "argus.site.urls"
+
+FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 TEMPLATES = [
     {
@@ -85,6 +98,8 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "social_django.context_processors.backends",
                 "social_django.context_processors.login_redirect",
+                "argus.auth.context_processors.preferences",
+                "argus.htmx.context_processors.static_paths",
             ],
         },
     }

--- a/src/argus/site/settings/dev.py
+++ b/src/argus/site/settings/dev.py
@@ -1,16 +1,10 @@
 from dotenv import load_dotenv
 
-from argus.htmx.appconfig import APP_SETTINGS
-
 load_dotenv()
 
+from argus.htmx.settings import *  # noqa: E402
 from . import get_bool_env, get_str_env  # noqa: E402
-from .base import *  # noqa: E402, F403
-from ..utils import update_settings  # noqa: E402
 
-
-update_settings(globals(), APP_SETTINGS)
-ROOT_URLCONF = "argus.htmx.root_urls"
 
 DEBUG = get_bool_env("DEBUG", True)
 TEMPLATES[0]["OPTIONS"]["debug"] = get_bool_env("TEMPLATE_DEBUG", True)  # noqa: F405

--- a/src/argus/site/settings/prod.py
+++ b/src/argus/site/settings/prod.py
@@ -1,10 +1,30 @@
-from argus.site.utils import update_settings
-from argus.site.settings.backend import *
-from argus.htmx.appconfig import APP_SETTINGS
+from django.core.exceptions import ImproperlyConfigured
 
-update_settings(globals(), APP_SETTINGS)
+from argus.htmx.settings import *
 
-ROOT_URLCONF = "argus.htmx.root_urls"
+if not FRONTEND_URL:
+    raise ImproperlyConfigured('"FRONTEND_URL" has not been set in production!')
+
+# You must set this: ip-addresses, hostnames and domain names allowed
+# ALLOWED_HOSTS = [
+#     "127.0.0.1",
+#     "localhost",
+# ]
+
+SECRET_KEY = get_str_env("SECRET_KEY", required=True)
+STATIC_ROOT = get_str_env("STATIC_ROOT", required=True)
+STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = get_str_env("EMAIL_HOST", required=True)
+DEFAULT_FROM_EMAIL = get_str_env("DEFAULT_FROM_EMAIL", required=True)
+
+SEND_NOTIFICATIONS = get_bool_env("ARGUS_SEND_NOTIFICATIONS", default=True)
+
+# Paths to plugins
+MEDIA_PLUGINS = [
+    "argus.notificationprofile.media.email.EmailNotification",
+]
 
 # Beware: setting this to something else in production has security implications
 INTERNAL_IPS = []  # Don't alter me, please

--- a/src/argus/site/settings/test_CI.py
+++ b/src/argus/site/settings/test_CI.py
@@ -2,14 +2,9 @@ import os
 import subprocess
 import logging.config
 
+from argus.htmx.settings import *  # noqa: F403
+
 from . import get_bool_env, get_str_env
-from .base import *  # noqa: F403
-from ..utils import update_settings
-
-from argus.htmx.appconfig import APP_SETTINGS
-
-update_settings(globals(), APP_SETTINGS)
-ROOT_URLCONF = "argus.htmx.root_urls"
 
 DEBUG = get_bool_env("DEBUG", True)
 TEMPLATES[0]["OPTIONS"]["debug"] = get_bool_env("TEMPLATE_DEBUG", True)  # noqa: F405

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ setenv =
     PIP_CONSTRAINT=constraints.txt
 
 commands =
-    pip-compile --extra htmx --resolver backtracking --output-file requirements-django52.txt {posargs} pyproject.toml requirements/django52.txt constraints.txt
+    pip-compile --resolver backtracking --output-file requirements-django52.txt {posargs} pyproject.toml requirements/django52.txt constraints.txt
     cp requirements-django52.txt requirements.txt
 
 [testenv:tailwind]


### PR DESCRIPTION
## Scope and purpose

Makes it easier and more Django standard to use an adapted settings file.

<!-- remove things that do not apply -->
### This pull request
* adds/changes/removes a dependency

The htmx dependencies are moved from the optional dependencies block to the project dependencies block.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done


<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
