### PR TITLE
Add "fake" ticket page that DummyPlugin links to when autocreating tickets

### DIFF
--- a/changelog.d/1194.added.md
+++ b/changelog.d/1194.added.md
@@ -1,0 +1,1 @@
+Add fake ticket page that DummyPlugin links to when creating a ticket.

--- a/src/argus/htmx/incident/urls.py
+++ b/src/argus/htmx/incident/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path("filter/delete/<int:pk>/", views.delete_filter, name="filter-delete"),
     path("filter/update/<int:pk>/", views.update_filter, name="filter-update"),
     path("filter/existing/", views.get_existing_filters, name="existing-filters"),
+    path("fake_ticket/<int:pk>/", views.get_fake_ticket, name="fake-ticket"),
 ]

--- a/src/argus/incident/ticket/dummy.py
+++ b/src/argus/incident/ticket/dummy.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 
 from factory import Faker
 import logging
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.urls import reverse
+
 
 from .base import TicketPlugin
 
@@ -56,8 +61,6 @@ class TicketTestClient:
         global created_tickets
         created_tickets.append((*args, kwargs))
 
-        return _get_fake_url()
-
 
 class DummyPlugin(TicketPlugin):
     """Example of a minimal plugin, can be used for testing"""
@@ -94,11 +97,14 @@ class DummyPlugin(TicketPlugin):
         endpoint, authentication, ticket_information = cls.import_settings()
 
         client = cls.create_client(endpoint=endpoint, authentication=authentication)
-        ticket_url = client.create(
+        client.create(
             {
                 "title": serialized_incident["description"],
                 "description": serialized_incident["description"],
             }
         )
-
-        return ticket_url
+        url = urljoin(
+            getattr(settings, "FRONTEND_URL", ""),
+            reverse("htmx:incident-detail", kwargs={"pk": serialized_incident["pk"]}),
+        )
+        return url

--- a/tests/incident/ticket_plugins/test_dummy.py
+++ b/tests/incident/ticket_plugins/test_dummy.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from argus.incident.factories import SourceSystemFactory, SourceUserFactory, StatefulIncidentFactory
 from argus.incident.ticket.dummy import created_tickets
@@ -16,6 +16,9 @@ class DummyTicketSystemTests(TestCase):
     def tearDown(self):
         connect_signals()
 
+    @override_settings(
+        FRONTEND_URL="http://www.fakeurl.com",
+    )
     def test_create_ticket_writes_to_local_variable(self):
         dummy_class = import_class_from_dotted_path("argus.incident.ticket.dummy.DummyPlugin")
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1194. 

Adds a page with information from an incident that kinda simulates what a real ticket could look like on a ticket site (very basic page). DummyPlugin will return a URL to this page when you use the "Create ticket" function.

Example of the basic page (uses a ticket html file that already existed):
![image](https://github.com/user-attachments/assets/82935fb8-e905-43fc-b5fd-377bf795f7be)


The url has the format `/incidents/fake_ticket/<pk>/`. I'll happily take suggestions for URL names and such, or potentially other ways to generate a page like this. I kinda just went with the "fake" naming scheme, but maybe it should be called something else. Maybe `/incidents/dummy_ticket/<pk>/` instead?

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
