### PR TITLE
Add some default column presets

### DIFF
--- a/changelog.d/+add-more-default-column-presets.added.md
+++ b/changelog.d/+add-more-default-column-presets.added.md
@@ -1,0 +1,5 @@
+Added two new column presets:
+
+* "notifications" with columns useful for making notification profiles
+* "on maintenance" with columns useful for finding things that will be on
+  planned maintenance

--- a/src/argus/htmx/defaults.py
+++ b/src/argus/htmx/defaults.py
@@ -17,6 +17,23 @@ INCIDENT_TABLE_COLUMNS = [
     "description",
     "ticket",
 ]
+DEFAULT_INCIDENT_TABLE_COLUMN_LAYOUTS = {
+    "built-in": INCIDENT_TABLE_COLUMNS,
+    "notifications": [
+        "status_icon",
+        "ack_icon",
+        "level",
+        "source_type",
+        "source",
+        "tags",
+        "events",
+    ],
+    "on maintenance": [
+        "source_type",
+        "source",
+        "tags",
+    ],
+}
 ARGUS_HTMX_FILTER_FUNCTION = "argus.htmx.incident.filter.incident_list_filter"
 
 # These templates are auto-discovered by the templating engine and are relative

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from django.conf import settings
 
-from argus.htmx.defaults import INCIDENT_TABLE_COLUMNS as BUILTIN_INCIDENT_TABLE_COLUMNS
+from argus.htmx.defaults import DEFAULT_INCIDENT_TABLE_COLUMN_LAYOUTS
 
 
 LOG = logging.getLogger(__name__)
@@ -213,12 +213,6 @@ _BUILTIN_COLUMN_LIST = [
 BUILTIN_COLUMNS = {col.name: col for col in _BUILTIN_COLUMN_LIST}
 
 
-def get_builtin_column_layout():
-    "Return the column layout defined in `argus.htmx.defaults`"
-
-    return BUILTIN_COLUMN_LAYOUT_NAME, BUILTIN_INCIDENT_TABLE_COLUMNS
-
-
 def get_default_column_layout():
     """Return the column layout defined in the setting INCIDENT_TABLE_COLUMNS
 
@@ -245,13 +239,13 @@ def get_configured_column_layouts():
 def get_available_column_layouts():
     "Combine all found column layouts into a single collection"
 
-    builtin, builtin_columns = get_builtin_column_layout()
-    layouts = {builtin: builtin_columns}
+    layouts = DEFAULT_INCIDENT_TABLE_COLUMN_LAYOUTS.copy()
 
     default, default_columns = get_default_column_layout()
     if default_columns:
         layouts[default] = default_columns
 
+    # Layouts configured in settings can replace previously found layouts
     configured_layouts = get_configured_column_layouts()
     if configured_layouts:
         layouts.update(configured_layouts)


### PR DESCRIPTION
## Scope and purpose

This adds two default column presets, "notifications" and "on maintenance", that are useful for
visualizing what incidents will be hit by filters suitable for notifications or planned maintenance.

The new presets are added by default, which means that all upgraded installations will get a minimum of three column layouts (these two + built-in) to choose from in addition to any set in settings.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
