### PR TITLE
Improve HTMX error handling with meaningful messages and tracebacks

### DIFF
--- a/changelog.d/1702.fixed.md
+++ b/changelog.d/1702.fixed.md
@@ -1,0 +1,1 @@
+Show meaningful error messages in UI and log full tracebacks for HTMX errors instead of generic "500 Internal Server Error" and HTML content

--- a/src/argus/htmx/middleware.py
+++ b/src/argus/htmx/middleware.py
@@ -67,11 +67,9 @@ class HtmxMessageMiddleware(MiddlewareMixin):
     TEMPLATE = "messages/_notification_messages_htmx_append.html"
 
     def process_exception(self, request, exception):
-        error_msg = "500 Internal Server Error"
+        error_msg = f"{type(exception).__name__}: {exception}" if str(exception) else type(exception).__name__
         messages.error(request, error_msg)
-        if str(exception):
-            error_msg = f"{error_msg}: {exception}"
-        LOG.error(error_msg)
+        LOG.exception("HTMX request failed: %s", error_msg)
         return None
 
     def process_response(self, request: HtmxHttpRequest, response: HttpResponse) -> HttpResponse:
@@ -97,13 +95,9 @@ class HtmxMessageMiddleware(MiddlewareMixin):
             has_error_message = any("error" in message.tags for message in storage)
             storage.used = False
             if not has_error_message:
-                error_msg = getattr(response, "content", b"")
-                if isinstance(error_msg, bytes):
-                    error_msg = error_msg.decode("utf-8")
-                if not error_msg:
-                    error_msg = f"{response.status_code} {response.reason_phrase}"
-                LOG.error("Unhandled exception: %s", error_msg)
-                messages.error(request, "An unexpected error occured. Please try again")
+                error_msg = f"{response.status_code}: {response.reason_phrase}"
+                LOG.error("HTMX request returned %s for %s %s", error_msg, request.method, request.path)
+                messages.error(request, error_msg)
             # HTMX doesn't swap content for response codes >=400. However, we do want to show
             # the new messages, so we need to rewrite the response to 200, and make sure it only
             # swaps the oob notification content


### PR DESCRIPTION
## Scope and purpose

Fixes #1702

Previously, HTMX errors showed a generic "500 Internal Server Error" in the UI and logged HTML error pages instead of useful information.

### This pull request
- Adds actual error details in UI (e.g., ValueError: invalid input instead of generic "500 Internal Server Error")
- Logs full tracebacks using LOG.exception() for proper debugging
- Logs structured error info for HTTP error responses ("HTMX request returned 404 Not Found for GET /path") instead of HTML content

### How to test

1. Open a javascript console in the browser
2. Paste in `htmx.ajax('GET', '/does-not-exist', {target: 'body'})`
3. Verify that an error toast is shown with "404 Not Found"
4. Verify that a proper error is logged in the python console, looking something like this:
    `2026-01-15 13:40:29,442 argus.htmx.middleware ERROR    HTMX request returned 404 Not Found for GET /does-not-exist`

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
