### PR TITLE
Add management command to set `incidents` field for recently started planned maintenance tasks

### DIFF
--- a/changelog.d/1734.added.md
+++ b/changelog.d/1734.added.md
@@ -1,0 +1,1 @@
+Added management command to connect incidents to new planned maintenance tasks

--- a/docs/development/management-commands.rst
+++ b/docs/development/management-commands.rst
@@ -466,6 +466,20 @@ whether the user is a superuser (superuser) or not (nosuperuser). Superusers
 have by default access to the admin, but this can be turned off with
 ``--nostaff``.
 
+Planned maintenance handling
+============================
+Connect new planned maintenance tasks with their covered incidents
+------------------------------------------------------------------
+
+There is a command ``check_started_maintenance``. It takes an argument ``--minutes``
+(default 5 min) and will find all planned maintenance tasks that have started within
+the last x minutes. For each of these tasks it finds all open incidents that are
+covered by it and adds them to the ``incidents`` list of that task if it isn't already
+there.
+
+This field will be used to show in the dashboard which incidents are covered by an
+ongoing planned maintenance task.
+
 Deprecated/overlapping commands
 ===============================
 

--- a/src/argus/dev/management/commands/check_started_maintenance.py
+++ b/src/argus/dev/management/commands/check_started_maintenance.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from argus.plannedmaintenance.models import PlannedMaintenanceTask
+
+
+class Command(BaseCommand):
+    help = "Find all planned maintenance tasks that have started recently and connect them with incidents that are hit by them"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-m",
+            "--minutes",
+            default=5,
+            type=int,
+            help="Only calculate the connected incidents for planned maintenance tasks that have started within the last <number> minutes",
+        )
+
+    def handle(self, *args, **options):
+        start_time = timezone.now() - timedelta(minutes=options.get("minutes"))
+        started_pm_tasks = PlannedMaintenanceTask.objects.started_after_time(start_time)
+
+        for pm_task in started_pm_tasks:
+            pm_task.connect_covered_incidents()

--- a/tests/plannedmaintenance/test_models.py
+++ b/tests/plannedmaintenance/test_models.py
@@ -52,6 +52,19 @@ class PlannedMaintenanceQuerySetTests(TestCase):
         self.assertIn(self.future_pm, active_at_time_pms)
         self.assertIn(self.current_pm, active_at_time_pms)
 
+    def test_started_after_time_returns_only_open_pms_with_start_time_between_given_time_and_now(self):
+        recently_started_closed_pm = PlannedMaintenanceFactory(
+            start_time=self.current_pm.start_time, end_time=self.current_pm.start_time + timedelta(seconds=15)
+        )
+        started_after_time_pms = PlannedMaintenanceTask.objects.started_after_time(
+            self.current_pm.start_time - timedelta(minutes=1)
+        )
+
+        self.assertNotIn(self.past_pm, started_after_time_pms)
+        self.assertIn(self.current_pm, started_after_time_pms)
+        self.assertNotIn(self.future_pm, started_after_time_pms)
+        self.assertNotIn(recently_started_closed_pm, started_after_time_pms)
+
 
 @tag("database")
 class PlannedMaintenanceTaskTests(TestCase):


### PR DESCRIPTION
## Scope and purpose

Dependent on #1733. Part of working on #1589. 

This management command should be set up as a cronjob that will run regularly to keep the `incidents` field of new planned maintenance tasks updated so that the planned maintenance column can show which incidents are under maintenance. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
