### PR TITLE
Fix fields incorrectly marked as autocreated in squashed migration

### DIFF
--- a/changelog.d/1506.changed.md
+++ b/changelog.d/1506.changed.md
@@ -1,0 +1,1 @@
+Fix fields incorrectly marked as autocreated in squashed migration

--- a/src/argus/incident/migrations/0001_squashed_incident_20250514.py
+++ b/src/argus/incident/migrations/0001_squashed_incident_20250514.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Event',
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('timestamp', models.DateTimeField()),
                 ('received', models.DateTimeField(default=django.utils.timezone.now)),
                 ('type', models.TextField(choices=[('STA', 'Incident start'), ('END', 'Incident end'), ('CHI', 'Incident change'), ('CLO', 'Close'), ('REO', 'Reopen'), ('ACK', 'Acknowledge'), ('OTH', 'Other'), ('LES', 'Stateless')])),
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Incident',
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('start_time', models.DateTimeField(help_text='The time the incident was created.')),
                 ('end_time', argus.incident.fields.DateTimeInfinityField(blank=True, help_text="The time the incident was resolved or closed. If not set, the incident is stateless; if 'infinity' is checked, the incident is stateful, but has not yet been resolved or closed - i.e. open.", null=True)),
                 ('source_incident_id', models.TextField(blank=True, default='', verbose_name='source incident ID')),
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Tag',
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('key', models.TextField(validators=[argus.incident.validators.validate_key])),
                 ('value', models.TextField()),
             ],
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IncidentTagRelation',
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('added_time', models.DateTimeField(auto_now_add=True)),
                 ('added_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='tags_added', to=settings.AUTH_USER_MODEL)),
                 ('incident', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='incident_tag_relations', to='argus_incident.incident')),

--- a/src/argus/incident/migrations/0001_squashed_incident_20250514.py
+++ b/src/argus/incident/migrations/0001_squashed_incident_20250514.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Event',
             fields=[
-                ('id', models.BigAutoField(primary_key=True, serialize=False)),
+                ('id', models.BigAutoField(primary_key=True, serialize=False, verbose_name='ID')),
                 ('timestamp', models.DateTimeField()),
                 ('received', models.DateTimeField(default=django.utils.timezone.now)),
                 ('type', models.TextField(choices=[('STA', 'Incident start'), ('END', 'Incident end'), ('CHI', 'Incident change'), ('CLO', 'Close'), ('REO', 'Reopen'), ('ACK', 'Acknowledge'), ('OTH', 'Other'), ('LES', 'Stateless')])),
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Incident',
             fields=[
-                ('id', models.BigAutoField(primary_key=True, serialize=False)),
+                ('id', models.BigAutoField(primary_key=True, serialize=False, verbose_name='ID')),
                 ('start_time', models.DateTimeField(help_text='The time the incident was created.')),
                 ('end_time', argus.incident.fields.DateTimeInfinityField(blank=True, help_text="The time the incident was resolved or closed. If not set, the incident is stateless; if 'infinity' is checked, the incident is stateful, but has not yet been resolved or closed - i.e. open.", null=True)),
                 ('source_incident_id', models.TextField(blank=True, default='', verbose_name='source incident ID')),
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Tag',
             fields=[
-                ('id', models.BigAutoField(primary_key=True, serialize=False)),
+                ('id', models.BigAutoField(primary_key=True, serialize=False, verbose_name='ID')),
                 ('key', models.TextField(validators=[argus.incident.validators.validate_key])),
                 ('value', models.TextField()),
             ],
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IncidentTagRelation',
             fields=[
-                ('id', models.BigAutoField(primary_key=True, serialize=False)),
+                ('id', models.BigAutoField(primary_key=True, serialize=False, verbose_name='ID')),
                 ('added_time', models.DateTimeField(auto_now_add=True)),
                 ('added_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='tags_added', to=settings.AUTH_USER_MODEL)),
                 ('incident', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='incident_tag_relations', to='argus_incident.incident')),

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -189,7 +189,7 @@ class TagQuerySet(models.QuerySet):
 class Tag(models.Model):
     TAG_DELIMITER = "="
 
-    id = models.BigAutoField(primary_key=True)
+    id = models.BigAutoField(primary_key=True, verbose_name="ID")
     key = models.TextField(validators=[validate_key])
     value = models.TextField()
 
@@ -227,7 +227,7 @@ class Tag(models.Model):
 
 
 class IncidentTagRelation(models.Model):
-    id = models.BigAutoField(primary_key=True)
+    id = models.BigAutoField(primary_key=True, verbose_name="ID")
     tag = models.ForeignKey(to=Tag, on_delete=models.CASCADE, related_name="incident_tag_relations")
     incident = models.ForeignKey(to="Incident", on_delete=models.CASCADE, related_name="incident_tag_relations")
     added_by = models.ForeignKey(to=User, on_delete=models.PROTECT, related_name="tags_added")
@@ -262,7 +262,7 @@ class Event(models.Model):
     }
     ALLOWED_TYPES_FOR_END_USERS = {Type.CLOSE, Type.REOPEN, Type.ACKNOWLEDGE, Type.OTHER}
 
-    id = models.BigAutoField(primary_key=True)
+    id = models.BigAutoField(primary_key=True, verbose_name="ID")
     incident = models.ForeignKey(to="Incident", on_delete=models.PROTECT, related_name="events")
     actor = models.ForeignKey(to=User, on_delete=models.PROTECT, related_name="caused_events")
     timestamp = models.DateTimeField()
@@ -414,7 +414,7 @@ class IncidentQuerySet(models.QuerySet):
 class Incident(models.Model):
     LEVEL_CHOICES = tuple(zip(Level.values, map(str, Level.values)))
 
-    id = models.BigAutoField(primary_key=True)
+    id = models.BigAutoField(primary_key=True, verbose_name="ID")
     start_time = models.DateTimeField(help_text="The time the incident was created.")
     end_time = DateTimeInfinityField(
         null=True,


### PR DESCRIPTION
## Scope and purpose

Since the incident migrations were squashed in 7cbcc9fe7c843e500a6e6fcf8bfb92a2475e7084 it seems like makemigrations still detects some small changes in some BigAutoField's without making any changes to the database model. The reason for these changes seem to be that in the squashed migration these fields are marked as auto_created even though they are explicitly defined in the model. Removing auto_created and vebose_name from these fields makes makemigrations no longer detect changes. This also aligns with how these fields were defined in the latest migration before squashing where these fields were converted to BigAutoField (https://github.com/Uninett/Argus/commit/10bc007b672c367d4305340127aae8127cbb5488#diff-0f8dba41fb179ac51f795d2f691e8ec017ba2eb706190a6bc3ad5b7b8904f34f)
<details>
<summary>Generated migration with no model changes</summary>

```python
    class Migration(migrations.Migration):
    
        dependencies = [
            ("argus_incident", "0001_squashed_incident_20250514"),
        ]
    
        operations = [
            migrations.AlterField(
                model_name="event",
                name="id",
                field=models.BigAutoField(primary_key=True, serialize=False),
            ),
            migrations.AlterField(
                model_name="incident",
                name="id",
                field=models.BigAutoField(primary_key=True, serialize=False),
            ),
            migrations.AlterField(
                model_name="incidenttagrelation",
                name="id",
                field=models.BigAutoField(primary_key=True, serialize=False),
            ),
            migrations.AlterField(
                model_name="tag",
                name="id",
                field=models.BigAutoField(primary_key=True, serialize=False),
            ),
        ]
```

</details>

Related to discussion in #1504

<!-- remove things that do not apply -->
### This pull request
* changes the database


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If this results in changes to the database model: <del>Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)</del>
There are no changes to the ER diagram

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
