### PR TITLE
Adjust default column dropdown alignment to avoid horizontal scrollbar

### DIFF
--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -3,7 +3,7 @@
 {% with field=form|get_form_field:fieldname %}
   <div>
     {{ column.label }}
-    <div id="{{ column.name }}-dropdown" class="dropdown">
+    <div id="{{ column.name }}-dropdown" class="dropdown dropdown-end">
       <button type="button"
               tabindex="0"
               class="filter-btn btn btn-xs {% if field.value %} btn-primary {% else %} btn-ghost text-primary {% endif %} min-h-4 h-4">


### PR DESCRIPTION
## Scope and purpose

Fixes #1622

This PR fixes a bug where a column dropdown at the end of the table causes a horizontal scrollbar. This happens because DaisyUI hides elements by using `visibility: hidden; opacity: 0;`, which means the element is still rendered in the dom (and extending beyond the screen). This is necessary for show/hide animations to work (display: none; is not animatable)

I tried adding a check-on-load as to whether the dropdown-content extends beyond the screen, but due to invisible elements not having measurable width (yay), and to avoid changing DaisyUI dropdown styles, I ended up with a very simple solution: The default dropdown alignment is set to `dropdown-end`. This means that the auto-alignment introduced in #1607 will only flip columns that extend beyond the _left_ of the screen.

No news as this functionality is covered in #1598 and #1607.



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
