### PR TITLE
Fix bug when checking whether to send notifications

### DIFF
--- a/changelog.d/+fix-longstanding-bug-with-notifications.fixed.md
+++ b/changelog.d/+fix-longstanding-bug-with-notifications.fixed.md
@@ -1,0 +1,5 @@
+Fixed longstanding bug that led to fewer notifications than expected. Instead
+of checking when an *event* happened in order to decide whether to send
+a notification, we only checked when the incident *started*. So, no
+notifications could be sent for long-lasting incidents if they started outside
+of all active timeslots.

--- a/src/argus/notificationprofile/filterwrapper.py
+++ b/src/argus/notificationprofile/filterwrapper.py
@@ -36,12 +36,12 @@ class NotificationProfileFilterWrapper(PrecisionFilterWrapper):
     def incident_fits(self, incident: Incident) -> bool:
         if not self.model.active:
             return False
-        is_selected_by_time = self.timeslot_fits(incident.start_time)
-        if not is_selected_by_time:
-            return False
         return super().incident_fits(incident)
 
     def event_fits(self, event: Event) -> bool:
         if not self.model.active:
+            return False
+        is_selected_by_time = self.timeslot_fits(event.timestamp)
+        if not is_selected_by_time:
             return False
         return super().event_fits(event)

--- a/tests/notificationprofile/test_filterwrapper.py
+++ b/tests/notificationprofile/test_filterwrapper.py
@@ -81,4 +81,4 @@ class NotificationProfileFilterWrapperTests(DjangoTestCase):
 
         npfw = NotificationProfileFilterWrapper(profile)
         self.assertFalse(npfw.timeslot_fits(today))
-        self.assertFalse(npfw.incident_fits(self.incident))
+        self.assertFalse(npfw.filter_fits(self.incident.events.first()))


### PR DESCRIPTION
For incidents that happen outside of all active timeslots, events that happened within the timelsots will now trigger notifications regardless.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
