### PR TITLE
Replace column filter button with debounced auto-submit

### DIFF
--- a/changelog.d/1575.changed.md
+++ b/changelog.d/1575.changed.md
@@ -1,0 +1,1 @@
+Replace column filter button with debounced auto-submit

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_footer.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_footer.html
@@ -1,5 +1,5 @@
 <!-- htmx/incident/_incident_table_footer.html -->
-<tfoot>
+<tfoot id="table-footer">
   <tr class="sticky bottom-0 bg-base-100">
     <td colspan="{{ columns|length }}" class="border-t border-primary">
       <div class="flex justify-between items-center">

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -21,7 +21,7 @@
             {# djlint:off #}
             {% if not dummy_column %}
               {% url 'htmx:incident-list' as incident_list_url %}
-              {% render_field field hx-get=incident_list_url hx-include=".incident-list-param" hx-target="#table" hx-swap="outerHTML" hx-push-url="true" hx-indicator="#incident-list .htmx-indicator" hx-trigger="change delay:500ms" %}
+              {% render_field field hx-get=incident_list_url hx-include=".incident-list-param" hx-target="#table-body" hx-select="#table-body" hx-select-oob="#table-footer" hx-swap="outerHTML" hx-push-url="true" hx-indicator="#incident-list .htmx-indicator" hx-trigger="change delay:500ms" %}
             {% else %}
               {{ field }}
             {% endif %}
@@ -33,15 +33,30 @@
   </div>
 {% endwith %}
 <script>
-document.querySelector('#{{ column.name }}-dropdown .filter-btn').addEventListener('focus', function() {
-  const dropdown = this.closest('.dropdown');
-  const content = dropdown.querySelector('.dropdown-content');
-  const rect = content.getBoundingClientRect();
+(function() {
+  const dropdown = document.querySelector('#{{ column.name }}-dropdown');
+  const filterBtn = dropdown.querySelector('.filter-btn');
 
-  if (rect.right > window.innerWidth) {
-    dropdown.classList.add('dropdown-end');
-  } else if (rect.left < 0) {
-    dropdown.classList.remove('dropdown-end');
-  }
-});
+  filterBtn.addEventListener('focus', function() {
+    const content = dropdown.querySelector('.dropdown-content');
+    const rect = content.getBoundingClientRect();
+
+    if (rect.right > window.innerWidth) {
+      dropdown.classList.add('dropdown-end');
+    } else if (rect.left < 0) {
+      dropdown.classList.remove('dropdown-end');
+    }
+  });
+
+  dropdown.addEventListener('htmx:afterRequest', function() {
+    const field = dropdown.querySelector('input:not([type="hidden"]), select');
+    if (field?.value) {
+      filterBtn.classList.add('btn-primary');
+      filterBtn.classList.remove('btn-ghost', 'text-primary');
+    } else {
+      filterBtn.classList.remove('btn-primary');
+      filterBtn.classList.add('btn-ghost', 'text-primary');
+    }
+  });
+})();
 </script>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -1,5 +1,5 @@
 <!-- htmx/incident/cells/_incident_filterable_column_header_content.html -->
-{% load argus_htmx %}
+{% load argus_htmx widget_tweaks %}
 {% with field=form|get_form_field:fieldname %}
   <div class="flex items-center gap-1">
     <span id="{{ field.name }}-label">{{ column.label }}</span>
@@ -16,19 +16,17 @@
       <div id="{{ column.name }}-dropdown-content"
            class="dropdown-content bg-base-100 p-2 mt-1 rounded-lg shadow border border-primary z-10"
            tabindex="-1">
-        <form class="flex gap-2 incident-list-param"
-          {# djlint:off #}
+        <form class="incident-list-param">
+          <div aria-labelledby="{{ field.name }}-label">
+            {# djlint:off #}
             {% if not dummy_column %}
-            hx-get="{% url 'htmx:incident-list' %}"
-            hx-include=".incident-list-param"
-            hx-target="#table"
-            hx-swap="outerHTML"
-            hx-push-url="true"
-            hx-indicator="#incident-list .htmx-indicator"
-            {% endif %}>
-          {# djlint:on #}
-          <div aria-labelledby="{{ field.name }}-label">{{ field }}</div>
-          <button type="submit" class="btn btn-xs btn-primary">Filter</button>
+              {% url 'htmx:incident-list' as incident_list_url %}
+              {% render_field field hx-get=incident_list_url hx-include=".incident-list-param" hx-target="#table" hx-swap="outerHTML" hx-push-url="true" hx-indicator="#incident-list .htmx-indicator" hx-trigger="change delay:500ms" %}
+            {% else %}
+              {{ field }}
+            {% endif %}
+            {# djlint:on #}
+          </div>
         </form>
       </div>
     </div>

--- a/src/argus/htmx/templates/htmx/incident/cells/search_fields/input_search.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/search_fields/input_search.html
@@ -1,16 +1,24 @@
-<!-- htmx/incident/cells/search_field/input_search.html -->
+<!-- htmx/incident/cells/search_fields/input_search.html -->
+{% url 'htmx:incident-list' as incident_list_url %}
 <div class="flex gap-1 input input-xs grow input-primary pr-0 group">
   <input name="{{ widget.name }}"
          type="text"
          autocomplete="off"
          class="incident-list-param flex-1 peer"
          {% if widget.attrs.placeholder %}placeholder="{{ widget.attrs.placeholder }}"{% endif %}
-         {% if widget.value %}value="{{ widget.value }}"{% endif %}>
+         {% if widget.value %}value="{{ widget.value }}"{% endif %}
+         hx-get="{{ incident_list_url }}"
+         hx-include=".incident-list-param"
+         hx-target="#table"
+         hx-swap="outerHTML"
+         hx-push-url="true"
+         hx-indicator="#incident-list .htmx-indicator"
+         hx-trigger="input changed delay:500ms, keydown[keyCode==13]">
   <button id="{{ widget.name }}-clear-btn"
           type="button"
           class="btn btn-xs btn-ghost opacity-0 peer-focus:opacity-100 focus:opacity-100 group-hover:opacity-100"
           aria-label="Clear {{ widget.name }} search field"
-          _="on click set value of <input[name='{{ widget.name }}']/> to ''">
+          _="on click set value of <input[name='{{ widget.name }}']/> to '' then send input to <input[name='{{ widget.name }}']/>">
   <i class="fa-solid fa-xmark"></i>
 </button>
 </div>

--- a/src/argus/htmx/templates/htmx/incident/cells/search_fields/input_search.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/search_fields/input_search.html
@@ -9,7 +9,9 @@
          {% if widget.value %}value="{{ widget.value }}"{% endif %}
          hx-get="{{ incident_list_url }}"
          hx-include=".incident-list-param"
-         hx-target="#table"
+         hx-target="#table-body"
+         hx-select="#table-body"
+         hx-select-oob="#table-footer"
          hx-swap="outerHTML"
          hx-push-url="true"
          hx-indicator="#incident-list .htmx-indicator"


### PR DESCRIPTION
## Scope and purpose

Resolves #1575

This PR changes the behaviour of column search filters to submit after a short delay in typing or selecting. The current implementation with a filter button is problematic for two reasons:
* Whenever the page reloads, the filter will get submitted even if the user wasn't finished typing. This removes perceived control from the user.
* Other filters on the page submit instantly when changed, and the column filters should behave the same. Automatic filtering is also a common UX pattern, and expected by many users.

In the new implementation, filters are submitted after a short delay in typing or selecting (500ms)


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
