### PR TITLE
Improve admin for source systems

### DIFF
--- a/src/argus/incident/admin.py
+++ b/src/argus/incident/admin.py
@@ -53,12 +53,14 @@ class SourceSystemTypeAdmin(TextWidgetsOverrideModelAdmin):
 
 
 class SourceSystemAdmin(TextWidgetsOverrideModelAdmin):
-    list_display = ("name", "type", "user")
-    search_fields = ("name", "user__username")
+    list_display = ("id", "name", "type", "user")
+    list_display_links = ("id", "name")
+    search_fields = ("id", "name", "user__username")
     list_filter = ("type",)
 
     text_input_form_fields = ("name",)
     raw_id_fields = ("user",)
+    readonly_fields = ("id",)
 
     def get_form(self, request, obj=None, **kwargs):
         # If add form (instead of change form):


### PR DESCRIPTION
## Scope and purpose

A bug in `create_source` necessitated using the admin to create a source and that was also fraught with peril.

Filtering on source uses a source's id, but the id wasn't readily visible in the admin. Now it is.

This PR is a collection of admin changes to make working with sources easier.

## Note!

I suspect tests break here for the exact same reason that they break in #1820: Because `readonly_fields` is set while `user` is excluded in the AddSourceSystemForm.

## Screenshots

User admin, before:

<img width="275" height="514" alt="image" src="https://github.com/user-attachments/assets/9ebca113-efbb-49a6-a128-85b1d9150f8f" />

 User admin, after:

<img width="276" height="624" alt="image" src="https://github.com/user-attachments/assets/bf1f223a-41b3-44f0-93ef-58583f20c612" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
