### PR TITLE
Change production Docker image to work with Argus 2

### DIFF
--- a/changelog.d/+docker-2-1-1-htmx.fixed.md
+++ b/changelog.d/+docker-2-1-1-htmx.fixed.md
@@ -1,0 +1,1 @@
+Make Docker image work properly for Argus 2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /static && chown argus /static
 ENV STATIC_ROOT=/static
 
 COPY . /src
-RUN pip install '/src[spa]' && rm -rf /src
+RUN pip install /src && rm -rf /src
 
 # Install API backend settings suitable for Docker deployment
 RUN mkdir /extrapython

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,8 +3,7 @@
 django-admin collectstatic --noinput
 django-admin migrate --noinput
 exec gunicorn \
-     argus.spa.ws.asgi:application \
-     -k uvicorn.workers.UvicornWorker \
+     argus.site.wsgi:application \
      --forwarded-allow-ips="*" \
      --access-logfile - \
      -b 0.0.0.0:$PORT \


### PR DESCRIPTION
## Scope and purpose

The production-oriented Docker image (which is published automatically to
`gchr.io` on every new release) has never worked for Argus 2.

This updates the image to run Argus 2 with the new default HTMX front-end.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
