### PR TITLE
Replace toasts with more accessible options and improve form validation

### DIFF
--- a/changelog.d/1711.changed.md
+++ b/changelog.d/1711.changed.md
@@ -1,0 +1,1 @@
+Improve toast notification accessibility with ARIA attributes and screen reader support

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -4,7 +4,6 @@ from typing import Mapping
 
 from django.conf import settings
 from django.contrib.auth.backends import ModelBackend, RemoteUserBackend
-from django.contrib import messages
 from django.http import HttpRequest
 from django.utils.module_loading import import_string
 
@@ -101,7 +100,6 @@ def _save_preference(request: HttpRequest, prefs: Preferences, preference: str, 
     form = prefs.get_forms()[preference](data, request=request)
 
     if not form.is_valid():
-        messages.warning(request, f"Failed to change {preference}, invalid input")
         LOG.warning("Failed to change %s, invalid input: %s", preference, data)
         return value, False
 

--- a/src/argus/auth/utils.py
+++ b/src/argus/auth/utils.py
@@ -112,6 +112,5 @@ def _save_preference(request: HttpRequest, prefs: Preferences, preference: str, 
         return value, True
 
     prefs.save_preference(preference, value)
-    messages.success(request, f"Changed {preference}: {old_value} → {value}")
     LOG.info("Changed %s: %s → %s", preference, old_value, value)
     return value, True

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -95,7 +95,6 @@ def incident_update(request: HtmxHttpRequest, action: str):
         return HttpResponseBadRequest("Invalid update action")
     incident_ids = get_incident_ids_to_update(request)
     if not incident_ids:
-        messages.warning(request, "No incidents selected, nothing to change")
         return HttpResponseClientRefresh()
 
     if action == "autocreate-ticket":

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -154,7 +154,6 @@ def update_filter(request: HtmxHttpRequest, pk: int):
         # Immediately select the newly updated filter - keep or not?
         # request.session["selected_filter"] = str(filter_obj.id)
 
-        messages.success(request, f"Updated filter '{filter_obj.name}'.")
         return HttpResponseClientRefresh()
     messages.error(request, f"Failed to update filter '{filter_obj.name}'.")
     return HttpResponseBadRequest()
@@ -165,7 +164,6 @@ def delete_filter(request: HtmxHttpRequest, pk: int):
     filter_obj = get_object_or_404(Filter, id=pk)
     deleted_id = filter_obj.delete()
     if deleted_id:
-        messages.success(request, f"Deleted filter {filter_obj.name}.")
         if request.session.get("selected_filter") == str(pk):
             request.session["selected_filter"] = None
         return HttpResponseClientRefresh()

--- a/src/argus/htmx/templates/htmx/destination/_delete_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_delete_form.html
@@ -1,6 +1,6 @@
 <form hx-post="{% url 'htmx:htmx-delete' form.instance.id %}"
       hx-trigger="submit"
-      hx-target="closest details"
+      hx-target="closest .card"
       hx-swap="outerHTML">
   {% csrf_token %}
   <fieldset class="menu menu-horizontal menu-md items-center gap-4">

--- a/src/argus/htmx/templates/htmx/destination/_edit_form.html
+++ b/src/argus/htmx/templates/htmx/destination/_edit_form.html
@@ -1,6 +1,6 @@
 <form hx-post="{% url 'htmx:htmx-update' form.instance.id %}"
       hx-trigger="submit"
-      hx-target="closest details"
+      hx-target="closest .card"
       hx-swap="outerHTML"
       class="flex flex-nowrap items-center gap-4">
   {% csrf_token %}

--- a/src/argus/htmx/templates/htmx/forms/input_field.html
+++ b/src/argus/htmx/templates/htmx/forms/input_field.html
@@ -26,10 +26,14 @@
       {% endif %}
     </div>
   {% endblock input_rendering %}
-  {% if help_text or errors %}
-    <label class="label">
+  {% if field.errors %}
+    <div class="label">
+      {% for error in field.errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
+    </div>
+  {% elif help_text or errors %}
+    <div class="label">
       {% if help_text %}<span class="label-text-alt">{{ help_text }}</span>{% endif %}
       {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
-    </label>
+    </div>
   {% endif %}
 </div>

--- a/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
+++ b/src/argus/htmx/templates/htmx/timeslot/_timeslot_form.html
@@ -1,8 +1,18 @@
 {% load widget_tweaks %}
 <section class="card-body max-w-4xl w-full">
   <form method="post"
+        novalidate
         action="{% if form.instance.pk %}{% url "htmx:timeslot-update" pk=form.instance.pk %}{% else %}{% url "htmx:timeslot-create" %}{% endif %}">
     {% csrf_token %}
+    {% if form.errors or formset.total_error_count %}
+      <div class="alert alert-error flex flex-col items-start gap-2 w-full mb-4"
+           role="alert">
+        <div class="flex items-center gap-2 font-semibold">
+          <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+          <span>Please correct the errors below</span>
+        </div>
+      </div>
+    {% endif %}
     <div class="flex flex-col gap-4 w-full">
       <div class="flex gap-16 justify-between">
         <div>

--- a/src/argus/htmx/templates/htmx/timeslot/timerecurrence_div.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timerecurrence_div.html
@@ -18,7 +18,7 @@
     <div class="form-control w-full self-center">
       <label class="label label-text" for={{ form.days.auto_id }}><em>{{ form.days.label }}</em>
       </label>
-      {{ errors }}
+      {% for error in form.days.errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
       {% render_field form.days %}
     </div>
   </fieldset>

--- a/src/argus/htmx/templates/messages/_banner.html
+++ b/src/argus/htmx/templates/messages/_banner.html
@@ -1,0 +1,31 @@
+{% comment %}
+Accessible inline banner. Uses role="alert" for error/warning, role="status" for success/info.
+Parameters: message (required), level (error|warning|success|info), dismissible (default: true), id
+{% endcomment %}
+{% with level=level|default:"info" dismissible=dismissible|default:True %}
+  <div {% if id %}id="{{ id }}"{% endif %}
+       class="alert {% if level == 'error' %}alert-error{% elif level == 'warning' %}alert-warning{% elif level == 'success' %}alert-success{% else %}alert-info{% endif %} flex justify-between w-full"
+       role="{% if level == 'error' or level == 'warning' %}alert{% else %}status{% endif %}"
+       {% if level != 'error' and level != 'warning' %}aria-live="polite"{% endif %}>
+    <div class="flex items-center gap-2">
+      {% if level == "error" %}
+        <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+      {% elif level == "warning" %}
+        <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+      {% elif level == "success" %}
+        <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
+      {% else %}
+        <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+      {% endif %}
+      <span>{{ message }}</span>
+    </div>
+    {% if dismissible %}
+      <button type="button"
+              class="btn btn-ghost btn-sm btn-circle"
+              aria-label="Dismiss message"
+              _="on click remove closest .alert">
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      </button>
+    {% endif %}
+  </div>
+{% endwith %}

--- a/src/argus/htmx/templates/messages/_notification_message.html
+++ b/src/argus/htmx/templates/messages/_notification_message.html
@@ -1,21 +1,29 @@
 {% load argus_htmx %}
 {% with autoclose=message|autoclose_time %}
   <div class="alert flex justify-between w-fit border-3 bg-base-100 border-opacity-100 {% if message.tags %}{{ message.tags }}{% endif %}"
-       {% if autoclose >= 0 %}_="on load wait {{ autoclose }}s then add .autoclosing to me then wait 0.3s then remove me"{% endif %}>
+       role="{% if 'error' in message.tags or 'warning' in message.tags %}alert{% else %}status{% endif %}"
+       {% if 'error' not in message.tags and 'warning' not in message.tags %}aria-live="polite"{% endif %}
+       _="on load focus() me then {% if autoclose >= 0 %}wait {{ autoclose }}s then add .autoclosing to me then wait 0.3s then remove me{% endif %}"
+       tabindex="-1">
     {% block message-content %}
-      <div>{{ message }}</div>
+      <div class="flex items-center gap-2">
+        {% if "error" in message.tags %}
+          <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+        {% elif "warning" in message.tags %}
+          <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+        {% elif "success" in message.tags %}
+          <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
+        {% else %}
+          <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+        {% endif %}
+        <span>{{ message }}</span>
+      </div>
     {% endblock message-content %}
     <button type="button"
-            class="rounded-full p-2 hover:bg-gray-100/10 ring-gray-500/50 ring-inset hover:ring-1 focus:outline-none focus:ring-2"
+            class="btn btn-ghost btn-sm btn-circle"
+            aria-label="Dismiss message"
             _="on click remove closest .alert">
-      <svg class="h-6 w-6"
-           xmlns="http://www.w3.org/2000/svg"
-           fill="none"
-           viewBox="0 0 24 24"
-           stroke="currentColor"
-           aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-      </svg>
+      <i class="fa-solid fa-xmark" aria-hidden="true"></i>
     </button>
   </div>
 {% endwith %}

--- a/src/argus/htmx/templates/messages/_notification_messages.html
+++ b/src/argus/htmx/templates/messages/_notification_messages.html
@@ -1,4 +1,4 @@
-<div id="notification-messages">
+<div id="notification-messages" aria-live="assertive" aria-atomic="false">
   <div class="toast items-end z-50">
     {% for message in messages %}
       {% include "./_notification_message.html" %}

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -148,12 +148,6 @@ class FormsetMixin:
             return self.form_invalid(form, formset)
 
     def form_invalid(self, form, formset):
-        errors = []
-        for error in [form.errors] + formset.errors:
-            if error:
-                errors.append(error.as_text())
-        if errors:
-            messages.warning(self.request, f"Couldn't save timeslot: {errors}")
         return self.render_to_response(self.get_context_data(form=form, formset=formset))
 
     def form_valid(self, form, formset):

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -264,5 +264,4 @@ class TimeslotDeleteView(TimeslotMixin, DeleteView):
         self.object = self.get_object()
         success_url = self.get_success_url()
         self.object.delete()
-        messages.success(request, f'Successfully deleted timeslot "{self.object}"')
         return HttpResponseRedirect(success_url)

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -223,7 +223,8 @@ class TimeslotCreateView(FormsetMixin, TimeslotMixin, CreateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["formset"] = make_timerecurrence_formset()
+        if "formset" not in context:
+            context["formset"] = make_timerecurrence_formset()
         return context
 
     def post(self, request, *args, **kwargs):
@@ -236,7 +237,8 @@ class TimeslotUpdateView(FormsetMixin, TimeslotMixin, UpdateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["formset"] = make_timerecurrence_formset(timeslot=self.object)
+        if "formset" not in context:
+            context["formset"] = make_timerecurrence_formset(timeslot=self.object)
         form = context["form"]
         form = self._set_delete_modal(form, self.object)
         context["form"] = form

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -68,6 +68,14 @@ class TimeRecurrenceForm(forms.ModelForm):
             timeobj = timeobj.replace(second=0, microsecond=0)
         return timeobj
 
+    def clean(self):
+        cleaned_data = super().clean()
+        start = cleaned_data.get("start")
+        end = cleaned_data.get("end")
+        if start and end and start >= end:
+            self.add_error("start", "Start time must be before end time.")
+        return cleaned_data
+
 
 class TimeslotForm(forms.ModelForm):
     class Meta:

--- a/tests/htmx/timeslot/test_views.py
+++ b/tests/htmx/timeslot/test_views.py
@@ -1,0 +1,120 @@
+from django.contrib.messages import get_messages
+from django.test import TestCase
+from django.urls import reverse
+
+from argus.auth.factories import PersonUserFactory
+from argus.notificationprofile.factories import TimeslotFactory, TimeRecurrenceFactory
+
+
+class TestTimeslotUpdateView(TestCase):
+    def test_get_renders_form_with_formset(self):
+        user = PersonUserFactory()
+        timeslot = TimeslotFactory(user=user)
+        self.client.force_login(user=user)
+
+        response = self.client.get(reverse("htmx:timeslot-update", kwargs={"pk": timeslot.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("formset", response.context)
+
+    def test_deleting_all_recurrences_shows_warning(self):
+        user = PersonUserFactory()
+        timeslot = TimeslotFactory(user=user)
+        recurrence = TimeRecurrenceFactory(timeslot=timeslot)
+        self.client.force_login(user=user)
+
+        post_data = _build_timeslot_post_data(timeslot, [recurrence], delete_indices=[0])
+
+        response = self.client.post(
+            reverse("htmx:timeslot-update", kwargs={"pk": timeslot.pk}),
+            data=post_data,
+        )
+
+        self.assertRedirects(response, reverse("htmx:timeslot-list"), fetch_redirect_response=False)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].level_tag, "warning")
+        self.assertIn("no time recurrences", str(messages[0]))
+
+    def test_invalid_formset_preserves_errors(self):
+        user = PersonUserFactory()
+        timeslot = TimeslotFactory(user=user)
+        recurrence = TimeRecurrenceFactory(timeslot=timeslot)
+        self.client.force_login(user=user)
+
+        # Submit with missing required field (empty start time)
+        post_data = _build_timeslot_post_data(timeslot, [recurrence])
+        formset_prefix = f"timerecurrenceform-{timeslot.pk}"
+        post_data[f"{formset_prefix}-0-start"] = ""
+
+        response = self.client.post(
+            reverse("htmx:timeslot-update", kwargs={"pk": timeslot.pk}),
+            data=post_data,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("formset", response.context)
+        self.assertTrue(response.context["formset"].errors)
+
+
+class TestTimeslotCreateView(TestCase):
+    def test_get_renders_form_with_formset(self):
+        user = PersonUserFactory()
+        self.client.force_login(user=user)
+
+        response = self.client.get(reverse("htmx:timeslot-create"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("formset", response.context)
+
+    def test_invalid_formset_preserves_errors(self):
+        user = PersonUserFactory()
+        self.client.force_login(user=user)
+
+        # Submit with missing required fields
+        post_data = {
+            "name": "Test Timeslot",
+            "time_recurrences-TOTAL_FORMS": "1",
+            "time_recurrences-INITIAL_FORMS": "0",
+            "time_recurrences-MIN_NUM_FORMS": "1",
+            "time_recurrences-MAX_NUM_FORMS": "1000",
+            "time_recurrences-0-start": "",
+            "time_recurrences-0-end": "",
+            "time_recurrences-0-days": [],
+        }
+
+        response = self.client.post(reverse("htmx:timeslot-create"), data=post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("formset", response.context)
+        self.assertTrue(response.context["formset"].errors)
+
+
+def _build_timeslot_post_data(timeslot, recurrences, delete_indices=None):
+    """Build POST data for timeslot form with recurrences."""
+    delete_indices = delete_indices or []
+    form_prefix = f"timeslot-{timeslot.pk}"
+    formset_prefix = f"timerecurrenceform-{timeslot.pk}"
+
+    data = {
+        f"{form_prefix}-name": timeslot.name,
+        f"{formset_prefix}-TOTAL_FORMS": str(len(recurrences)),
+        f"{formset_prefix}-INITIAL_FORMS": str(len(recurrences)),
+        f"{formset_prefix}-MIN_NUM_FORMS": "1",
+        f"{formset_prefix}-MAX_NUM_FORMS": "1000",
+    }
+
+    for i, recurrence in enumerate(recurrences):
+        data.update(
+            {
+                f"{formset_prefix}-{i}-id": str(recurrence.pk),
+                f"{formset_prefix}-{i}-timeslot": str(timeslot.pk),
+                f"{formset_prefix}-{i}-start": recurrence.start.strftime("%H:%M"),
+                f"{formset_prefix}-{i}-end": recurrence.end.strftime("%H:%M"),
+                f"{formset_prefix}-{i}-days": [str(d) for d in recurrence.days],
+            }
+        )
+        if i in delete_indices:
+            data[f"{formset_prefix}-{i}-DELETE"] = "on"
+
+    return data


### PR DESCRIPTION
## Scope and purpose

Resolves #1701

Replace toast notifications with accessible alternatives following WCAG and GitHub Primer accessibility patterns:

  - Add ARIA attributes (role="alert", role="status", aria-live) to notification messages
  - Add focus management so screen readers announce toasts on page load
  - Remove redundant success toasts for self-evident actions (filter update/delete, preference saves)
  - Remove form validation toasts in favor of inline error display
  - Show inline validation errors in timeslot forms with error summary banner
  - Keep warning toast for empty timeslots (important user feedback)
  - Add reusable _banner.html and _form_errors.html components

## How to test
  
### 1. Inline form validation  

1. Go to "Timeslots"
2. Leave both name, start/end and day empty
3. Verify that a red banner appears on top, and that inline errors show on the expected fields

### 2. Removal of self-evident success toasts

1. Go to incidents and select a filter from the dropdown. No toast should be triggered.
2. Update or delete a shared filter. Should not trigger a toast.
3. Change a preference (or more) in the user preferences. Should not trigger a toast.

### 3. Warning toast

There are still toasts in place for certain warnings, or when the server has an error such as code 500.

#### 3.1 Warning toast message

1. Go to "Timeslots", and edit an existing timeslot with recurrences
2. Check "delete" on all recurrences
3. Verify that a warning toast is triggered about no recurrences.

#### 3.2 Screen reader announcement

1. Enable a screen reader (e.g. VoiceOver on macOS: `Cmd+F5`)
2. Repeat steps 1.-3. in 3.1
3. Verify that the toast was announced by the screen reader

## Screenshots

#### Form validation in Timeslot form
<img width="400" height="329" alt="image" src="https://github.com/user-attachments/assets/b04d14d3-162a-4178-89ae-a13b836b4297" />

#### Warning toast when deleting all recurrences in a timeslot
<img width="644" height="253" alt="image" src="https://github.com/user-attachments/assets/8db08be4-961d-4380-9350-586199c098b2" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
