### PR TITLE
Add end_time column to incident table

### DIFF
--- a/changelog.d/1715.added.md
+++ b/changelog.d/1715.added.md
@@ -1,0 +1,1 @@
+Add column to display the end_time of an incident

--- a/changelog.d/1715.added.md
+++ b/changelog.d/1715.added.md
@@ -1,1 +1,1 @@
-Add column to display the end_time of an incident
+Add new end_time and narrow_end_time columns to display the end_time of an incident

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -267,6 +267,12 @@ search_description
     .. image:: img/columns/search_description.png
        :width: 200
 
+end_time
+    :From: end_time
+    :Name: end_time
+    :Description: When the incident was resolved/closed. Empty for open and
+                  stateless incidents.
+
 id
     :From: id
     :Name: id

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -272,6 +272,14 @@ end_time
     :Name: end_time
     :Description: When the incident was resolved/closed. Empty for open and
                   stateless incidents.
+    :Redundant with: narrow_end_time
+
+narrow_end_time
+    :From: end_time
+    :Name: end_time
+    :Description: When the incident was resolved/closed, width depends on date format.
+                  Empty for open and stateless incidents.
+    :Redundant with: end_time
 
 id
     :From: id

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -119,7 +119,7 @@ _BUILTIN_COLUMN_LIST = [
     ),
     IncidentTableColumn(
         "end_time",
-        "End Time",
+        "End time",
         "htmx/incident/cells/_incident_end_time.html",
         detail_link=True,
         sort_field="end_time",

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -118,6 +118,13 @@ _BUILTIN_COLUMN_LIST = [
         sort_field="start_time",
     ),
     IncidentTableColumn(
+        "end_time",
+        "End Time",
+        "htmx/incident/cells/_incident_end_time.html",
+        detail_link=True,
+        sort_field="end_time",
+    ),
+    IncidentTableColumn(
         "status",
         "Status",
         "htmx/incident/cells/_incident_status.html",

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -122,6 +122,14 @@ _BUILTIN_COLUMN_LIST = [
         "End time",
         "htmx/incident/cells/_incident_end_time.html",
         detail_link=True,
+        column_classes="min-w-48",
+        sort_field="end_time",
+    ),
+    IncidentTableColumn(
+        "narrow_end_time",
+        "End time",
+        "htmx/incident/cells/_incident_end_time.html",
+        detail_link=True,
         sort_field="end_time",
     ),
     IncidentTableColumn(

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_end_time.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_end_time.html
@@ -1,0 +1,4 @@
+<!-- htmx/incident/cells/_incident_end_time.html -->
+{% if incident.end_time and not incident.open %}
+  {{ incident.end_time|date:preferences.argus_htmx.datetime_format }}
+{% endif %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1715

Adds a new end_time column that displays the resolved timestamp for closed incidents. Open and stateless incidents show an empty cell, consistent with other columns like Ticket.

<img width="498" height="474" alt="image" src="https://github.com/user-attachments/assets/638a1e61-6305-4cd0-bb53-3088eff3d643" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
