### PR TITLE
Add mgmt cmd to clear incidents from past PM tasks

### DIFF
--- a/changelog.d/1735.added.md
+++ b/changelog.d/1735.added.md
@@ -1,0 +1,1 @@
+Added management command to remove incidents from ended planned maintenance tasks

--- a/docs/development/management-commands.rst
+++ b/docs/development/management-commands.rst
@@ -480,6 +480,17 @@ there.
 This field will be used to show in the dashboard which incidents are covered by an
 ongoing planned maintenance task.
 
+Remove covered incidents from recently closed planned maintenance tasks
+-----------------------------------------------------------------------
+
+There is a command ``check_ended_maintenance``. It takes an argument ``--minutes``
+(default 5 min) and will find all planned maintenance tasks that have ended within the
+last x minutes. For each of these tasks it clears the ``incidents`` field of that task.
+
+This field is be used to show in the dashboard which incidents are covered by an
+ongoing planned maintenance task. Since the task has ended these incidents are not
+covered by it anymore.
+
 Deprecated/overlapping commands
 ===============================
 

--- a/src/argus/dev/management/commands/check_ended_maintenance.py
+++ b/src/argus/dev/management/commands/check_ended_maintenance.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from argus.plannedmaintenance.models import PlannedMaintenanceTask
+
+
+class Command(BaseCommand):
+    help = "Find all planned maintenance tasks that have ended recently and remove the incidents connection"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-m",
+            "--minutes",
+            default=5,
+            type=int,
+            help="Only remove the incidents from the planned maintenance tasks that have ended within the last <number> minutes",
+        )
+
+    def handle(self, *args, **options):
+        end_time = timezone.now() - timedelta(minutes=options.get("minutes"))
+        ended_pm_tasks = PlannedMaintenanceTask.objects.ended_after_time(end_time)
+
+        for pm_task in ended_pm_tasks:
+            pm_task.incidents.clear()

--- a/src/argus/plannedmaintenance/models.py
+++ b/src/argus/plannedmaintenance/models.py
@@ -43,6 +43,12 @@ class PlannedMaintenanceQuerySet(models.QuerySet):
         now = timezone.now()
         return self.filter(start_time__gte=time, start_time__lte=now, end_time__gte=now)
 
+    def ended_after_time(self, time: datetime):
+        """
+        Returns all tasks that were ended after the given time and now
+        """
+        return self.filter(end_time__gte=time, end_time__lte=timezone.now())
+
 
 class PlannedMaintenanceTask(models.Model):
     class Meta:

--- a/tests/plannedmaintenance/test_models.py
+++ b/tests/plannedmaintenance/test_models.py
@@ -65,6 +65,19 @@ class PlannedMaintenanceQuerySetTests(TestCase):
         self.assertNotIn(self.future_pm, started_after_time_pms)
         self.assertNotIn(recently_started_closed_pm, started_after_time_pms)
 
+    def ended_after_time_returns_only_closed_pms_with_end_time_after_time(self):
+        recently_started_closed_pm = PlannedMaintenanceFactory(
+            start_time=self.current_pm.start_time, end_time=self.current_pm.start_time + timedelta(seconds=15)
+        )
+        ended_after_time_pms = PlannedMaintenanceTask.objects.ended_after_time(
+            self.current_pm.start_time - timedelta(minutes=1)
+        )
+
+        self.assertNotIn(self.past_pm, ended_after_time_pms)
+        self.assertNotIn(self.current_pm, ended_after_time_pms)
+        self.assertIn(self.future_pm, ended_after_time_pms)
+        self.assertNotIn(recently_started_closed_pm, ended_after_time_pms)
+
 
 @tag("database")
 class PlannedMaintenanceTaskTests(TestCase):


### PR DESCRIPTION
## Scope and purpose

Dependent on #1733. Part of #1589.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
