### PR TITLE
Add wider `start_time_and_age` column

### DIFF
--- a/changelog.d/1719.changed.md
+++ b/changelog.d/1719.changed.md
@@ -1,0 +1,1 @@
+Renamed column `start_time_and_age` to `narrow_start_time_and_age` and added wider column named `start_time_and_age`

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -96,7 +96,7 @@ _BUILTIN_COLUMN_LIST = [
         sort_field="start_time",
     ),
     IncidentTableColumn(
-        "start_time_and_age",
+        "narrow_start_time_and_age",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time_and_age.html",
         detail_link=True,

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -103,6 +103,14 @@ _BUILTIN_COLUMN_LIST = [
         sort_field="start_time",
     ),
     IncidentTableColumn(
+        "start_time_and_age",
+        "Timestamp",
+        "htmx/incident/cells/_incident_start_time_and_age.html",
+        detail_link=True,
+        column_classes="min-w-48",
+        sort_field="start_time",
+    ),
+    IncidentTableColumn(
         "narrow_start_time",
         "Timestamp",
         "htmx/incident/cells/_incident_start_time.html",


### PR DESCRIPTION
## Scope and purpose

In a meeting with Argus users at Sikt a column that showed start time and age, but the same width as the standard start time column was asked for. This renames the existing `start_time_and_age` column to `narrow_start_time_and_age` and adds a new column `start_time_and_age` that is wider. 

Before:
<img width="560" height="360" alt="image" src="https://github.com/user-attachments/assets/583ba2e5-7003-4806-91e1-86582630137f" />


After:
<img width="833" height="360" alt="image" src="https://github.com/user-attachments/assets/c17626f3-db2a-4854-beb6-ce579e3d81a4" />
(`start_time_and_age` on the left and `narrow_start_time_and_age` on the right)


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
