### PR TITLE
Change label of `start_time` column to 'Start time'

### DIFF
--- a/changelog.d/1718.changed.md
+++ b/changelog.d/1718.changed.md
@@ -1,0 +1,1 @@
+Changed label of start time column to 'Start time'

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -82,7 +82,7 @@ _BUILTIN_COLUMN_LIST = [
     ),
     IncidentTableColumn(
         "start_time",
-        "Timestamp",
+        "Start time",
         "htmx/incident/cells/_incident_start_time.html",
         detail_link=True,
         column_classes="min-w-48",
@@ -97,14 +97,14 @@ _BUILTIN_COLUMN_LIST = [
     ),
     IncidentTableColumn(
         "narrow_start_time_and_age",
-        "Timestamp",
+        "Start time",
         "htmx/incident/cells/_incident_start_time_and_age.html",
         detail_link=True,
         sort_field="start_time",
     ),
     IncidentTableColumn(
         "start_time_and_age",
-        "Timestamp",
+        "Start time",
         "htmx/incident/cells/_incident_start_time_and_age.html",
         detail_link=True,
         column_classes="min-w-48",
@@ -112,7 +112,7 @@ _BUILTIN_COLUMN_LIST = [
     ),
     IncidentTableColumn(
         "narrow_start_time",
-        "Timestamp",
+        "Start time",
         "htmx/incident/cells/_incident_start_time.html",
         detail_link=True,
         sort_field="start_time",


### PR DESCRIPTION
## Scope and purpose

Fixes #1718.

As requested by the CNaaS users. 

Screenshots:
<img width="859" height="62" alt="image" src="https://github.com/user-attachments/assets/43afce8b-7a4b-404b-9879-21f8c9e80e39" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
