### PR TITLE
Fix bug where status icons render on top of header when scrolling

### DIFF
--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -5164,12 +5164,21 @@ details.collapse summary::-webkit-details-marker {
   z-index: 1;
 }
 
+.z-20 {
+  z-index: 20;
+}
+
 .m-1 {
   margin: 0.25rem;
 }
 
 .m-4 {
   margin: 1rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .my-0 {
@@ -5383,6 +5392,10 @@ details.collapse summary::-webkit-details-marker {
 
 .max-w-\[30\%\] {
   max-width: 30%;
+}
+
+.max-w-screen-md {
+  max-width: 768px;
 }
 
 .max-w-sm {
@@ -5654,6 +5667,11 @@ details.collapse summary::-webkit-details-marker {
 
 .border-none {
   border-style: none;
+}
+
+.border-base-200 {
+  --tw-border-opacity: 1;
+  border-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-border-opacity, 1)));
 }
 
 .border-neutral-content {

--- a/src/argus/htmx/templates/htmx/incident/_base_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_base_incident_table.html
@@ -4,7 +4,7 @@
        {% endblock incident_list_table_autorefresh %}>
   <!-- htmx/incident/_incident_table.html, including table tag above -->
   <thead>
-    <tr class="border-b border-primary bg-base-100 sticky top-0">
+    <tr class="border-b border-primary bg-base-100 sticky top-0 z-10">
       {% block columns %}
         {% for col in columns %}
           <th class="border-b border-primary {{ col.column_classes }}">

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -1,4 +1,4 @@
-<ul class="menu menu-md dropdown-content bg-base-200 text-base-content rounded-box z-[1] mt-3 w-52 p-2 shadow max-h-svh">
+<ul class="z-20 menu menu-md dropdown-content bg-base-200 text-base-content rounded-box z-[1] mt-3 w-52 p-2 shadow max-h-svh">
   <li class="menu-title">
     Logged in as: <span class="text-info">{{ request.user }}</span>
     <div class="divider divider-secondary my-0 pointer-events-none"></div>


### PR DESCRIPTION
## Scope and purpose

Follow-up to PR #1636 which resolved #1635. 

Nonews as the change is so small, and just a quick-fix to the fragment in #1636.
 
The status icon columns are rendered on top of the sticky header (z-index issue), which is fixed by this PR.
I also added z-index to the user menu, so it renders on top of the table header.

## Screenshots

### Before
<img width="476" height="102" alt="image" src="https://github.com/user-attachments/assets/f92480c0-ab6e-44e5-b152-06e1c0edb041" />

### After
<img width="399" height="87" alt="image" src="https://github.com/user-attachments/assets/be3f5889-d3d2-47b8-af75-c8ce1f3abf62" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
