### PR TITLE
Add column for planned maintenance

### DIFF
--- a/changelog.d/1589.added.md
+++ b/changelog.d/1589.added.md
@@ -1,0 +1,1 @@
+Added column for marking incidents as under maintenance

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -332,6 +332,13 @@ compact_select_levels
                   be selected.
     :Redundant with: level, select_levels, compact_level
 
+under_maintenance
+    :From: planned_maintenance_tasks
+    :Name: under_maintenance
+    :Description: An icon indicating if there exists a planned maintenance task that
+                  covers the incident, meaning no notifications are being sent for that
+                  incident.
+
 status
     :From: open
     :Name: status

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -269,6 +269,11 @@ _BUILTIN_COLUMN_LIST = [
         "htmx/incident/cells/_incident_tags.html",
         detail_link=True,
     ),
+    IncidentTableColumn(
+        "under_maintenance",
+        "Maintenance",
+        "htmx/incident/cells/_incident_maintenance.html",
+    ),
 ]
 BUILTIN_COLUMNS = {col.name: col for col in _BUILTIN_COLUMN_LIST}
 

--- a/src/argus/htmx/incident/views.py
+++ b/src/argus/htmx/incident/views.py
@@ -58,6 +58,7 @@ def prefetch_incident_daughters():
         "incident_tag_relations__tag",
         "events",
         "events__ack",
+        "planned_maintenance_tasks",
     )
 
 

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_maintenance.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_maintenance.html
@@ -1,0 +1,4 @@
+<!-- htmx/templates/htmx/incident/cells/_incident_maintenance.html -->
+{% if incident.planned_maintenance_tasks.exists %}
+  <i class="text-primary text-lg fa-solid fa-person-digging"></i>
+{% endif %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1589. Replaces #1703.

Based on work done in #1733, #1734, #1736 and #1737.  Uses many-to-many field `incidents` on `PlannedMaintenanceTask` model. 

### Screenshot
<img width="134" height="211" alt="image" src="https://github.com/user-attachments/assets/efc0ef93-2b7d-46e0-a1e9-a18c290de180" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
  will add screenshots to user manual when we have decided that it is the final look
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
