### PR TITLE
Fix page size preference reset when URL param is missing

### DIFF
--- a/changelog.d/1704.fixed.md
+++ b/changelog.d/1704.fixed.md
@@ -1,0 +1,1 @@
+Fixed page size preference being reset to default when visiting the incidents page without a page_size URL parameter

--- a/src/argus/htmx/incident/forms/incident_filters.py
+++ b/src/argus/htmx/incident/forms/incident_filters.py
@@ -103,6 +103,14 @@ class PageSizeForm(IncidentListForm):
 
     # page_size is used by a paginator, no need to define ``filter``
 
+    def __init__(self, data=None, *args, **kwargs):
+        # Only bind the form if page_size is actually in the data.
+        # This ensures the stored preference is used for rendering when
+        # page_size is not in the URL.
+        if data is not None and self.fieldname not in data:
+            data = None
+        super().__init__(data, *args, **kwargs)
+
     def get_clean_value(self, request):
         # breakpoint()
         if request.GET.get(self.fieldname, 0):
@@ -114,6 +122,9 @@ class PageSizeForm(IncidentListForm):
         return cls._get_initial_preference_value(request, "argus_htmx")
 
     def store(self, request):
+        # Only store the preference if page_size was explicitly provided in the request
+        if not request.GET.get(self.fieldname):
+            return None
         return self._store_preference(request, "argus_htmx")
 
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1704

This PR fixes a bug where the stored `page_size` was reported to reset after logging in. The issue turned out to not be specific to logging in, but was caused by empty URL parameters, where a missing `page_size` parameter resets the value to 10 (the default).

## How to test

1. **Manual URL manipulation**
    1. Set the page size to something other than the default
    2. Change the URL to not have any URL parameters, i.e. `/incidents`
    3. Verify that the page size is _not_ reset
2. **Authentication flow**
    1. Set the page size to something other than the default
    2. Log out and then log back in
    3. Verify that the page size is _not_reset

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
