### PR TITLE
Improve prod docker setup and local documentation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,15 +2,19 @@
 # Needs the repository root directory as its context:
 #
 # If you're in the same dorectory as this Dockerfile try:
-#   docker build ..
+#   docker build -f Dockerfile ..
 #
 # If you're in the repository root try:
 #   docker build -f docker/Dockerfile .
 
-FROM python:3.12
+FROM python:3.13-trixie
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini build-essential
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install some dev requirements that aren't part of the minimal dependencies:
 RUN pip install psycopg2-binary django-extensions python-dotenv gunicorn

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,10 +21,23 @@ docker build -t argus -f docker/Dockerfile .
 ## Configuration of the running container
 
 This image runs with default production settings, with a few tweaks from
-[dockersettings.py](dockersettings.py). This means that the most useful
-settings can be overriden through the use of environment variables exported to
-the container.  Consult the documentation section on [site-specific
+[dockersettings.py](dockersettings.py). The most useful settings can be
+overriden through the use of environment variables exported to the container,
+but some MUST be set.
+
+The required environment variables in question are:
+
+* `ARGUS_FRONTEND_URL` (url)
+* `DATABASE_URL` (example: postgresql://argus:PASSWORD@HOST.NAME:5432/argus)
+* `DEFAULT_FROM_EMAIL` (email address)
+* `EMAIL_HOST` (hostname or ip address)
+* `SECRET_KEY` (long random string, around 50 characters is good)
+
+The `SECRET_KEY` and `DATABASE_URL` should be protected from prying eyes.
+
+Consult the documentation section on [site-specific
 settings](http://argus-server.rtfd.io/en/latest/site-specific-settings.html).
+for further details.
 
 ## Limitations
 


### PR DESCRIPTION
For Uninett/argus-docker/pull/36

Hopefully make it easier to use the stuff in `/docker/` to run Argus in production via docker.

* Fix error in comment on how to build
* Lock down distro version and explicitly use the default Python version for that distro version.
* Control where deps are installed and explicitly set VIRTUAL_ENV and PATH.
* Add required environment variables to README

This dockerfile is used by `Uninett/argus-docker`.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* ~[ ] Added/amended tests for new/changed code~
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* ~[ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)~
* ~[ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)~
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
