### PR TITLE
Fix some planned mainenance tests

### DIFF
--- a/tests/plannedmaintenance/test_utils.py
+++ b/tests/plannedmaintenance/test_utils.py
@@ -65,9 +65,11 @@ class TestIncidentsCoveredByPlannedMaintenanceTask(TestCase):
 class TestEventCoveredByPlannedMaintenanceTasks(TestCase):
     def setUp(self):
         disconnect_signals()
-        self.start_event = EventFactory(type=Event.Type.INCIDENT_START)
+        self.default_level = 5
+        self.incident = StatefulIncidentFactory(level=self.default_level)
+        self.start_event = EventFactory(incident=self.incident, type=Event.Type.INCIDENT_START)
         self.current_pm = PlannedMaintenanceFactory()
-        self.maxlevel_filter = FilterFactory(filter={"maxlevel": 5})
+        self.maxlevel_filter = FilterFactory(filter={"maxlevel": self.default_level})
 
     def teardown(self):
         connect_signals()


### PR DESCRIPTION
## Scope and purpose

Fixes spurious failure: level wasn't explicitly set, so when testing a filter checking maxlevel it sometimes, guaranteed randomly, failed.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
