### PR TITLE
Add rudimentary docs for planned maintenance

### DIFF
--- a/docs/about-argus.rst
+++ b/docs/about-argus.rst
@@ -67,6 +67,7 @@ server, such as:
 * Administration of Argus user accounts
 * Creating API authentication tokens for users
 * Defining new source systems to collect incidents from
+* Creating and updating planned maintenance tasks
 
 Pick and choose
 ---------------

--- a/docs/reference/models.rst
+++ b/docs/reference/models.rst
@@ -89,6 +89,18 @@ Handling notifications
       Holds a ``DestinationConfig``'s type. The ``installed``-field is updated
       on startup to keep track of which ``notification plugin``\s are installed.
 
+Handling maintenance work
+=========================
+
+.. glossary::
+
+   PlannedMaintenanceTask
+      Holds who created the task and when (not editable), the start and end time
+      of such a task, and a description of what this maintenance work entails and/or
+      why it is happening.
+
+      It also holds a collection of ``Filter``\s that describe what kind of events are
+      covered by that planned maintenance.
 
 ER diagram
 ==========

--- a/docs/reference/planned-maintenance.rst
+++ b/docs/reference/planned-maintenance.rst
@@ -1,0 +1,43 @@
+===================
+Planned maintenance
+===================
+
+To interact with planned maintenance tasks visit the admin interface at:
+``/admin/argus_plannedmaintenance/plannedmaintenancetask/``.
+
+A planned maintenance task consists of a start time and an end time (where the latter
+is by default infinity). Those define the period during which planned work is happening
+and when notifications for events, for example for affected devices, should not be
+sent.
+
+Filters are used to define exactly which kind of events notifications should be
+suppressed for. As it is for notification profiles, if multiple filters are connected
+to one planned maintenance task, then that tasks will only lead to a notification being
+suppressed if all of the filters apply to that event.
+
+.. warning:: When notifications are suppressed during a planned maintenance task and
+    that task ends, while the incident is still open, you will not receive a
+    notification.
+    It is your responsibility to check that everything is resolved when a planned
+    maintenance task is finished!
+
+The planned maintenance task list
+=================================
+
+In the admin you can view a list of planned maintenance tasks, filter them and search
+for specific ones.
+
+You can also select multiple planned maintenance tasks and delete them or mark them as
+finished. Marking a task as finished will set an open task's end time to the current
+time. If you mark a task as finished that has not begun yet, then that task will be
+deleted.
+
+Adding/editing a planned maintenance task
+=========================================
+
+If you want to add a planned maintenance task click the
+``Add planned maintenance task`` button. If you want to see details for a specific
+task or edit it, click the username in the column ``created by``.
+
+You can mark an existing task as finished and see its history by clicking on the
+buttons in the top right corner of the edit page.


### PR DESCRIPTION
## Scope and purpose

Good to have some docs for the new planned maintenance functionality.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
