### PR TITLE
Fail codecov check on coverage drop more than 10%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,10 @@ coverage:
   status:
     project:
       default:
-        threshold: 90%
+        threshold: 10%
     patch:
       default:
-        threshold: 90%
+        threshold: 10%
 
 ignore:
   - "manage.py"


### PR DESCRIPTION
## Scope and purpose

Reference: https://docs.codecov.com/docs/commit-status#threshold

Currently the codecov check will succeed even on a 90% drop in coverage. I think 10% drop was the intended target, but we can of course discuss about the specific number. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] ~Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)~
* [ ] ~Added/amended tests for new/changed code~
* [ ] ~Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed~
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
   used the `https://codecov.io/validate` API endpoint to validate the config file
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
