### PR TITLE
Drop mentioning Redis server as dependency in docker docs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,7 @@ settings](http://argus-server.rtfd.io/en/latest/site-specific-settings.html).
 ## Limitations
 
 This is not a complete Argus environment.  This image only defines the backend
-API server component. It still depends on a PostgreSQL and a Redis server to be
+API server component. It still depends on a PostgreSQL to be
 functional. Also, the Argus front-end component is needed to have a functional
 user interface against the API server.
 


### PR DESCRIPTION
## Scope and purpose

We do not rely on Redis server anymore since SPA frontend is discontinued. This PR drops last mentions of Redis server as dependency in the docker docs.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
