### PR TITLE
Send request into ticket creation function

### DIFF
--- a/changelog.d/+fix-request-to-ticket-creation.fixed.md
+++ b/changelog.d/+fix-request-to-ticket-creation.fixed.md
@@ -1,0 +1,1 @@
+Fixed sending request to ticket creation function which was forgotten in #1497

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -98,7 +98,7 @@ def incident_update(request: HtmxHttpRequest, action: str):
 
     if action == "autocreate-ticket":
         try:
-            single_autocreate_ticket_url_queryset(request.user, incident_ids, {"timestamp": tznow()})
+            single_autocreate_ticket_url_queryset(request, incident_ids, {"timestamp": tznow()})
         except TicketPluginException as e:
             messages.error(request, str(e))
         return HttpResponseClientRefresh()


### PR DESCRIPTION
## Scope and purpose

In #1497 the function signature of `single_autocreate_ticket_url_queryset` was changed, but one call was forgotten, leading to an internal server error when trying to automatically create a ticket.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
  it was already changed in the tests in #1497
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
