### PR TITLE
Store unsaved filters in user preferences

### DIFF
--- a/changelog.d/1682.added.md
+++ b/changelog.d/1682.added.md
@@ -1,0 +1,1 @@
+Save current incident filters as a user preference and restore on page load

--- a/src/argus/htmx/templates/htmx/base.html
+++ b/src/argus/htmx/templates/htmx/base.html
@@ -7,7 +7,7 @@
         {% block logo %}
           <a class="link" {% if logo.url %} href="{% url logo.url %}">
           {% else %}
-            href="{% url 'htmx:incident-list' %}{% querystring page_size=preferences.argus_htmx.page_size %}"
+            href="{% url 'htmx:incident-list' %}"
           {% endif %}
           >
           <img class="object-scale-down h-14"

--- a/src/argus/htmx/user/preferences/forms.py
+++ b/src/argus/htmx/user/preferences/forms.py
@@ -284,3 +284,12 @@ class ThemeForm(SimplePreferenceForm):
             ],
         }
         return context
+
+
+class IncidentFilterPreferenceForm(ClassicPreferenceFormMixin, forms.Form):
+    """Form for storing the current incident filter as a user preference.
+
+    Filter is stored as a JSON object.
+    """
+
+    incident_filter = forms.JSONField(required=False, initial=dict)

--- a/src/argus/htmx/user/preferences/forms.py
+++ b/src/argus/htmx/user/preferences/forms.py
@@ -289,7 +289,20 @@ class ThemeForm(SimplePreferenceForm):
 class IncidentFilterPreferenceForm(ClassicPreferenceFormMixin, forms.Form):
     """Form for storing the current incident filter as a user preference.
 
-    Filter is stored as a JSON object.
+    Filter is stored as a JSON object. This is not a choice-based preference,
+    so get_choices() returns None.
     """
 
     incident_filter = forms.JSONField(required=False, initial=dict)
+
+    @classmethod
+    def get_choices(cls):
+        return None
+
+    @classmethod
+    def get_default(cls):
+        return {}
+
+    @classmethod
+    def get_preference_field(cls):
+        return PreferenceField(form=cls, default=cls.get_default())

--- a/src/argus/htmx/user/preferences/models.py
+++ b/src/argus/htmx/user/preferences/models.py
@@ -1,4 +1,4 @@
-from argus.auth.models import preferences
+from argus.auth.models import preferences, PreferenceField
 from argus.htmx.dateformat.constants import DATETIME_FORMATS
 from argus.htmx.constants import (
     INCIDENTS_TABLE_LAYOUT_DEFAULT,
@@ -7,6 +7,7 @@ from argus.htmx.constants import (
 from argus.htmx.incident.utils import update_interval_string
 from .forms import (
     DateTimeFormatForm,
+    IncidentFilterPreferenceForm,
     IncidentsTableLayout,
     IncidentsTableColumnForm,
     PageSizeForm,
@@ -24,6 +25,10 @@ class ArgusHtmxPreferences:
         "update_interval": UpdateIntervalForm.get_preference_field(),
         "incidents_table_layout": IncidentsTableLayout.get_preference_field(),
         "incidents_table_column_name": IncidentsTableColumnForm.get_preference_field(),
+        "incident_filter": PreferenceField(
+            form=IncidentFilterPreferenceForm,
+            default={},
+        ),
     }
 
     def update_context(self, context):

--- a/src/argus/htmx/user/preferences/models.py
+++ b/src/argus/htmx/user/preferences/models.py
@@ -1,4 +1,4 @@
-from argus.auth.models import preferences, PreferenceField
+from argus.auth.models import preferences
 from argus.htmx.dateformat.constants import DATETIME_FORMATS
 from argus.htmx.constants import (
     INCIDENTS_TABLE_LAYOUT_DEFAULT,
@@ -25,10 +25,7 @@ class ArgusHtmxPreferences:
         "update_interval": UpdateIntervalForm.get_preference_field(),
         "incidents_table_layout": IncidentsTableLayout.get_preference_field(),
         "incidents_table_column_name": IncidentsTableColumnForm.get_preference_field(),
-        "incident_filter": PreferenceField(
-            form=IncidentFilterPreferenceForm,
-            default={},
-        ),
+        "incident_filter": IncidentFilterPreferenceForm.get_preference_field(),
     }
 
     def update_context(self, context):


### PR DESCRIPTION
## Scope and purpose

Resolves #1682

This PR adds functionality to automatically save the current incident filter settings to user preferences, so they persist across page navigation and sessions. When returning to the incident list without explicit filter parameters, the saved filter is restored.

<!-- remove things that do not apply -->
### This pull request
- Adds `incident_filter` preference field to store filter state as JSON
- Modifies `incident_list_filter()` to load/save filter preferences automatically
- Removes `page_size` query parameter from logo link (no longer needed)

### How to test
1. Load Argus without a selected filter. Make some changes to filters, and navigate away, e.g. to user preferences.
2. Click the Argus logo in the header, and verify that the filters you selected previously are still there
3. Load "http://localhost:8000" manually, and verify that the filters you selected in step 1 are restored.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
