### PR TITLE
Add admin user from environment variables

### DIFF
--- a/changelog.d/1776.added.md
+++ b/changelog.d/1776.added.md
@@ -1,0 +1,1 @@
+Create admin user from env variables in docker entrypoint

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,4 +5,16 @@ git config --global --add safe.directory /argus
 python3 -m pip install -e .
 python3 manage.py collectstatic --noinput
 python3 manage.py migrate --noinput
+
+# Stop password from being printed in logs
+set +x
+if [ -n "$ADMIN_USERNAME" ] && [ -n "$ADMIN_PASSWORD" ]; then
+     if [ -n "$ADMIN_EMAIL" ]; then
+         python3 manage.py initial_setup -u $ADMIN_USERNAME -p $ADMIN_PASSWORD -e $ADMIN_EMAIL
+     else
+          python3 manage.py initial_setup -u $ADMIN_USERNAME -p $ADMIN_PASSWORD
+     fi
+fi
+set -x
+
 exec gunicorn -b 0.0.0.0 -p 8000 argus.site.wsgi:application

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,6 +2,18 @@
 
 django-admin collectstatic --noinput
 django-admin migrate --noinput
+
+# Stop password from being printed in logs
+set +x
+if [ -n "$ADMIN_USERNAME" ] && [ -n "$ADMIN_PASSWORD" ]; then
+     if [ -n "$ADMIN_EMAIL" ]; then
+         python3 manage.py initial_setup -u $ADMIN_USERNAME -p $ADMIN_PASSWORD -e $ADMIN_EMAIL
+     else
+          python3 manage.py initial_setup -u $ADMIN_USERNAME -p $ADMIN_PASSWORD
+     fi
+fi
+set -x
+
 exec gunicorn \
      argus.site.wsgi:application \
      --forwarded-allow-ips="*" \


### PR DESCRIPTION
## Scope and purpose

Fixes #1776 

Adds option of creating an admin user via environment variables when using the docker image.

the `set +x` and `set -x` were added to stop the lines containing the user password from being logged. Without doing `set +x` before running the commands, it looked like this:
<img width="1333" height="321" alt="image" src="https://github.com/user-attachments/assets/4712ac47-a36d-4f65-b3fe-f1f6cf1b1ba7" />

Would like to add doc for this, but not sure it fits the actual Argus docs, since this is part of the docker/entrypoint stuff, so its not directly related to Argus itself. Would prob fit better in docs for helm chart

A bunch of PlannedMaintenance tests seem to be failing but I don't see how this would cause that @_@

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
