### PR TITLE
Safely handle missing filter in incident list

### DIFF
--- a/changelog.d/+fix-bug-in-stored-filters.fixed.md
+++ b/changelog.d/+fix-bug-in-stored-filters.fixed.md
@@ -1,0 +1,3 @@
+Missing filters are now handled better. If a filter was deleted while it was in
+use by the incident list page, the page would get stuck with a "500 Server
+Error" until the filter was manually removed from the session.

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -213,7 +213,11 @@ def incident_list_filter(request, qs, use_empty_filter=False):
     LOG.debug("GET at start: %s", request.GET)
     filter_pk, filter_obj = request.session.get("selected_filter", None), None
     if filter_pk:
-        filter_obj = Filter.objects.get(pk=filter_pk)
+        try:
+            filter_obj = Filter.objects.get(pk=filter_pk)
+        except Filter.DoesNotExist:  # never existed/has been deleted!
+            del request.session["selected_filter"]
+            filter_pk, filter_obj = None, None
     if filter_obj:
         form = IncidentFilterForm(_convert_filterblob(filter_obj.filter))
         LOG.debug("using stored filter: %s", filter_obj.filter)

--- a/tests/htmx/incident/test_filter.py
+++ b/tests/htmx/incident/test_filter.py
@@ -103,6 +103,12 @@ class TestIncidentListFilter(TestCase):
     def teardown(self):
         connect_signals()
 
+    def test_nonexistent_filter_should_return_unfiltered_queryset_and_repair_session(self):
+        self.request.session["selected_filter"] = -1
+        _, qs = incident_list_filter(self.request, self.qs)
+        self.assertEqual(qs, self.qs)
+        self.assertNotIn("selected_filter", self.request.session)
+
     def test_valid_request_should_return_filtered_queryset(self):
         self.request.session["selected_filter"] = self.valid_filter.pk
         _, qs = incident_list_filter(self.request, self.qs)


### PR DESCRIPTION
## Scope and purpose

If a stored filter is deleted while it is in use by the incident list view, the view will get a "500 Server Error".

This prevents that and removes the stored filter from the session.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* ~[ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed~
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* ~[ ] If this results in changes in the UI: Added screenshots of the before and after~
* ~[ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)~

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
