### PR TITLE
Add infinite placeholder and fix badge text overflowing in planned maintenance table

### DIFF
--- a/src/argus/htmx/templates/htmx/plannedmaintenance/plannedmaintenance_list.html
+++ b/src/argus/htmx/templates/htmx/plannedmaintenance/plannedmaintenance_list.html
@@ -41,14 +41,18 @@
             <td class="border-b border-neutral-content group-last:border-b-0 whitespace-nowrap">
               <div class="flex flex-col">
                 <span>{{ task.start_time|date:preferences.argus_htmx.datetime_format }}</span>
-                <span class="text-base-content/60">to {{ task.end_time|date:preferences.argus_htmx.datetime_format }}</span>
+                {% if task.end_time.year >= 9999 %}
+                  <span class="text-base-content/60">to now</span>
+                {% else %}
+                  <span class="text-base-content/60">to {{ task.end_time|date:preferences.argus_htmx.datetime_format }}</span>
+                {% endif %}
               </div>
             </td>
             <td class="border-b border-neutral-content group-last:border-b-0">{{ task.description|default:"-" }}</td>
             <td class="border-b border-neutral-content group-last:border-b-0">
               <div class="flex flex-wrap gap-1">
                 {% for filter in task.filters.all %}
-                  <span class="badge badge-primary text-xs">{{ filter.name }}</span>
+                  <span class="badge badge-primary text-xs whitespace-nowrap">{{ filter.name }}</span>
                 {% empty %}
                   <span class="text-base-content/60">None</span>
                 {% endfor %}


### PR DESCRIPTION
## Scope and purpose

Follow-up to #1744

This PR adds two small QoL fixes to the planned maintenance table:
* An infinite end_time is reprsenteded with "to now" instead of "to 9999-31-12"
* Fixed overflowing text in filter badges when column is narrow

### Screenshots

#### Before
<img width="932" height="145" alt="image" src="https://github.com/user-attachments/assets/1bbb5241-f18b-4040-808f-9e284c505c91" />

#### After
<img width="931" height="154" alt="image" src="https://github.com/user-attachments/assets/412ed154-f0f2-4c91-9bf5-9f6b0e31fe85" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
