### PR TITLE
Use correct filterwrapper for pm

### DIFF
--- a/src/argus/plannedmaintenance/models.py
+++ b/src/argus/plannedmaintenance/models.py
@@ -59,8 +59,13 @@ class PlannedMaintenanceTask(models.Model):
         return self.end_time > timezone.now() - MODIFICATION_WINDOW_PM
 
     @property
-    def current(self) -> bool:
-        return self.start_time <= timezone.now() <= self.end_time
+    def current(self):
+        return self.active_at_time(timezone.now())
+
+    def active_at_time(self, time: Optional[datetime] = None):
+        if not time:
+            time = timezone.now()
+        return self.start_time <= time <= self.end_time
 
     def cancel(self, end_time: Optional[datetime] = None):
         """


### PR DESCRIPTION
## Scope and purpose

Ensures that notificationprofile and pm tasks use filters the same way.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* ~[ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)~
* [ ] Added/amended tests for new/changed code
* ~[ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed~
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* ~[ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~