### PR TITLE
Fix djlint config

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Format HTML
       run: |
         djlint --version
-        djlint . --check
+        djlint . --check --configuration pyproject.toml

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,4 +32,6 @@ jobs:
         pip install djlint
 
     - name: Format HTML
-      run: djlint . --check
+      run: |
+        djlint --version
+        djlint . --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,6 @@ repos:
     rev: v1.36.4
     hooks:
       - id: djlint-reformat-django
+        args: [--configuration, pyproject.toml]
       - id: djlint-django
+        args: [--configuration, pyproject.toml]


### PR DESCRIPTION
## Scope and purpose

djlint run in the CLI, by pre-commit, and github actions, need not use the same version nor the same cinfiguration. Whuch means that hat one of them accepts, another might fail.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* ~[ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)~
* ~[ ] Added/amended tests for new/changed code~
* ~[ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed~
* ~[ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)~
* ~[ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)~
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
