### PR TITLE
Replace typing.Union with |

### DIFF
--- a/src/argus/auth/models.py
+++ b/src/argus/auth/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-from typing import Any, Optional, Sequence, Union, Protocol
+from typing import Any, Optional, Protocol, Sequence
 
 from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
@@ -80,7 +80,7 @@ class User(AbstractUser):
     def is_end_user(self):
         return not hasattr(self, "source_system")
 
-    def is_member_of_group(self, group: Union[str, Group]):
+    def is_member_of_group(self, group: str | Group):
         if isinstance(group, str):
             try:
                 group = Group.objects.get(name=group)

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import logging
-from typing import Mapping, Union
+from typing import Mapping
 
 from django.conf import settings
 from django.contrib.auth.backends import ModelBackend, RemoteUserBackend
@@ -62,7 +62,7 @@ def get_preference(request, namespace, preference):
     return prefs.get_preference(preference)
 
 
-def save_preferences(request, data, namespace_or_prefs: Union[str, Preferences]):
+def save_preferences(request, data, namespace_or_prefs: str | Preferences):
     prefs = (
         namespace_or_prefs
         if isinstance(namespace_or_prefs, Preferences)

--- a/src/argus/htmx/incident/customization.py
+++ b/src/argus/htmx/incident/customization.py
@@ -6,7 +6,7 @@ Currently customizable UI elements:
 """
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 from django.conf import settings
 
@@ -150,7 +150,7 @@ def get_incident_table_columns() -> list[IncidentTableColumn]:
     return [_resolve_column(col) for col in columns]
 
 
-def _resolve_column(col: Union[str, IncidentTableColumn]):
+def _resolve_column(col: str | IncidentTableColumn):
     if isinstance(col, str):
         try:
             col = BUILTIN_COLUMNS[col]

--- a/src/argus/htmx/incident/utils.py
+++ b/src/argus/htmx/incident/utils.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Union, Literal
+from typing import Literal
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -9,7 +9,7 @@ from argus.htmx import defaults
 FUNCTION_NAME_DEFAULT = "incident_list_filter"
 
 
-def update_interval_string(value: Union[int, Literal["never"]]):
+def update_interval_string(value: int | Literal["never"]):
     if value == "never":
         return "Never"
     return f"{value}s"

--- a/src/argus/htmx/templatetags/argus_htmx.py
+++ b/src/argus/htmx/templatetags/argus_htmx.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal
 from django import template
 from django.contrib.messages.storage.base import Message
 from django.conf import settings
@@ -69,7 +69,7 @@ def autoclose_time(message: Message):
 
 
 @register.filter
-def update_interval_string(value: Union[int, Literal["never"]]):
+def update_interval_string(value: int | Literal["never"]):
     if value == "never":
         return "Never"
     return f"{value}s"

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -7,7 +7,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from types import NoneType
-    from typing import Union
 
     from django.contrib.auth import get_user_model
     from django.db.models.query import QuerySet
@@ -116,7 +115,7 @@ class NotificationMedium(ABC):
             )
 
     @staticmethod
-    def update(destination: DestinationConfig, validated_data: dict) -> Union[DestinationConfig, NoneType]:
+    def update(destination: DestinationConfig, validated_data: dict) -> DestinationConfig | NoneType:
         """
         Updates a destination in case the normal update function is not
         sufficient and returns the updated destination in that case,

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from types import NoneType
-    from typing import Union
 
     from django.contrib.auth import get_user_model
     from django.db.models.query import QuerySet
@@ -107,7 +106,7 @@ class EmailNotification(NotificationMedium):
             )
 
     @staticmethod
-    def update(destination: DestinationConfig, validated_data: dict) -> Union[DestinationConfig, NoneType]:
+    def update(destination: DestinationConfig, validated_data: dict) -> DestinationConfig | NoneType:
         """
         Updates the synced email destination by copying its contents to
         a new destination and updating the given destination with the given

--- a/src/argus/util/admin_utils.py
+++ b/src/argus/util/admin_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence, Union
+from typing import Callable, Sequence
 
 from django.contrib import admin
 from django.contrib.admin.utils import quote
@@ -55,7 +55,7 @@ def list_filter_factory(
 
 def add_elements_to_deleted_objects(
     objs: Sequence[Model],
-    to_delete: list[Union[str, list]],
+    to_delete: list[str | list],
     get_elements_func: Callable[[Model], Sequence[Model]],
     admin_site,
 ):


### PR DESCRIPTION
## Scope and purpose

Fixes #1596. Since we're running Python 3.10+ we can replace it.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
  documentation for how to handle SonarQube follows in another PR
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
