### PR TITLE
Add docs on how to handle sonarqube

### DIFF
--- a/docs/development/howtos/sonarqube.rst
+++ b/docs/development/howtos/sonarqube.rst
@@ -1,0 +1,19 @@
+=======================
+Howto: Handle sonarqube
+=======================
+
+We use `sonarqube`_ to scan new code for potential issues and security hotspots.
+It posts comments on pull requests when it finds new issues in that code using rules
+defined by the developer team at Sikt.
+
+But we sometimes also disagree with how it handles parts of certain rules. We will
+document that here and which comment to use when marking such an issue as accepted or
+false positive.
+
+python:S1192 - String literals should not be duplicated
+-------------------------------------------------------
+
+If it makes it more readable, for example if configuration is happening within the
+Python code, then we accept it with "This is better for readability".
+
+.. _sonarqube: https://www.sonarsource.com/products/sonarcloud/


### PR DESCRIPTION
## Scope and purpose

After working on #1596 this is a start for docs that can be extended every time we are annoyed by sonarqube to document which explanation to use when marking an issue as false positive or accepted. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
