### PR TITLE
Hide potentially dangerous files from sdist build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,12 @@ artifacts = ["src/argus/version.py"]
 packages = ["src/argus"]
 
 [tool.hatch.build.targets.sdist]
-exclude = ["/.github"]
+exclude = [
+    "/.github",
+    "/*.json",
+    "/*.py",
+    "/*.sh",
+]
 
 [tool.versioningit.write]
 file = "src/argus/version.py"


### PR DESCRIPTION
## Scope and purpose

While experimenting it is quick to whip up temporary settings-files, app settings (json files), shell scripts and other crud that ends up as siblings of 'src/'. These should never be included in an sdist and distributed to the world, but are frequently not long-lived enough to be put in a .gitignore. Being able to see them when running `git status` is useful though.

When releasing with hatchling, it normally includes everything in the repo that is not excluded by .gitignore. This means if you don't remember to `git stash -u` before building the new release you might get a nasty surprise... but everyone always manually check for unwanted files (new version of dependency? new surprises! new linter version? new surprises!) in the sdist anyway, right? Right?

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* ~[ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)~
* ~[ ] Added/amended tests for new/changed code~
* ~[ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed~
* ~[ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)~
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* ~[ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
