### PR TITLE
Add searchable id column

### DIFF
--- a/changelog.d/1288.added.md
+++ b/changelog.d/1288.added.md
@@ -1,0 +1,1 @@
+Added searchable `id` column

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -250,6 +250,13 @@ id
     :From: id
     :Name: id
     :Description: The internal id of the incident in argus.
+    :Redundant with: search_id
+
+search_id
+    :From: id
+    :Name: search_id
+    :Description: Search for incidents with a given id.
+    :Redundant with: id
 
 level
     :From: level

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -70,6 +70,13 @@ _BUILTIN_COLUMN_LIST = [
         detail_link=True,
     ),
     IncidentTableColumn(
+        "search_id",
+        "ID",
+        "htmx/incident/cells/_incident_pk.html",
+        detail_link=True,
+        filter_field="id",
+    ),
+    IncidentTableColumn(
         "start_time",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time.html",

--- a/src/argus/htmx/incident/forms/incident_filters.py
+++ b/src/argus/htmx/incident/forms/incident_filters.py
@@ -31,6 +31,16 @@ class PageNumberForm(IncidentListForm):
 
 
 # column search, not stored
+class IdForm(SearchMixin, IncidentListForm):
+    widget_template_name = "htmx/incident/cells/search_fields/input_search.html"
+    fieldname = "id"
+    field_initial = ""
+    lookup = fieldname
+    placeholder = "ID"
+
+    id = forms.IntegerField(required=False)
+
+
 class DescriptionForm(SearchMixin, IncidentListForm):
     widget_template_name = "htmx/incident/cells/search_fields/input_search.html"
     fieldname = "description"

--- a/tests/htmx/incident/test_forms_incident_filters.py
+++ b/tests/htmx/incident/test_forms_incident_filters.py
@@ -3,7 +3,55 @@ from django.test import TestCase
 
 from argus.incident.models import Incident
 from argus.incident.factories import IncidentFactory
-from argus.htmx.incident.forms.incident_filters import DescriptionForm, HasTicketForm
+from argus.htmx.incident.forms.incident_filters import DescriptionForm, HasTicketForm, IdForm
+
+
+class IdFormTest(TestCase):
+    class obj:
+        pass
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.incident = IncidentFactory(id=95)
+        IncidentFactory()
+
+    def test_form_without_input_returns_every_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="")
+        form = IdForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertEqual(qs, result_qs)
+
+    def test_form_with_unfound_input_returns_empty_queryset(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="id=14063")
+        form = IdForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertFalse(result_qs.exists())
+
+    def test_form_with_irrelevant_input_returns_every_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="otherkey=1234")
+        form = IdForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertEqual(qs, result_qs)
+
+    def test_form_with_found_input_returns_specific_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="id=95")
+        form = IdForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertEqual(result_qs.count(), 1)
+        self.assertEqual(result_qs[0], self.incident)
 
 
 class DescriptionFormTest(TestCase):


### PR DESCRIPTION
## Scope and purpose

Fixes #1288.

Screenshots:
<img width="211" height="473" alt="image" src="https://github.com/user-attachments/assets/3ce7fd84-de4f-47e7-8fdd-0220e1c1e3e6" />
<img width="536" height="131" alt="image" src="https://github.com/user-attachments/assets/b0c831ee-92e6-446e-bd5b-21f414b5767f" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
