### PR TITLE
Pass request to incident update actions

### DIFF
--- a/changelog.d/1497.changed.md
+++ b/changelog.d/1497.changed.md
@@ -1,0 +1,1 @@
+Request is now passed to incident update actions to allow for sending messages

--- a/docs/development/howtos/htmx-frontend/custom-incident-actions.rst
+++ b/docs/development/howtos/htmx-frontend/custom-incident-actions.rst
@@ -24,9 +24,9 @@ form of a dictionary ``argus.htmx.incident.views.INCIDENT_UPDATE_ACTIONS``. This
 contains a Form and a handling function for every action type. The Form is a ``django.forms.Form``
 and the handlers are functions with the following signature::
 
-  def action_handler(actor: User, qs: IncidentQuerySet, data: dict[str, Any]) -> Sequence[Incident]:
+  def action_handler(request: HtmxHttpRequest, qs: IncidentQuerySet, data: dict[str, Any]) -> Sequence[Incident]:
       """
-      :param actor: The user that requested the action
+      :param request: The django request that triggered the action
       :param qs: The queryset that contains all selected incidents
       :param data: a dictionary containing the Form's data
       :return: a sequence containing the incidents that have succesfully had the action applied
@@ -36,8 +36,8 @@ and the handlers are functions with the following signature::
 For the backend, all you need to do is update the action handler for the ``ack`` action. Let's
 assume that you have a custom action handler like this::
 
-  def custom_ack_handler(actor, qs, data):
-      incidents = bulk_ack_queryset(actor, qs, data) # the default behaviour
+  def custom_ack_handler(request, qs, data):
+      incidents = bulk_ack_queryset(request, qs, data) # the default behaviour
       ...  # add custom behaviour
       return incidents
 
@@ -84,7 +84,7 @@ create a ``Form`` for the action and register it together with the action handle
   class CustomActionForm(django.forms.Form):
       custom_field = django.forms.CharField()
 
-  def custom_action_handler(actor, qs, data):
+  def custom_action_handler(request, qs, data):
       ...
 
   class MyApp(AppConfig):

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -105,7 +105,7 @@ def incident_update(request: HtmxHttpRequest, action: str):
 
     form = get_form(request, formclass)
     if form.is_valid():
-        bulk_change_incidents(request.user, incident_ids, form.cleaned_data, callback_func)
+        bulk_change_incidents(request, incident_ids, form.cleaned_data, callback_func)
     else:
         messages.error(request, form.errors)
     return HttpResponseClientRefresh()

--- a/src/argus/htmx/utils.py
+++ b/src/argus/htmx/utils.py
@@ -24,7 +24,8 @@ def get_qs_for_incident_ids(incident_ids: list[int], qs=None):
     return qs, missing_ids
 
 
-def bulk_ack_queryset(actor, qs, data: dict[str, Any]):
+def bulk_ack_queryset(request, qs, data: dict[str, Any]):
+    actor = request.user
     timestamp = data["timestamp"]
     description = data.get("description", "")
     expiration = data.get("expiration", None)
@@ -35,7 +36,8 @@ def bulk_ack_queryset(actor, qs, data: dict[str, Any]):
     return incidents
 
 
-def bulk_close_queryset(actor, qs, data: dict[str, Any]):
+def bulk_close_queryset(request, qs, data: dict[str, Any]):
+    actor = request.user
     timestamp = data["timestamp"]
     description = data.get("description", "")
     events = qs.close(actor, timestamp, description)
@@ -45,7 +47,8 @@ def bulk_close_queryset(actor, qs, data: dict[str, Any]):
     return incidents
 
 
-def bulk_reopen_queryset(actor, qs, data: dict[str, Any]):
+def bulk_reopen_queryset(request, qs, data: dict[str, Any]):
+    actor = request.user
     timestamp = data["timestamp"]
     description = data.get("description", "")
     events = qs.reopen(actor, timestamp, description)
@@ -55,13 +58,15 @@ def bulk_reopen_queryset(actor, qs, data: dict[str, Any]):
     return incidents
 
 
-def bulk_change_ticket_url_queryset(actor, qs, data: dict[str, Any]):
+def bulk_change_ticket_url_queryset(request, qs, data: dict[str, Any]):
+    actor = request.user
     timestamp = data["timestamp"]
     ticket_url = data.get("ticket_url", "")
     return qs.update_ticket_url(actor, ticket_url, timestamp=timestamp)
 
 
-def single_autocreate_ticket_url_queryset(actor, incident_ids, data: dict[str, Any]):
+def single_autocreate_ticket_url_queryset(request, incident_ids, data: dict[str, Any]):
+    actor = request.user
     qs, _ = get_qs_for_incident_ids(incident_ids)
     incident = qs.get()
     autocreate_ticket(incident, actor, timestamp=data["timestamp"])
@@ -69,7 +74,7 @@ def single_autocreate_ticket_url_queryset(actor, incident_ids, data: dict[str, A
     return incident
 
 
-def bulk_change_incidents(actor, incident_ids: list[int], data: dict[str, Any], func, qs=None):
+def bulk_change_incidents(request, incident_ids: list[int], data: dict[str, Any], func, qs=None):
     """
     Update incidents in bulk
 
@@ -89,5 +94,5 @@ def bulk_change_incidents(actor, incident_ids: list[int], data: dict[str, Any], 
     qs, missing_ids = get_qs_for_incident_ids(incident_ids, qs)
     if not data.get("timestamp"):
         data["timestamp"] = timezone.now()
-    incidents = func(actor, qs, data)
+    incidents = func(request, qs, data)
     return incidents, missing_ids


### PR DESCRIPTION
## Scope and purpose


Incident update actions currently dont have any good way to report errors to the UI beyond causing a 500 and can fail silently. This PR passes the request to bulk actions to allow for sending messages to UI when errors occur. geant-argus has bulk actions which interact with external services which can be much less obvious if broken. Also extra checks such as checking for a user's write permission before executing some actions which need to send messages to indicate insufficient permissions in the UI.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
