### PR TITLE
Fix dropdown multi-select fields selecting first item when clicked

### DIFF
--- a/changelog.d/1697.fixed.md
+++ b/changelog.d/1697.fixed.md
@@ -1,0 +1,1 @@
+Fixed dropdown multi-select fields (e.g. Source Types) selecting first item when clicked

--- a/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
@@ -19,7 +19,7 @@
       {% for field in filter_form %}
         {% if not field.field.in_header %}
           <li class="form-control">
-            {% if field.name == "sourceSystemIds" or field.name == "tags" %}
+            {% if "dropdownmultiselect" in field|widget_type %}
               <div class="flex flex-nowrap">
                 <label class="label">
                   <span class="label-text">{{ field.label }}</span>


### PR DESCRIPTION
## Scope and purpose

The source_types dropdown (and any other `DropdownMultiSelect` widget) was incorrectly selecting the first item when clicking to open the dropdown.

The field was rendered inside a `<label>` element, which caused the browser to activate the first form control (checkbox) when clicking anywhere on the label.

I changed the template condition to check for `"dropdownmultiselect"` in the widget type, ensuring all dropdown multi-select fields are rendered outside the wrapping <label>, consistent with how `sourceSystemIds` and `tags` were already handled. This should also fix the same bug in #1692 for the `event_types` filter widget.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
