### PR TITLE
Fix bug where multiselect is not cleared when de-selecting all options

### DIFF
--- a/changelog.d/1751.fixed.md
+++ b/changelog.d/1751.fixed.md
@@ -1,0 +1,1 @@
+Fix bug where multiselect is not cleared when de-selecting all options

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -321,10 +321,7 @@ def _normalize_form_data(request):
         value = raw_data.getlist(key, [])
         if key == "tags":
             value = _normalize_tags_param(value)
-        elif key in ["source_types", "sourceSystemIds", "event_types"]:
-            # Filter out empty strings to support empty selection in multi-selects
-            value = [v for v in value if v]
-        else:
+        elif key not in ["source_types", "sourceSystemIds", "event_types"]:
             value = value[0]
         data[key] = value
     return data

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -321,7 +321,10 @@ def _normalize_form_data(request):
         value = raw_data.getlist(key, [])
         if key == "tags":
             value = _normalize_tags_param(value)
-        elif key not in ["source_types", "sourceSystemIds", "event_types"]:
+        elif key in ["source_types", "sourceSystemIds", "event_types"]:
+            # Filter out empty strings to support empty selection in multi-selects
+            value = [v for v in value if v]
+        else:
             value = value[0]
         data[key] = value
     return data

--- a/src/argus/htmx/templates/htmx/forms/dropdown_select_multiple.html
+++ b/src/argus/htmx/templates/htmx/forms/dropdown_select_multiple.html
@@ -7,7 +7,7 @@
      hx-target="find .show-selected-box"
      hx-select="#dropdown-{{ widget.attrs.id }} .show-selected-box"
      hx-get="{{ widget.partial_get }}"
-     hx-include="find #{{ widget.attrs.id }}"
+     hx-include="find .dropdown-content"
      {% endblock field_control %}>
   <div tabindex="0"
        role="button"
@@ -28,6 +28,8 @@
   <div tabindex="0"
        class="dropdown-content bg-base-100 rounded-box z-20 min-w-fit w-full max-h-80 overflow-y-auto p-2 mt-0.5 shadow">
     {% block field_template %}
+      {# Hidden input to ensure that a value always is included in the form submission, even when no options are selected #}
+      <input type="hidden" name="{{ widget.name }}" value="">
       {% include "django/forms/widgets/multiple_input.html" %}
     {% endblock field_template %}
   </div>

--- a/src/argus/htmx/widgets.py
+++ b/src/argus/htmx/widgets.py
@@ -46,6 +46,13 @@ class DropdownMultiSelect(ExtraWidgetMixin, forms.CheckboxSelectMultiple):
                     return option.get("selected", False)
         return False
 
+    def value_from_datadict(self, data, files, name):
+        # Filter out falsy values (like empty strings) from submitted values
+        values = super().value_from_datadict(data, files, name)
+        if values:
+            return [v for v in values if v]
+        return values
+
 
 class SearchDropdownMultiSelect(DropdownMultiSelect):
     template_name = "htmx/forms/search_select_multiple.html"


### PR DESCRIPTION
## Scope and purpose

Fixes #1751 

This PR fixes a bug with all `BadgeDropdownMultiSelect` filters (source types, source system ids, event types). When de-selecting all options, the multiselect did not reset its value. It was fixed by adding a hidden empty input to ensure a value is sent, and filtering the empty value in the filter handlers.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
