### PR TITLE
Add option to set source type for fake incidents

### DIFF
--- a/changelog.d/+source-type-create-fake-incident.added.md
+++ b/changelog.d/+source-type-create-fake-incident.added.md
@@ -1,0 +1,1 @@
+Add option to set source type in create_fake_incident CLI command

--- a/src/argus/dev/management/commands/create_fake_incident.py
+++ b/src/argus/dev/management/commands/create_fake_incident.py
@@ -44,12 +44,8 @@ class Command(BaseCommand):
             help="Set level to <level>, otherwise a random number within the correct range is used",
         )
         parser.add_argument("-t", "--tags", nargs="+", type=str, help="Add the listed tags to the incident")
-        parser.add_argument(
-            "-s",
-            "--source",
-            type=str,
-            help="Use this source for the incident (the source needs to exist, see 'create_source' for creating one)",
-        )
+        parser.add_argument("-s", "--source", type=str, help="Use this source for the incident")
+        parser.add_argument("--source-type", type=str, help="Use this source type for the incident")
         parser.add_argument("--stateless", action="store_true", help="Create a stateless incident (end_time = None)")
         metadata_parser = parser.add_mutually_exclusive_group()
         metadata_parser.add_argument(
@@ -67,6 +63,7 @@ class Command(BaseCommand):
         tags = options.get("tags") or []
         description = options.get("description") or None
         source = options.get("source") or None
+        source_type = options.get("source_type") or None
         batch_size = options.get("batch_size") or 1
         level = options.get("level") or None
         stateful = False if options.get("stateless") else True
@@ -77,7 +74,7 @@ class Command(BaseCommand):
                 with metadata_path.open() as jsonfile:
                     metadata = json.load(jsonfile)
         if source:
-            call_command("create_source", [source, f"-t={source}"])
+            call_command("create_source", [source, f"-t={source_type or source}"])
 
         for i in range(batch_size):
             try:

--- a/src/argus/dev/management/commands/create_fake_incident.py
+++ b/src/argus/dev/management/commands/create_fake_incident.py
@@ -76,8 +76,8 @@ class Command(BaseCommand):
             if metadata_path:
                 with metadata_path.open() as jsonfile:
                     metadata = json.load(jsonfile)
-
-        call_command("create_source", [source, f"-t={source}"])
+        if source:
+            call_command("create_source", [source, f"-t={source}"])
 
         for i in range(batch_size):
             try:

--- a/tests/dev/test_create_fake_incident.py
+++ b/tests/dev/test_create_fake_incident.py
@@ -80,6 +80,23 @@ class CreateFakeIncidentTests(TestCase):
             Incident.objects.exclude(id__in=previous_incidents_pks).filter(source__name=source_name).exists()
         )
 
+    def test_create_fake_incident_will_create_single_fake_incident_with_set_source_and_source_type(self):
+        previous_incidents_pks = [incident.id for incident in Incident.objects.all()]
+
+        source_name = "notargus"
+        source_type = "abcd"
+
+        out = self.call_command(source=source_name, source_type=source_type)
+
+        self.assertFalse(out)
+
+        self.assertTrue(
+            Incident.objects.exclude(id__in=previous_incidents_pks)
+            .filter(source__name=source_name)
+            .filter(source__type__name=source_type)
+            .exists()
+        )
+
     def test_create_fake_incident_will_create_source_if_not_existing(self):
         source_name = "source_a"
 


### PR DESCRIPTION
## Scope and purpose

Gives the user the ability to not only specify a source when creating a fake incident, but also the source type. 

Also fixes a bug introduced in #1424: If no source is given the `create_source` is called, but the source name is interpreted as 'None' (a string), so a source with the name and type 'None' will be created. 

## Contributor Checklist

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
  - will add this in #1452
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
