### PR TITLE
Send notifications on bulk event creation

### DIFF
--- a/changelog.d/1763.fixed.md
+++ b/changelog.d/1763.fixed.md
@@ -21,7 +21,7 @@ changing the Django setting `ARGUS_FALLBACK_FILTER` to `{"event_types": ["STA",
 overridden by end-users themselves.
 
 End-users themselves can get back the old, low amount of notifications via the
-frontend by creating a filter with "Event Types" set to both of:
+frontend by creating a filter with "Event Types" set to both:
 
 * Incident start
 * Incident end
@@ -30,8 +30,8 @@ frontend by creating a filter with "Event Types" set to both of:
 what's set in `ARGUS_FALLBACK_FILTER`.
 
 A third option is adding a public filter "Source-initiated status changes" via
-admin and use the admin to add that filter to all notification profiles that
-doesn't explicitly set event types.
+admin and using the admin to add that filter to all notification profiles that
+don't explicitly set event types.
 
 `ARGUS_FALLBACK_FILTER` will not affect what's shown on the dashboard or
 filters used for planned maintenance.

--- a/changelog.d/1763.fixed.md
+++ b/changelog.d/1763.fixed.md
@@ -1,0 +1,37 @@
+Notifications are now also sent on bulk changes to incidents. Note that for
+filters used for sending notifications, it will be necessary to control event
+types to maintain the current expected amount of notifications sent. See NOTES.
+
+NOTES:
+
+If you want the full fire hose of notifications site-wide you need do nothing.
+
+To maintain a lower amount of notifications it is necessary to alter the "Event
+types" filter to care only about source-initiated changes to the incident
+status.
+
+Note: It might not lower the amount all the way back to the levels before
+this bugfix, as it depends on whether any glue-services used the bulk API to
+alter multiple incidents at once. Previously, notifications for those changes
+would be suppressed.
+
+The easiest and fastest way to get back to lower levels of notifications is by
+changing the Django setting `ARGUS_FALLBACK_FILTER` to `{"event_types": ["STA",
+"END"]}`. This affects all existing and future notification filters, and can be
+overridden by end-users themselves.
+
+End-users themselves can get back the old, low amount of notifications via the
+frontend by creating a filter with "Event Types" set to both of:
+
+* Incident start
+* Incident end
+
+… and adding that to their existing notification profiles. This will override
+what's set in `ARGUS_FALLBACK_FILTER`.
+
+A third option is adding a public filter "Source-initiated status changes" via
+admin and use the admin to add that filter to all notification profiles that
+doesn't explicitly set event types.
+
+`ARGUS_FALLBACK_FILTER` will not affect what's shown on the dashboard or
+filters used for planned maintenance.

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -360,22 +360,19 @@ class IncidentQuerySet(models.QuerySet):
         """
         Create events of type ``event_type``, does not change dependent objects
 
-        This means that no signals are sent. On CLOSE, INCIDENT_END or REOPEN,
-        the incident for the event keeps its original end_time. Also, it is not
-        possible to set an expiration time for an ack.
+        Signals are sent. On CLOSE, INCIDENT_END or REOPEN, the incident for
+        the event keeps its original end_time. Also, it is not possible to set
+        an expiration time for an ack.
         """
         timestamp = timestamp if timestamp else timezone.now()
-        event_objs = [
-            Event(
-                incident=i,
+        for incident in self:
+            Event.objects.create(
+                incident=incident,
                 actor=actor,
                 timestamp=timestamp,
                 type=event_type,
                 description=description,
             )
-            for i in self
-        ]
-        Event.objects.bulk_create(event_objs)
         qs = Event.objects.filter(
             incident__in=self,
             actor=actor,

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -591,7 +591,6 @@ class BulkAcknowledgementViewSet(BulkHelper, viewsets.ViewSet):
         qs, changes, status_codes_seen = self.bulk_setup(incident_ids)
 
         acks = qs.create_acks(actor, timestamp, description, expiration)
-        # send notifications manually
 
         for ack in acks:
             event = ack.event


### PR DESCRIPTION
## Scope and purpose

Fixes #1762

Does not override `Event.objects.bulk_create`, instead saves events in a loop in `Incident.objects.create_events`.

This will lead to a lot more notifications sent so must be flagged properly everywhere.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
