### PR TITLE
Fix z-index bug for filter dropdowns

### DIFF
--- a/changelog.d/1669.fixed.md
+++ b/changelog.d/1669.fixed.md
@@ -1,0 +1,1 @@
+Fix bug where the incident table overlaps filter dropdowns

--- a/src/argus/htmx/templates/htmx/forms/dropdown_select_multiple.html
+++ b/src/argus/htmx/templates/htmx/forms/dropdown_select_multiple.html
@@ -25,7 +25,7 @@
     {% endfor %}
   </div>
   <div tabindex="0"
-       class="dropdown-content bg-base-100 rounded-box z-[1] min-w-fit w-full max-h-80 overflow-y-auto p-2 mt-0.5 shadow">
+       class="dropdown-content bg-base-100 rounded-box z-20 min-w-fit w-full max-h-80 overflow-y-auto p-2 mt-0.5 shadow">
     {% block field_template %}
       {% include "django/forms/widgets/multiple_input.html" %}
     {% endblock field_template %}


### PR DESCRIPTION
## Scope and purpose

Fixes a bug where the incident filter dropdowns are rendered behind the incident table header.

## Screenshots

| Before | After |
| --- | --- |
| <img width="306" height="215" alt="image" src="https://github.com/user-attachments/assets/cd4fc1b3-532a-4914-b332-db68689e3355" /> | <img width="279" height="225" alt="image" src="https://github.com/user-attachments/assets/fe314802-d654-4f4c-bbb6-2e3e91dc77c6" /> |

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
