### PR TITLE
Change all mentions of master to main in docs and workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,7 +2,7 @@ name: Verify formatting
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
 
 jobs:

--- a/.github/workflows/generate-er-model.yml
+++ b/.github/workflows/generate-er-model.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create pull request
         run: |
-          gh pr create -B master -H update-er-model-${{ github.run_number }} \
+          gh pr create -B main -H update-er-model-${{ github.run_number }} \
           --title 'Update ER model' \
           --body 'Created by GitHub action, triggered manually by @${{ github.actor }}'
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,7 +2,7 @@ name: Test django site
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
   schedule: # Run daily at 08:00 CEST (06:00 UST)
     - cron: '0 6 * * *'

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -21,4 +21,4 @@ jobs:
         sudo apt-get install -y pipx
         pipx install towncrier
     - name: Check for changelog file
-      run: towncrier check --compare-with origin/master
+      run: towncrier check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ read by developers.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/Uninett/Argus/tree/master/changelog.d/>.
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/Uninett/Argus/tree/main/changelog.d/>.
 
 <!-- towncrier release notes start -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Argus
 [![test badge](https://github.com/Uninett/Argus/actions/workflows/python.yml/badge.svg)](https://github.com/Uninett/Argus/actions)
-[![codecov badge](https://codecov.io/gh/Uninett/Argus/branch/master/graph/badge.svg)](https://codecov.io/gh/Uninett/Argus)
+[![codecov badge](https://codecov.io/gh/Uninett/Argus/branch/main/graph/badge.svg)](https://codecov.io/gh/Uninett/Argus)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![djLint](https://img.shields.io/badge/html%20style-djlint-blue.svg)](https://www.djlint.com)
 [![docs badge](https://readthedocs.org/projects/argus-server/badge/?version=latest&style=flat)](http://argus-server.rtfd.io/en/latest/)
@@ -261,12 +261,12 @@ Refer to the [tox.ini](tox.ini) file for further options.
 
 Do not ever remove these
 
-* master
+* main
 * argus-demo
 * stable/SOMETHING
 
 The last branch-type is for backporting bugfixes and similar to older releases,
-bypassing master if necessary.
+bypassing main if necessary.
 
 
 ## How to do maintenance

--- a/docs/development/howtos/release-checklist.rst
+++ b/docs/development/howtos/release-checklist.rst
@@ -43,11 +43,11 @@ not needed to do this yet.
 Checklist
 ---------
 
-#. Ensure you're on the correct branch to be released. Either ``master`` or
+#. Ensure you're on the correct branch to be released. Either ``main`` or
    newest stable, which has a name of the form ``stable/1.5.x``. Release from
    the stable branch only under exceptional circumstances. For instance:
    there's a critical bugfix for production and there's a lot of new stuff on
-   master that is not ready to go.
+   main that is not ready to go.
 
 #. Check that there are no files that have not been commited:
 

--- a/docs/development/howtos/vendor-a-repo.rst
+++ b/docs/development/howtos/vendor-a-repo.rst
@@ -55,7 +55,7 @@ Prep the ORIGIN repo
 
         git fetch TARGET
 
-9. Merge ORIGIN-clone's "main" into feceiving's "master"::
+9. Merge ORIGIN-clone's "main" into receiving's "master"::
 
         git merge --allow-unrelated-histories TARGET/master
 

--- a/docs/integrations/notifications/writing-notification-plugins.rst
+++ b/docs/integrations/notifications/writing-notification-plugins.rst
@@ -4,7 +4,7 @@ Writing your own notification plugin
 ====================================
 
 When writing a new notification plugin the plugins for
-`SMS-as-Email <https://github.com/Uninett/Argus/blob/master/src/argus/notificationprofile/media/sms_as_email.py>`_
+`SMS-as-Email <https://github.com/Uninett/Argus/blob/main/src/argus/notificationprofile/media/sms_as_email.py>`_
 and
 `Teams <https://github.com/Uninett/argus_notification_msteams/blob/main/src/argus_notification_msteams.py>`_
 can be used as guides.


### PR DESCRIPTION
## Scope and purpose

I realized that the workflows were still referencing master instead of main.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
