### PR TITLE
Refresh css on building package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 !.sonarcloud.properties
 !.mailmap
 
+src/argus/htmx/static/styles.css
+
 # local config files
 cmd.sh
 localsettings.py

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ testclean: coverageclean clean
 nuke: clean docclean distclean testclean cacheclean
 
 tailwindcli:
-	@which tailwind || echo "tailwindcss not in path"
+	@which tailwindcss || echo "tailwindcss not in path"
 
 tailwind: tailwindcli
 	tailwindcss -c $(TAILWINDDIR)/tailwind.config.js -i $(TAILWINDDIR)/styles.css -o $(STATICDIR)/styles.css

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-.PHONY: clean testclean distclean coverageclean cacheclean nuke tailwind docclean upgrade-tailwind tailwind-watch
+.PHONY: clean build testclean distclean docclean coverageclean cacheclean nuke tailwindcli tailwind tailwind-watch upgrade-tailwind
 
-TAILWINDDIR=src/argus/htmx/tailwindtheme
-STATICDIR=src/argus/htmx/static
-PYTHONPATH=./src
-
+STYLE_SOURCES := $(shell find src/argus -name '*.html')
+TAILWINDDIR:=src/argus/htmx/tailwindtheme
+STATICDIR:=src/argus/htmx/static
+PYTHONPATH:=./src
 
 clean:
 	-find . -name __pycache__ -print0 | xargs -0 rm -rf
 	-find . -name "*.pyc" -print0 | xargs -0 rm -rf
 	-find . -name "*.egg-info" -print0 | xargs -0 rm -rf
+
+build: tailwind
 
 cacheclean:
 	-find . -name ".ruff_cache" -print0 | xargs -0 rm -rf
@@ -31,8 +33,11 @@ testclean: coverageclean clean
 
 nuke: clean docclean distclean testclean cacheclean
 
-tailwind:
-	$(TAILWINDDIR)/tailwindcss -c $(TAILWINDDIR)/tailwind.config.js -i $(TAILWINDDIR)/styles.css -o $(STATICDIR)/styles.css
+tailwindcli:
+	@which tailwind || echo "tailwindcss not in path"
+
+tailwind: tailwindcli
+	tailwindcss -c $(TAILWINDDIR)/tailwind.config.js -i $(TAILWINDDIR)/styles.css -o $(STATICDIR)/styles.css
 
 tailwind-watch:
 	$(TAILWINDDIR)/tailwindcss -c $(TAILWINDDIR)/tailwind.config.js -i $(TAILWINDDIR)/styles.css -o $(STATICDIR)/styles.css --watch

--- a/docs/customization/htmx-frontend.rst
+++ b/docs/customization/htmx-frontend.rst
@@ -41,70 +41,82 @@ example.
 Themes and styling
 ==================
 
-How to customize the look:
+In order to customize the CSS you need to have ``tailwindcss`` in the shell
+``$PATH``. Running ``make upgrade-tailwind`` will download a binary to
+``src/argus/htmx/tailwindtheme/tailwindcss`` which can then be copied or linked
+to a directory in $PATH, or you can add the absolute path to the parent
+directory of ``tailwindcss`` to your ``$PATH`` by changing the environment
+variable as per your shell.
 
-* Override Argus' Tailwind CSS theme defaults and/or choose which daisyUI color
-  themes to include. You can do so by updating the default
-  :setting:`TAILWIND_THEME_OVERRIDE` and :setting:`DAISYUI_THEMES` settings
-  respectively before running a ``tailwind_config`` management command:
+Alter themes
+------------
 
-  Via environment variables, for example::
+Override Argus' Tailwind CSS theme defaults and/or choose which daisyUI color
+themes to include. You can do so by updating the default
+:setting:`TAILWIND_THEME_OVERRIDE` and :setting:`DAISYUI_THEMES` settings
+respectively before running a ``tailwind_config`` management command:
 
-    TAILWIND_THEME_OVERRIDE = '
-      {
-        "borderWidth": {
-          "DEFAULT": "1px"
-        },
-        "extend": {
-          "borderRadius": {
-            "4xl": "2rem"
-          }
-        }
-      }
-    '
-    DAISYUI_THEMES = '
-      [
-        "light",
-        "dark",
-        "cyberpunk",
-        "dim",
-        "autumn",
-        { "mytheme": {
-            "color-scheme": "dark",
-            "primary": "#009eb6",
-            "primary-content": "#00090c",
-            "secondary": "#00ac00",
-            "secondary-content": "#000b00",
-            "accent": "#ff0000",
-            "accent-content": "#160000",
-            "neutral": "#262c0e",
-            "neutral-content": "#cfd1ca",
-            "base-100": "#292129",
-            "base-200": "#221b22",
-            "base-300": "#1c161c",
-            "base-content": "#d0cdd0",
-            "info": "#00feff",
-            "info-content": "#001616",
-            "success": "#b1ea50",
-            "success-content": "#0c1302",
-            "warning": "#d86d00",
-            "warning-content": "#110400",
-            "error": "#ff6280",
-            "error-content": "#160306"
-            }
-        }
-      ]
-    '
+Via environment variables, for example::
 
-  Or by providing corresponding values in your local settings that star-imports from an `argus-server`_ settings file::
+TAILWIND_THEME_OVERRIDE = '
+{
+"borderWidth": {
+  "DEFAULT": "1px"
+},
+"extend": {
+  "borderRadius": {
+    "4xl": "2rem"
+  }
+}
+}
+'
+DAISYUI_THEMES = '
+[
+"light",
+"dark",
+"cyberpunk",
+"dim",
+"autumn",
+{ "mytheme": {
+    "color-scheme": "dark",
+    "primary": "#009eb6",
+    "primary-content": "#00090c",
+    "secondary": "#00ac00",
+    "secondary-content": "#000b00",
+    "accent": "#ff0000",
+    "accent-content": "#160000",
+    "neutral": "#262c0e",
+    "neutral-content": "#cfd1ca",
+    "base-100": "#292129",
+    "base-200": "#221b22",
+    "base-300": "#1c161c",
+    "base-content": "#d0cdd0",
+    "info": "#00feff",
+    "info-content": "#001616",
+    "success": "#b1ea50",
+    "success-content": "#0c1302",
+    "warning": "#d86d00",
+    "warning-content": "#110400",
+    "error": "#ff6280",
+    "error-content": "#160306"
+    }
+}
+]
+'
 
-        TAILWIND_THEME_OVERRIDE = {...}
-        DAISYUI_THEMES = [...]
+Or by providing corresponding values in your local settings that star-imports from an `argus-server`_ settings file::
 
-  Some links that may be relevant for the customization values mentioned above:
-    * `daisyUI themes`_
-    * `list of daisyUI color names`_
-    * `Tailwind CSS theme customization`_
+   TAILWIND_THEME_OVERRIDE = {...}
+   DAISYUI_THEMES = [...]
+
+Some links that may be relevant for the customization values mentioned above:
+
+* `daisyUI themes`_
+* `list of daisyUI color names`_
+* `Tailwind CSS theme customization`_
+
+Alter CSS and stylesheets
+-------------------------
 
 * Override the default main stylesheet path by setting
   ``ARGUS_STYLESHEET_PATH`` in the environment. The path is under

--- a/docs/development/howtos/release-checklist.rst
+++ b/docs/development/howtos/release-checklist.rst
@@ -180,3 +180,12 @@ Checklist
    #. Copy the changelog into the box below, dedent the headers once.
 
    #. Finally, click the "Publish release"-button. Done!
+
+Post-release clean up
+---------------------
+
+The packaging will have generated package files in ``dist/``, these can be
+removed by running ``make distclean``.
+
+The file ``src/argus/htmx/static/styles.css`` will also have been regenerated,
+don't commit it so as to keep merge conflicts down.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "versioningit>=3.0.0"]
+requires = ["hatchling", "hatch-build-scripts", "versioningit>=3.0.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -86,6 +86,15 @@ exclude = [
     "/*.json",
     "/*.py",
     "/*.sh",
+]
+
+[[tool.hatch.build.hooks.build-scripts.scripts]]
+# build css
+commands = [
+    "make tailwind"
+]
+artifacts = [
+    "src/argus/htmx/static/styles.css",
 ]
 
 [tool.versioningit.write]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ exclude = [
 [[tool.hatch.build.hooks.build-scripts.scripts]]
 # build css
 commands = [
-    "make tailwind"
+    "make upgrade-tailwind tailwind"
 ]
 artifacts = [
     "src/argus/htmx/static/styles.css",


### PR DESCRIPTION
## Scope and purpose

Fixes #1712

For this to work, "tailwindcss" must be in PATH. How to set PATH is OS and distro dependent.

<!-- remove things that do not apply -->
### This pull request
* adds/changes/removes a dependency

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* ~[ ] Added/amended tests for new/changed code~
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* ~[ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)~
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
