### PR TITLE
Split user preferences in two sections

### DIFF
--- a/changelog.d/1557.changed.md
+++ b/changelog.d/1557.changed.md
@@ -1,0 +1,1 @@
+Split user preferences into multiple sections

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -5196,6 +5196,11 @@ details.collapse summary::-webkit-details-marker {
   margin-bottom: 1rem;
 }
 
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .-ml-2 {
   margin-left: -0.5rem;
 }
@@ -5404,6 +5409,14 @@ details.collapse summary::-webkit-details-marker {
 
 .max-w-xs {
   max-width: 20rem;
+}
+
+.max-w-md {
+  max-width: 28rem;
+}
+
+.max-w-screen-md {
+  max-width: 768px;
 }
 
 .flex-1 {
@@ -5819,6 +5832,10 @@ details.collapse summary::-webkit-details-marker {
   padding: 1.5rem;
 }
 
+.p-0\.5 {
+  padding: 0.125rem;
+}
+
 .px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
@@ -6200,6 +6217,10 @@ details.collapse summary::-webkit-details-marker {
 @media (min-width: 1024px) {
   .lg\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .lg\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/src/argus/htmx/templates/htmx/user/preference_form/_base_form.html
+++ b/src/argus/htmx/templates/htmx/user/preference_form/_base_form.html
@@ -1,0 +1,19 @@
+<section id="{% block section_id %}{% endblock section_id %}"
+         class="card card-base border border-base-200 p-4 max-w-screen-md mx-auto space-y-2">
+  <h3 class="card-title text-xl">
+    {% block section_title %}
+    {% endblock section_title %}
+  </h3>
+  <form hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"
+        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        class="space-y-2">
+    <ul class="card-body menu">
+      {% block section_forms %}
+      {% endblock section_forms %}
+    </ul>
+    <div class="preference-form-actions flex justify-end gap-2 px-2">
+      <button class="btn btn-primary btn-sm">Save preferences</button>
+      <button type="reset" class="btn btn-sm">Reset</button>
+    </div>
+  </form>
+</section>

--- a/src/argus/htmx/templates/htmx/user/preference_form/_incident_table_form.html
+++ b/src/argus/htmx/templates/htmx/user/preference_form/_incident_table_form.html
@@ -1,0 +1,10 @@
+{% extends "htmx/user/preference_form/_base_form.html" %}
+{% block section_id %}
+  user-settings
+{% endblock section_id %}
+{% block section_title %}
+  Incident Table
+{% endblock section_title %}
+{% block section_forms %}
+  {% for form in incident_forms %}{{ form }}{% endfor %}
+{% endblock section_forms %}

--- a/src/argus/htmx/templates/htmx/user/preference_form/_preference_form_script.html
+++ b/src/argus/htmx/templates/htmx/user/preference_form/_preference_form_script.html
@@ -1,0 +1,26 @@
+<script>
+const BUTTON_SELECTOR = '.preference-form-actions button';
+document.querySelectorAll('form').forEach(form => {
+    const getFormData = f => JSON.stringify(Object.fromEntries(new FormData(f)));
+    const initial = getFormData(form);
+
+    // Disable all preference buttons on initialization
+    form.querySelectorAll(BUTTON_SELECTOR).forEach(btn => {
+        btn.disabled = true;
+    });
+
+    const updateButtons = () => {
+        const current = getFormData(form);
+        const dirty = current !== initial;
+        form.querySelectorAll(BUTTON_SELECTOR).forEach(btn => {
+            btn.disabled = !dirty;
+        });
+    };
+
+    form.addEventListener('input', updateButtons);
+    form.addEventListener('change', updateButtons);
+    form.addEventListener('reset', () => {
+        setTimeout(updateButtons, 0);
+    });
+});
+</script>

--- a/src/argus/htmx/templates/htmx/user/preference_form/_theme_and_format_form.html
+++ b/src/argus/htmx/templates/htmx/user/preference_form/_theme_and_format_form.html
@@ -1,0 +1,10 @@
+{% extends "htmx/user/preference_form/_base_form.html" %}
+{% block section_id %}
+  theme-settings
+{% endblock section_id %}
+{% block section_title %}
+  Theme and Format
+{% endblock section_title %}
+{% block section_forms %}
+  {% for form in theme_forms %}{{ form }}{% endfor %}
+{% endblock section_forms %}

--- a/src/argus/htmx/templates/htmx/user/preferences_list.html
+++ b/src/argus/htmx/templates/htmx/user/preferences_list.html
@@ -2,13 +2,11 @@
 {% extends "htmx/base.html" %}
 {% block main %}
   <div class="p-4 space-y-4">
-    <h1 class="text-3xl">{{ page_title }}</h1>
-    <section id="user-settings" class="card">
-      <ul class="menu card-body">
-        {% block preferences %}
-          {% for form in forms.values %}{{ form }}{% endfor %}
-        {% endblock preferences %}
-      </ul>
-    </section>
+    {% include "htmx/components/_page_title.html" %}
+    {% block preferences %}
+      {% include "htmx/user/preference_form/_theme_and_format_form.html" %}
+      {% include "htmx/user/preference_form/_incident_table_form.html" %}
+      {% include "htmx/user/preference_form/_preference_form_script.html" %}
+    {% endblock preferences %}
   </div>
 {% endblock main %}

--- a/src/argus/htmx/templates/htmx/user/radio_option.html
+++ b/src/argus/htmx/templates/htmx/user/radio_option.html
@@ -2,9 +2,7 @@
 <input type="radio"
        class="btn btn-sm btn-block btn-ghost justify-start"
        {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
+       {% if widget.attrs.checked %}checked="checked"{% endif %}
        aria-label="{{ widget.label }}"
        name="{{ widget.name }}"
-       autocomplete="off"
-       hx-post="{% url 'htmx:update-preferences' namespace='argus_htmx' %}"
-       hx-trigger="change"
-       hx-headers='{"X-CSRFToken": "{{ widget.attrs.csrf_token }}"}' />
+       autocomplete="off" />

--- a/src/argus/htmx/user/views.py
+++ b/src/argus/htmx/user/views.py
@@ -9,15 +9,22 @@ from argus.htmx.incident.views import HtmxHttpRequest
 from argus.htmx.user.preferences.utils import setup_preference_forms
 
 
+THEME_PREFERENCES = ["theme", "datetime_format_name"]
+
+
 @require_GET
 def user_preferences(request) -> HttpResponse:
     """Renders the main preferences page for a user"""
 
     forms = setup_preference_forms(request)
+    theme_forms = [form for name, form in forms.items() if name in THEME_PREFERENCES]
+    incident_forms = [form for name, form in forms.items() if name not in THEME_PREFERENCES]
 
     context = {
         "page_title": "User preferences",
         "forms": forms,
+        "theme_forms": theme_forms,
+        "incident_forms": incident_forms,
     }
 
     return render(request, "htmx/user/preferences_list.html", context=context)


### PR DESCRIPTION
## Scope and purpose

Part 1 of redesigning preference page (#1557)

This PR refactors the user preferences into two form groups, ie. "Theme and Format" and "Incident Table" fields.

* Changes are no longer saved on input change, but when the form as a whole is submitted. This is in preparation of adding "preview effects", i.e. show the effects of selecting one option over another. 
* Each option group shows the currently checked option on initial load, not just after selecting.
* Each form group has a save and clear button, which are disabled when no changes have been made. This is intended to make it clear that client-side changes are not saved yet.
* The layout of the preferences page has been modified slightly. Namely, the title has been centered, and there is a max width and centering on forms.

## Screenshots

### Before
<img width="943" height="441" alt="image" src="https://github.com/user-attachments/assets/352df28c-6ef9-4823-91f5-12f22c50d8f2" />

### After

#### Default preference forms without changes
<img width="943" height="762" alt="image" src="https://github.com/user-attachments/assets/9fb36ec0-7fd3-4fb5-b148-77abf5b978f7" />

#### Form buttons are enabled when changes are made to the form (it is "dirty") 
<img width="803" height="331" alt="image" src="https://github.com/user-attachments/assets/406a82fc-fac9-4d64-95e6-a4cae9e7afc2" />



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
