### PR TITLE
Add setting to toggle cron jobs

### DIFF
--- a/src/argus/dev/management/commands/check_ended_maintenance.py
+++ b/src/argus/dev/management/commands/check_ended_maintenance.py
@@ -1,9 +1,15 @@
+import logging
 from datetime import timedelta
+import sys
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from argus.plannedmaintenance.models import PlannedMaintenanceTask
+
+
+LOG = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -19,8 +25,16 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        if not getattr(settings, "ENABLE_CRON_JOBS", False):
+            sys.exit()
         end_time = timezone.now() - timedelta(minutes=options.get("minutes"))
         ended_pm_tasks = PlannedMaintenanceTask.objects.ended_after_time(end_time)
+        if count := ended_pm_tasks.count():
+            LOG.info("Cleaning up after %s ended planned maintenance tasks", count)
+        else:
+            LOG.info("No planned maintenance tasks to clean up after")
 
         for pm_task in ended_pm_tasks:
             pm_task.incidents.clear()
+        else:
+            LOG.info("Finished cleaning up after ended planned maintenance tasks")

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -327,3 +327,5 @@ del _extra_apps_env
 update_settings(globals(), EXTRA_APPS)
 
 BANNER_MESSAGE = get_str_env("ARGUS_BANNER_MESSAGE", default=None)
+
+ENABLE_CRON_JOBS = get_bool_env("ARGUS_ENABLE_CRON_JOBS", default=False)


### PR DESCRIPTION
## Scope and purpose

Control via settings whether a management command suitable for running in cron actually does its job.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
