### PR TITLE
Disable buttons in dummy columns

### DIFF
--- a/changelog.d/+disable-buttons-in-dummy-columns.changed.md
+++ b/changelog.d/+disable-buttons-in-dummy-columns.changed.md
@@ -1,0 +1,1 @@
+The buttons in the column layout preview were disabled.

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -10,7 +10,8 @@
               tabindex="0"
               aria-label="Filter by {{ column.label|lower }}"
               aria-controls="{{ column.name }}-dropdown-content"
-              class="filter-btn btn btn-xs {% if field.value %} btn-primary {% else %} btn-ghost text-primary {% endif %} min-h-4 h-4">
+              class="filter-btn btn btn-xs {% if field.value %} btn-primary {% else %} btn-ghost text-primary {% endif %} min-h-4 h-4"
+              {% if dummy_column %}disabled{% endif %}>
         <i class="fa-solid fa-magnifying-glass"></i>
       </button>
       <div id="{{ column.name }}-dropdown-content"

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button_element.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_sort_button_element.html
@@ -3,6 +3,7 @@
 <button type="button"
         class="btn btn-xs btn-ghost p-0 aspect-square min-h-4 h-4 {% if active %}text-primary{% else %}text-base-content/50 hover:text-primary{% endif %}"
         aria-label="{{ label }}"
+        {% if dummy_column %}disabled{% endif %}
         hx-get="{% url 'htmx:incident-list' %}"
         hx-vals='{"sort": "{{ next_sort }}", "sort_order": "{{ next_order }}"}'
         hx-include=".incident-list-param"


### PR DESCRIPTION
## Scope and purpose

In a dummy incident column, like for instance when choosing column layouts in the user preferences page, we want the buttons to be visible but not working. This must include any sort buttons!

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* ~[ ] Added/amended tests for new/changed code~
* ~[ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed~
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~