### PR TITLE
Add auto-alignment of filterable column dropdown

### DIFF
--- a/changelog.d/1607.changed.md
+++ b/changelog.d/1607.changed.md
@@ -1,0 +1,1 @@
+Auto-align filterable column dropdown if it extends beyond the screen

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -3,7 +3,7 @@
 {% with field=form|get_form_field:fieldname %}
   <div>
     {{ column.label }}
-    <div class="dropdown dropdown-end">
+    <div id="{{ column.name }}-dropdown" class="dropdown">
       <button type="button"
               tabindex="0"
               class="filter-btn btn btn-xs {% if field.value %} btn-primary {% else %} btn-ghost text-primary {% endif %} min-h-4 h-4">
@@ -25,3 +25,16 @@
     </div>
   </div>
 {% endwith %}
+<script>
+document.querySelector('#{{ column.name }}-dropdown .filter-btn').addEventListener('focus', function() {
+  const dropdown = this.closest('.dropdown');
+  const content = dropdown.querySelector('.dropdown-content');
+  const rect = content.getBoundingClientRect();
+
+  if (rect.right > window.innerWidth) {
+    dropdown.classList.add('dropdown-end');
+  } else if (rect.left < 0) {
+    dropdown.classList.remove('dropdown-end');
+  }
+});
+</script>


### PR DESCRIPTION
## Scope and purpose

Follow-up to #1598, which changed filterable column dropdowns to use DaisyUI dropdowns. However, as this PR added end-alignment (instead of start-alignment) to all columns, it does not work well when a filterable column is among the first columns. To avoid the dropdown extending beyond the screen, this PR adds auto-alignment by checking whether the `.dropdown-content` is within the viewport or not.

## Screenshots
<img width="519" height="141" alt="image" src="https://github.com/user-attachments/assets/26223171-95f2-4d54-a8db-dd4a3b351521" />
<img width="497" height="107" alt="image" src="https://github.com/user-attachments/assets/3c222362-59a0-483e-8dff-b19e12213fb6" />

## How to test

I tested by adding two columns to the end of the default `INCIDENT_TABLE_COLUMNS` list:
```
    "search_description",
    "select_levels",
```


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
