### PR TITLE
Make `SourceSystemType` factory use lowercase name

### DIFF
--- a/changelog.d/1499.fixed.md
+++ b/changelog.d/1499.fixed.md
@@ -1,0 +1,1 @@
+Ensure SourceSystemTypeFactory is called with lowercase name

--- a/src/argus/dev/management/commands/create_source.py
+++ b/src/argus/dev/management/commands/create_source.py
@@ -15,6 +15,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         source = options["source"]
         source_type = options.get("source_type") or "argus"
-        sst = SourceSystemTypeFactory(name=source_type)
+        sst = SourceSystemTypeFactory(name=source_type.lower())
         user = SourceUserFactory(username=source)
         SourceSystemFactory(name=source, type=sst, user=user)

--- a/src/argus/incident/factories.py
+++ b/src/argus/incident/factories.py
@@ -23,6 +23,9 @@ __all__ = [
 class SourceSystemTypeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.SourceSystemType
+        # When calling this factory with a potentially not lowercase name make
+        # sure to force the name into lowercase first, since get_or_create
+        # cares about cases, but SourceSystemType.save() makes it lowercase
         django_get_or_create = ("name",)
 
     name = factory.Sequence(lambda s: "SourceSystemType %s" % s)

--- a/tests/dev/test_create_source.py
+++ b/tests/dev/test_create_source.py
@@ -56,7 +56,7 @@ class CreateSourceTests(TestCase):
         # So we need to test for using the same type with different cases
         previous_source_pks = [source.id for source in SourceSystem.objects.all()]
         source_name = "source name"
-        capitalized_source_type_name = "source type name"
+        capitalized_source_type_name = "Source Type Name"
         lowercase_source_type_name = capitalized_source_type_name.lower()
         existing_source_type = SourceSystemType.objects.create(name=lowercase_source_type_name)
 

--- a/tests/dev/test_create_source.py
+++ b/tests/dev/test_create_source.py
@@ -51,6 +51,21 @@ class CreateSourceTests(TestCase):
         self.assertTrue(source)
         self.assertEqual(source.type_id, existing_source_type.name)
 
+    def test_create_source_will_use_already_existing_source_system_type_with_differing_case(self):
+        # Source system types are forced to lowercase when saving
+        # So we need to test for using the same type with different cases
+        previous_source_pks = [source.id for source in SourceSystem.objects.all()]
+        source_name = "source name"
+        capitalized_source_type_name = "source type name"
+        lowercase_source_type_name = capitalized_source_type_name.lower()
+        existing_source_type = SourceSystemType.objects.create(name=lowercase_source_type_name)
+
+        call_command("create_source", source_name, source_type=capitalized_source_type_name)
+
+        source = SourceSystem.objects.exclude(id__in=previous_source_pks).filter(name=source_name).first()
+        self.assertTrue(source)
+        self.assertEqual(source.type_id, existing_source_type.name)
+
     def test_create_source_will_use_already_existing_source_system(self):
         previous_source_pks = [source.id for source in SourceSystem.objects.all()]
         source_name = "source name"


### PR DESCRIPTION
## Scope and purpose

We're using factory boy's [`django_get_or_create`](https://factoryboy.readthedocs.io/en/stable/orms.html#factory.django.DjangoOptions.django_get_or_create) to ensure that we don't create a source system type that does not already exist. The problem is that in the `SourceSystemType.save()` method we force the name to be lowercase, but the `get_or_create` cares about case, so if we try to call `SourceSystemTypeFactory` twice with an uppercase name, the first time a source system type is saved with the name forced to lowercase, but then the second time it does not find a source system type with the uppercase name, so it tries to create one (again with the name forced lowercase), but that leads to a database error:

```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "argus_incident_sourcesystemtype_pkey"
DETAIL:  Key (name)=(sikt nav) already exists.
```

I have not found a way to make `django_get_or_create` not care about case, so the easiest way was to always make sure `SourceSystemTypeFactory` is called with a lowercase name and to document it within the factory. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation
    not needed for bugfix
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
