### PR TITLE
Implement sortable columns

### DIFF
--- a/changelog.d/1980.added.md
+++ b/changelog.d/1980.added.md
@@ -1,0 +1,1 @@
+Add sortable columns to incident table

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -36,6 +36,8 @@ class IncidentTableColumn:
     :param filter_field: when given, this column is considered filterable and a filter
         input is attached to the column header that can provide a query param with `filter_field`
         as the key
+    :param sort_field: the model field to use for sorting. When set, the column header
+        will include a sort button. Must be a valid field name for Django's order_by().
     """
 
     name: str  # unique identifier
@@ -47,6 +49,7 @@ class IncidentTableColumn:
     detail_link: bool = False
     cell_wrapper_template: str = CELL_WRAPPER_TEMPLATE_DEFAULT
     column_classes: str = ""
+    sort_field: Optional[str] = None
 
 
 _BUILTIN_COLUMN_LIST = [
@@ -68,6 +71,7 @@ _BUILTIN_COLUMN_LIST = [
         "ID",
         "htmx/incident/cells/_incident_pk.html",
         detail_link=True,
+        sort_field="pk",
     ),
     IncidentTableColumn(
         "search_id",
@@ -80,44 +84,51 @@ _BUILTIN_COLUMN_LIST = [
         "start_time",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time.html",
-        header_template="htmx/incident/cells/_incident_start_time_header.html",
         detail_link=True,
+        column_classes="min-w-48",
+        sort_field="start_time",
     ),
     IncidentTableColumn(
         "age",
         "Age",
         "htmx/incident/cells/_incident_age.html",
         detail_link=True,
+        sort_field="start_time",
     ),
     IncidentTableColumn(
         "start_time_and_age",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time_and_age.html",
         detail_link=True,
+        sort_field="start_time",
     ),
     IncidentTableColumn(
         "narrow_start_time",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time.html",
         detail_link=True,
+        sort_field="start_time",
     ),
     IncidentTableColumn(
         "status",
         "Status",
         "htmx/incident/cells/_incident_status.html",
         detail_link=True,
+        sort_field="end_time",
     ),
     IncidentTableColumn(
         "status_icon",
         "Status",
         "htmx/incident/cells/_incident_status_icon.html",
         detail_link=True,
+        sort_field="end_time",
     ),
     IncidentTableColumn(
         "level",
         "Severity level",
         "htmx/incident/cells/_incident_level.html",
         detail_link=True,
+        sort_field="level",
     ),
     IncidentTableColumn(
         "select_levels",
@@ -125,24 +136,28 @@ _BUILTIN_COLUMN_LIST = [
         "htmx/incident/cells/_incident_level.html",
         detail_link=True,
         filter_field="level",
+        sort_field="level",
     ),
     IncidentTableColumn(
         "source",
         "Source",
         "htmx/incident/cells/_incident_source.html",
         detail_link=True,
+        sort_field="source__name",
     ),
     IncidentTableColumn(
         "source_type",
         "Source Type",
         "htmx/incident/cells/_incident_source_type.html",
         detail_link=True,
+        sort_field="source__type__name",
     ),
     IncidentTableColumn(
         "description",
         "Description",
         "htmx/incident/cells/_incident_description.html",
         detail_link=True,
+        sort_field="description",
     ),
     IncidentTableColumn(
         "search_description",
@@ -150,6 +165,7 @@ _BUILTIN_COLUMN_LIST = [
         "htmx/incident/cells/_incident_description.html",
         detail_link=True,
         filter_field="description",
+        sort_field="description",
     ),
     IncidentTableColumn(
         "ack",
@@ -168,12 +184,14 @@ _BUILTIN_COLUMN_LIST = [
         "Status",
         "htmx/incident/cells/_incident_combined_status.html",
         detail_link=True,
+        sort_field="end_time",
     ),
     IncidentTableColumn(
         "combined_status_icons",
         "Status",
         "htmx/incident/cells/_incident_combined_status_icons.html",
         detail_link=True,
+        sort_field="end_time",
     ),
     IncidentTableColumn(
         "ticket",

--- a/src/argus/htmx/incident/forms/incident_filters.py
+++ b/src/argus/htmx/incident/forms/incident_filters.py
@@ -202,3 +202,7 @@ class SortForm(forms.Form):
         if sort_order == "desc":
             return f"-{sort_field}"
         return sort_field
+
+    def is_default_sort_field(self):
+        """Check if the current sort field is the default."""
+        return self.get_sort_field() == SORT_DEFAULT

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -26,7 +26,7 @@ from ..request import HtmxHttpRequest
 
 from .columns import get_incident_table_columns
 from .utils import get_filter_function
-from .forms.incident_filters import IncidentListForm
+from .forms.incident_filters import IncidentListForm, SortForm
 from .forms.incident_actions import AckForm, DescriptionOptionalForm, EditTicketUrlForm, AddTicketUrlForm
 from ..utils import (
     single_autocreate_ticket_url_queryset,
@@ -271,8 +271,12 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
     column_layout_name = preferences["argus_htmx"]["incidents_table_column_name"]
     columns = get_incident_table_columns(column_layout_name)
 
-    # Load incidents
-    qs = prefetch_incident_daughters().order_by("-start_time")
+    # Handle sorting
+    sort_form = SortForm(request.GET)
+    ordering = sort_form.get_ordering()
+
+    # Load incidents with sorting
+    qs = prefetch_incident_daughters().order_by(ordering)
     total_count = qs.count()
     last_refreshed = make_aware(datetime.now())
 
@@ -298,6 +302,10 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         initial_value = Form.get_initial_value(request)
         GET_params[form.fieldname] = form.get_clean_value(request) or initial_value
         qs = form.filter(qs, request)
+
+    # Add sort parameters to GET_params for URL preservation
+    GET_params["sort"] = sort_form.get_sort_field()
+    GET_params["sort_order"] = sort_form.get_sort_order()
 
     filtered_count = qs.count()
 
@@ -331,6 +339,8 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         "filter_form": filter_form,
         "refresh_info": refresh_info,
         "refresh_info_forms": GET_forms,
+        "current_sort": sort_form.get_sort_field(),
+        "current_sort_order": sort_form.get_sort_order(),
         "page_title": "Incidents",
         "base": base_template,
         "page": page,

--- a/src/argus/htmx/static/styles.css
+++ b/src/argus/htmx/static/styles.css
@@ -2159,6 +2159,38 @@ input.tab:checked + .tab-content,
     var(--togglehandleborder);
 }
 
+.alert-info {
+  border-color: var(--fallback-in,oklch(var(--in)/0.2));
+  --tw-text-opacity: 1;
+  color: var(--fallback-inc,oklch(var(--inc)/var(--tw-text-opacity)));
+  --alert-bg: var(--fallback-in,oklch(var(--in)/1));
+  --alert-bg-mix: var(--fallback-b1,oklch(var(--b1)/1));
+}
+
+.alert-success {
+  border-color: var(--fallback-su,oklch(var(--su)/0.2));
+  --tw-text-opacity: 1;
+  color: var(--fallback-suc,oklch(var(--suc)/var(--tw-text-opacity)));
+  --alert-bg: var(--fallback-su,oklch(var(--su)/1));
+  --alert-bg-mix: var(--fallback-b1,oklch(var(--b1)/1));
+}
+
+.alert-warning {
+  border-color: var(--fallback-wa,oklch(var(--wa)/0.2));
+  --tw-text-opacity: 1;
+  color: var(--fallback-wac,oklch(var(--wac)/var(--tw-text-opacity)));
+  --alert-bg: var(--fallback-wa,oklch(var(--wa)/1));
+  --alert-bg-mix: var(--fallback-b1,oklch(var(--b1)/1));
+}
+
+.alert-error {
+  border-color: var(--fallback-er,oklch(var(--er)/0.2));
+  --tw-text-opacity: 1;
+  color: var(--fallback-erc,oklch(var(--erc)/var(--tw-text-opacity)));
+  --alert-bg: var(--fallback-er,oklch(var(--er)/1));
+  --alert-bg-mix: var(--fallback-b1,oklch(var(--b1)/1));
+}
+
 .avatar-group :where(.avatar) {
   overflow: hidden;
   border-radius: 9999px;
@@ -3713,6 +3745,14 @@ details.collapse summary::-webkit-details-marker {
   }
 }
 
+.badge-sm {
+  height: 1rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding-left: 0.438rem;
+  padding-right: 0.438rem;
+}
+
 .btm-nav-xs > *:where(.active) {
   border-top-width: 1px;
 }
@@ -4128,6 +4168,14 @@ details.collapse summary::-webkit-details-marker {
   bottom: auto;
 }
 
+.tooltip-right:before {
+  transform: translateY(-50%);
+  top: 50%;
+  left: var(--tooltip-offset);
+  right: auto;
+  bottom: auto;
+}
+
 .avatar.online:before {
   content: "";
   position: absolute;
@@ -4451,6 +4499,15 @@ details.collapse summary::-webkit-details-marker {
   top: 50%;
   left: auto;
   right: calc(var(--tooltip-tail-offset) + 0.0625rem);
+  bottom: auto;
+}
+
+.tooltip-right:after {
+  transform: translateY(-50%);
+  border-color: transparent var(--tooltip-color) transparent transparent;
+  top: 50%;
+  left: calc(var(--tooltip-tail-offset) + 0.0625rem);
+  right: auto;
   bottom: auto;
 }
 
@@ -5246,10 +5303,6 @@ details.collapse summary::-webkit-details-marker {
   z-index: 20;
 }
 
-.z-\[1\] {
-  z-index: 1;
-}
-
 .z-50 {
   z-index: 50;
 }
@@ -5334,6 +5387,10 @@ details.collapse summary::-webkit-details-marker {
   margin-top: 2.25rem;
 }
 
+.ml-6 {
+  margin-left: 1.5rem;
+}
+
 .block {
   display: block;
 }
@@ -5360,6 +5417,10 @@ details.collapse summary::-webkit-details-marker {
 
 .aspect-\[577\/310\] {
   aspect-ratio: 577/310;
+}
+
+.aspect-square {
+  aspect-ratio: 1 / 1;
 }
 
 .size-10 {
@@ -5563,8 +5624,32 @@ details.collapse summary::-webkit-details-marker {
   transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
+}
+
+.animate-bounce {
+  animation: bounce 1s infinite;
+}
+
 .cursor-pointer {
   cursor: pointer;
+}
+
+.list-inside {
+  list-style-position: inside;
+}
+
+.list-disc {
+  list-style-type: disc;
 }
 
 .grid-cols-2 {
@@ -5952,6 +6037,10 @@ details.collapse summary::-webkit-details-marker {
   padding: 1.5rem;
 }
 
+.p-0\.5 {
+  padding: 0.125rem;
+}
+
 .px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
@@ -5985,6 +6074,11 @@ details.collapse summary::-webkit-details-marker {
 .py-5 {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
+}
+
+.px-0\.5 {
+  padding-left: 0.125rem;
+  padding-right: 0.125rem;
 }
 
 .pb-0 {
@@ -6021,10 +6115,6 @@ details.collapse summary::-webkit-details-marker {
 
 .pt-4 {
   padding-top: 1rem;
-}
-
-.pb-4 {
-  padding-bottom: 1rem;
 }
 
 .text-left {
@@ -6088,6 +6178,10 @@ details.collapse summary::-webkit-details-marker {
 
 .font-semibold {
   font-weight: 600;
+}
+
+.font-black {
+  font-weight: 900;
 }
 
 .capitalize {
@@ -6181,6 +6275,11 @@ details.collapse summary::-webkit-details-marker {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.text-orange-400 {
+  --tw-text-opacity: 1;
+  color: rgb(251 146 60 / var(--tw-text-opacity, 1));
 }
 
 .antialiased {
@@ -6321,6 +6420,11 @@ details.collapse summary::-webkit-details-marker {
 
 .hover\:bg-gray-100\/10:hover {
   background-color: rgb(243 244 246 / 0.1);
+}
+
+.hover\:text-primary:hover {
+  --tw-text-opacity: 1;
+  color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity, 1)));
 }
 
 .hover\:opacity-100:hover {

--- a/src/argus/htmx/templates/htmx/incident/_base_incident_table.html
+++ b/src/argus/htmx/templates/htmx/incident/_base_incident_table.html
@@ -12,6 +12,8 @@
               {% include col.header_template with label=col.label %}
             {% elif col.filter_field %}
               {% include "htmx/incident/cells/_incident_filterable_column_header.html" with column=col %}
+            {% elif col.sort_field %}
+              {% include "htmx/incident/cells/_incident_sortable_column_header.html" with column=col %}
             {% else %}
               {{ col.label }}
             {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
@@ -11,6 +11,9 @@
       hx-push-url="true"
       hx-indicator="#incident-list .htmx-indicator"
       onkeydown="if (event.keyCode === 13) event.preventDefault();">
+  {# Hidden inputs to preserve sort state across filter submissions #}
+  <input type="hidden" name="sort" value="{{ current_sort }}">
+  <input type="hidden" name="sort_order" value="{{ current_sort_order }}">
   <fieldset {% block filter_select_custom_control %}
             hx-on:change="htmx.ajax('GET', '{% url 'htmx:select-filter' %}');"
             {% endblock filter_select_custom_control %}>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -1,8 +1,10 @@
 <!-- htmx/incident/cells/_incident_filterable_column_header_content.html -->
 {% load argus_htmx %}
 {% with field=form|get_form_field:fieldname %}
-  <div>
+  <div class="flex items-center gap-1">
     <span id="{{ field.name }}-label">{{ column.label }}</span>
+    {% include "htmx/incident/cells/_incident_sort_button.html" %}
+    {# Filter dropdown #}
     <div id="{{ column.name }}-dropdown" class="dropdown dropdown-end">
       <button type="button"
               tabindex="0"

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button.html
@@ -1,0 +1,33 @@
+<!-- htmx/incident/cells/_incident_sort_button.html -->
+{# Reusable sort button for column headers. Requires: column, current_sort, current_sort_order #}
+{% if column.sort_field %}
+  {% if current_sort == column.sort_field %}
+    {# Active: show directional icon, click toggles order #}
+    <button type="button"
+            class="btn btn-xs btn-ghost text-primary p-0 min-h-4 h-4"
+            aria-label="Sort by {{ column.label|lower }} {% if current_sort_order == 'asc' %}descending{% else %}ascending{% endif %}"
+            hx-get="{% url 'htmx:incident-list' %}"
+            hx-vals='{"sort": "{{ column.sort_field }}", "sort_order": "{% if current_sort_order == 'asc' %}desc{% else %}asc{% endif %}"}'
+            hx-include=".incident-list-param"
+            hx-target="#table"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-indicator="#incident-list .htmx-indicator">
+      <i class="fa-solid {% if current_sort_order == 'asc' %}fa-sort-up{% else %}fa-sort-down{% endif %}"></i>
+    </button>
+  {% else %}
+    {# Inactive: show neutral icon, click sorts descending #}
+    <button type="button"
+            class="btn btn-xs btn-ghost text-base-content/50 p-0 min-h-4 h-4 hover:text-primary"
+            aria-label="Sort by {{ column.label|lower }}"
+            hx-get="{% url 'htmx:incident-list' %}"
+            hx-vals='{"sort": "{{ column.sort_field }}", "sort_order": "desc"}'
+            hx-include=".incident-list-param"
+            hx-target="#table"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-indicator="#incident-list .htmx-indicator">
+      <i class="fa-solid fa-sort"></i>
+    </button>
+  {% endif %}
+{% endif %}

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button.html
@@ -1,33 +1,20 @@
 <!-- htmx/incident/cells/_incident_sort_button.html -->
 {# Reusable sort button for column headers. Requires: column, current_sort, current_sort_order #}
+{# Cycling order: inactive -> desc -> asc -> inactive (default) #}
 {% if column.sort_field %}
   {% if current_sort == column.sort_field %}
-    {# Active: show directional icon, click toggles order #}
-    <button type="button"
-            class="btn btn-xs btn-ghost text-primary p-0 min-h-4 h-4"
-            aria-label="Sort by {{ column.label|lower }} {% if current_sort_order == 'asc' %}descending{% else %}ascending{% endif %}"
-            hx-get="{% url 'htmx:incident-list' %}"
-            hx-vals='{"sort": "{{ column.sort_field }}", "sort_order": "{% if current_sort_order == 'asc' %}desc{% else %}asc{% endif %}"}'
-            hx-include=".incident-list-param"
-            hx-target="#table"
-            hx-swap="outerHTML"
-            hx-push-url="true"
-            hx-indicator="#incident-list .htmx-indicator">
-      <i class="fa-solid {% if current_sort_order == 'asc' %}fa-sort-up{% else %}fa-sort-down{% endif %}"></i>
-    </button>
+    {% if current_sort_order == "desc" %}
+      {% with icon="fa-sort-down" next_sort=column.sort_field next_order="asc" label="Sort by "|add:column.label|lower|add:" ascending" active=True %}
+        {% include "htmx/incident/cells/_incident_sort_button_element.html" %}
+      {% endwith %}
+    {% else %}
+      {% with icon="fa-sort-up" next_sort="" next_order="" label="Reset sort order" active=True %}
+        {% include "htmx/incident/cells/_incident_sort_button_element.html" %}
+      {% endwith %}
+    {% endif %}
   {% else %}
-    {# Inactive: show neutral icon, click sorts descending #}
-    <button type="button"
-            class="btn btn-xs btn-ghost text-base-content/50 p-0 min-h-4 h-4 hover:text-primary"
-            aria-label="Sort by {{ column.label|lower }}"
-            hx-get="{% url 'htmx:incident-list' %}"
-            hx-vals='{"sort": "{{ column.sort_field }}", "sort_order": "desc"}'
-            hx-include=".incident-list-param"
-            hx-target="#table"
-            hx-swap="outerHTML"
-            hx-push-url="true"
-            hx-indicator="#incident-list .htmx-indicator">
-      <i class="fa-solid fa-sort"></i>
-    </button>
+    {% with icon="fa-sort" next_sort=column.sort_field next_order="desc" label="Sort by "|add:column.label|lower active=False %}
+      {% include "htmx/incident/cells/_incident_sort_button_element.html" %}
+    {% endwith %}
   {% endif %}
 {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button_element.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button_element.html
@@ -1,0 +1,14 @@
+<!-- htmx/incident/cells/_incident_sort_button_element.html -->
+{# Sort button element. Requires: icon, next_sort, next_order, label, active #}
+<button type="button"
+        class="btn btn-xs btn-ghost p-0 aspect-square min-h-4 h-4 {% if active %}text-primary{% else %}text-base-content/50 hover:text-primary{% endif %}"
+        aria-label="{{ label }}"
+        hx-get="{% url 'htmx:incident-list' %}"
+        hx-vals='{"sort": "{{ next_sort }}", "sort_order": "{{ next_order }}"}'
+        hx-include=".incident-list-param"
+        hx-target="#table"
+        hx-swap="outerHTML"
+        hx-push-url="true"
+        hx-indicator="#incident-list .htmx-indicator">
+  <i class="fa-solid {{ icon }}"></i>
+</button>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_sortable_column_header.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_sortable_column_header.html
@@ -1,0 +1,5 @@
+<!-- htmx/incident/cells/_incident_sortable_column_header.html -->
+<div class="flex items-center gap-1">
+  <span>{{ column.label }}</span>
+  {% include "htmx/incident/cells/_incident_sort_button.html" %}
+</div>


### PR DESCRIPTION
## Scope and purpose

Resolves #1680, resolves #1687, resolves #1689

This PR adds support for sorting incidents by configurable columns (opt-in). 

* The `IncidentTableColumn` class is extended with a `sort_field`  property, which is used to both show a sorting button in the column header, and in the `incident_list` to sort by the given property. 
* Sorting query params are validated with the `SortForm` class, which both validates that a `sort_field` is valid (ignored otherwise) and sets default if either of the query params `sort` and `sort_order` are provided.
* The `sort` and `sort_order` fields are added as hidden inputs in the filter form, to preserve them when submitting the form and refreshing. When a column sort button is clicked, an HTMX request is fired which uses push history to update the URL params.
* When sorting by something other than the default (`start_time`), `-start_time` (descending start_time) is used as the secondary sorting, which makes columns with a lot of identical values more usable. This means that when sorting by e.g. Severity level, all "Severity 5" elements are shown in descending start_time order.
* The columns support cycling between three states: Inactive, Descending and Ascending. When an ascending column sort is clicked, the table sorting is reset to the default. This means that if the Timestamp column is visible in the table, it will now show as sorted in descending order.

## Screenshots

#### The default sorting is the timestamp (start_time) column, in descending order. 

<img width="858" height="144" alt="image" src="https://github.com/user-attachments/assets/d7f7e62d-5b72-4486-b859-5604539bc7af" />

#### A sortable column is grey when another column sort is active, and otherwise shows a directional arrow

<img width="142" height="50" alt="image" src="https://github.com/user-attachments/assets/a6826d20-7285-4aeb-ba66-5a3307b79bde" />
<img width="148" height="48" alt="image" src="https://github.com/user-attachments/assets/78563d69-f6f1-484f-8bb7-4bda7db628d2" />
<img width="125" height="44" alt="image" src="https://github.com/user-attachments/assets/9224633e-98fd-4410-83ec-138b4a7a5b23" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
