### PR TITLE
Refactor notification routes with tab navigation

### DIFF
--- a/changelog.d/1795.changed.md
+++ b/changelog.d/1795.changed.md
@@ -1,0 +1,1 @@
+Consolidate notification routes under /notifications/ with tab navigation

--- a/src/argus/htmx/context_processors.py
+++ b/src/argus/htmx/context_processors.py
@@ -8,6 +8,7 @@ See django settings for ``TEMPLATES``.
 """
 
 from django.conf import settings
+from packaging.version import InvalidVersion, Version
 
 from . import defaults
 from argus.site.views import get_version
@@ -29,4 +30,9 @@ def banner_message(request):
 
 
 def metadata(request):
-    return {"version": get_version()}
+    full_version = get_version()
+    try:
+        short_version = str(Version(full_version).base_version)
+    except (InvalidVersion, TypeError):
+        short_version = full_version or ""
+    return {"version": full_version, "short_version": short_version}

--- a/src/argus/htmx/destination/views.py
+++ b/src/argus/htmx/destination/views.py
@@ -95,6 +95,7 @@ def _render_destination_list(
         "create_form": create_form,
         "grouped_forms": grouped_forms,
         "page_title": "Destinations",
+        "active_tab": "destinations",
     }
     return render(request, template, context=context)
 

--- a/src/argus/htmx/notificationprofile/urls.py
+++ b/src/argus/htmx/notificationprofile/urls.py
@@ -6,14 +6,20 @@ from . import views
 app_name = "htmx"
 urlpatterns = [
     path("", views.NotificationProfileListView.as_view(), name="notificationprofile-list"),
-    path("create/", views.NotificationProfileCreateView.as_view(), name="notificationprofile-create"),
-    path("field/filters/", views.filters_form_view, name="notificationprofile-filters-field-create"),
-    path("field/destinations/", views.destinations_form_view, name="notificationprofile-destinations-field-create"),
-    path("<pk>/", views.NotificationProfileDetailView.as_view(), name="notificationprofile-detail"),
-    path("<pk>/update/", views.NotificationProfileUpdateView.as_view(), name="notificationprofile-update"),
-    path("<pk>/delete/", views.NotificationProfileDeleteView.as_view(), name="notificationprofile-delete"),
-    path("<pk>/field/filters/", views.filters_form_view, name="notificationprofile-filters-field-update"),
+    path("profiles/create/", views.NotificationProfileCreateView.as_view(), name="notificationprofile-create"),
+    path("profiles/field/filters/", views.filters_form_view, name="notificationprofile-filters-field-create"),
     path(
-        "<pk>/field/destinations/", views.destinations_form_view, name="notificationprofile-destinations-field-update"
+        "profiles/field/destinations/",
+        views.destinations_form_view,
+        name="notificationprofile-destinations-field-create",
+    ),
+    path("profiles/<pk>/", views.NotificationProfileDetailView.as_view(), name="notificationprofile-detail"),
+    path("profiles/<pk>/update/", views.NotificationProfileUpdateView.as_view(), name="notificationprofile-update"),
+    path("profiles/<pk>/delete/", views.NotificationProfileDeleteView.as_view(), name="notificationprofile-delete"),
+    path("profiles/<pk>/field/filters/", views.filters_form_view, name="notificationprofile-filters-field-update"),
+    path(
+        "profiles/<pk>/field/destinations/",
+        views.destinations_form_view,
+        name="notificationprofile-destinations-field-update",
     ),
 ]

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -211,6 +211,7 @@ class NotificationProfileMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = "Profiles"
+        context["active_tab"] = "profiles"
         return context
 
 

--- a/src/argus/htmx/templates/htmx/destination/destination_list.html
+++ b/src/argus/htmx/templates/htmx/destination/destination_list.html
@@ -2,7 +2,8 @@
 {% block main %}
   <div class="flex justify-center p-4">
     <div class="max-w-4xl w-full">
-      {% include "htmx/notifications/_tabs.html" %}
+      <h1 class="text-center text-3xl font-semibold mt-3 mb-4">Notification preferences</h1>
+      <div class="flex justify-between items-center mb-4">{% include "htmx/notifications/_tabs.html" %}</div>
       {% include "htmx/destination/_content.html" %}
     </div>
   </div>

--- a/src/argus/htmx/templates/htmx/destination/destination_list.html
+++ b/src/argus/htmx/templates/htmx/destination/destination_list.html
@@ -1,7 +1,9 @@
 {% extends "htmx/base.html" %}
 {% block main %}
-  <div class="px-4">
-    {% include "htmx/components/_page_title.html" %}
-    {% include "htmx/destination/_content.html" %}
+  <div class="flex justify-center p-4">
+    <div class="max-w-4xl w-full">
+      {% include "htmx/notifications/_tabs.html" %}
+      {% include "htmx/destination/_content.html" %}
+    </div>
   </div>
 {% endblock main %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/base.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/base.html
@@ -1,8 +1,10 @@
 {% extends "htmx/base.html" %}
 {% block main %}
-  {% include "htmx/components/_page_title.html" %}
-  <div class="flex justify-center px-4">
-    {% block profile_main %}
-    {% endblock profile_main %}
+  <div class="flex justify-center p-4">
+    <div class="max-w-4xl w-full">
+      {% include "htmx/notifications/_tabs.html" %}
+      {% block profile_main %}
+      {% endblock profile_main %}
+    </div>
   </div>
 {% endblock main %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/base.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/base.html
@@ -2,7 +2,12 @@
 {% block main %}
   <div class="flex justify-center p-4">
     <div class="max-w-4xl w-full">
-      {% include "htmx/notifications/_tabs.html" %}
+      <h1 class="text-center text-3xl font-semibold mt-3 mb-4">Notification preferences</h1>
+      <div class="flex justify-between items-center mb-4">
+        {% include "htmx/notifications/_tabs.html" %}
+        {% block tab_action %}
+        {% endblock tab_action %}
+      </div>
       {% block profile_main %}
       {% endblock profile_main %}
     </div>

--- a/src/argus/htmx/templates/htmx/notifications/_tabs.html
+++ b/src/argus/htmx/templates/htmx/notifications/_tabs.html
@@ -1,5 +1,4 @@
-<h1 class="text-center text-3xl font-semibold mt-3 mb-4">Notification preferences</h1>
-<div role="tablist" class="tabs tabs-boxed w-fit mb-4">
+<div role="tablist" class="tabs tabs-boxed w-fit">
   <a role="tab"
      class="tab {% if active_tab == 'profiles' %}tab-active{% endif %}"
      href="{% url 'htmx:notificationprofile-list' %}">Profiles</a>

--- a/src/argus/htmx/templates/htmx/notifications/_tabs.html
+++ b/src/argus/htmx/templates/htmx/notifications/_tabs.html
@@ -1,0 +1,12 @@
+<h1 class="text-center text-3xl font-semibold mt-3 mb-4">Notification preferences</h1>
+<div role="tablist" class="tabs tabs-boxed w-fit mb-4">
+  <a role="tab"
+     class="tab {% if active_tab == 'profiles' %}tab-active{% endif %}"
+     href="{% url 'htmx:notificationprofile-list' %}">Profiles</a>
+  <a role="tab"
+     class="tab {% if active_tab == 'timeslots' %}tab-active{% endif %}"
+     href="{% url 'htmx:timeslot-list' %}">Timeslots</a>
+  <a role="tab"
+     class="tab {% if active_tab == 'destinations' %}tab-active{% endif %}"
+     href="{% url 'htmx:destination-list' %}">Destinations</a>
+</div>

--- a/src/argus/htmx/templates/htmx/timeslot/base.html
+++ b/src/argus/htmx/templates/htmx/timeslot/base.html
@@ -7,7 +7,12 @@
 {% block main %}
   <div class="flex justify-center p-4">
     <div class="max-w-4xl w-full">
-      {% include "htmx/notifications/_tabs.html" %}
+      <h1 class="text-center text-3xl font-semibold mt-3 mb-4">Notification preferences</h1>
+      <div class="flex justify-between items-center mb-4">
+        {% include "htmx/notifications/_tabs.html" %}
+        {% block tab_action %}
+        {% endblock tab_action %}
+      </div>
       {% block timeslot_main %}
       {% endblock timeslot_main %}
     </div>

--- a/src/argus/htmx/templates/htmx/timeslot/base.html
+++ b/src/argus/htmx/templates/htmx/timeslot/base.html
@@ -5,9 +5,11 @@
   <link rel="stylesheet" href="{% static flatpickr_css_path %}">
 {% endblock head %}
 {% block main %}
-  {% include "htmx/components/_page_title.html" %}
-  <div class="flex justify-center px-4">
-    {% block timeslot_main %}
-    {% endblock timeslot_main %}
+  <div class="flex justify-center p-4">
+    <div class="max-w-4xl w-full">
+      {% include "htmx/notifications/_tabs.html" %}
+      {% block timeslot_main %}
+      {% endblock timeslot_main %}
+    </div>
   </div>
 {% endblock main %}

--- a/src/argus/htmx/templates/htmx/timeslot/timeslot_list.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timeslot_list.html
@@ -1,6 +1,6 @@
 {% extends "./base.html" %}
 {% block timeslot_main %}
-  <div class="max-w-4xl w-full">
+  <div>
     <div class="flex justify-end mb-4">
       <button hx-get="{% url 'htmx:timeslot-create' %}"
               hx-target="#timeslot-create"

--- a/src/argus/htmx/templates/htmx/timeslot/timeslot_list.html
+++ b/src/argus/htmx/templates/htmx/timeslot/timeslot_list.html
@@ -1,12 +1,12 @@
 {% extends "./base.html" %}
+{% block tab_action %}
+  <button hx-get="{% url 'htmx:timeslot-create' %}"
+          hx-target="#timeslot-create"
+          hx-swap="outerHTML"
+          class="btn btn-primary">New timeslot</button>
+{% endblock tab_action %}
 {% block timeslot_main %}
   <div>
-    <div class="flex justify-end mb-4">
-      <button hx-get="{% url 'htmx:timeslot-create' %}"
-              hx-target="#timeslot-create"
-              hx-swap="outerHTML"
-              class="btn btn-primary">New timeslot</button>
-    </div>
     <div id="timeslot-create"></div>
     {% for timeslot in object_list %}
       {% include "./_timeslot_card.html" %}

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -31,7 +31,7 @@
             onclick="navigator.clipboard.writeText('{{ version }}')">
       <div class="space-y-2 text-left">
         <span>Argus version:</span>
-        <span class="truncate">{{ version }}</span>
+        <span>{{ short_version }}</span>
       </div>
       <i class="fa-solid fa-copy"></i>
     </button>

--- a/src/argus/htmx/templates/htmx/user/_user_menu_notification_config.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu_notification_config.html
@@ -1,14 +1,3 @@
 <li>
-  <h2 class="menu-title">Notification config</h2>
-  <ul>
-    <li>
-      <a href="{% url 'htmx:timeslot-list' %}">Timeslots</a>
-    </li>
-    <li>
-      <a href="{% url 'htmx:notificationprofile-list' %}">Profiles</a>
-    </li>
-    <li>
-      <a href="{% url 'htmx:destination-list' %}">Destinations</a>
-    </li>
-  </ul>
+  <a href="{% url 'htmx:notificationprofile-list' %}">Notification preferences</a>
 </li>

--- a/src/argus/htmx/timeslot/views.py
+++ b/src/argus/htmx/timeslot/views.py
@@ -154,6 +154,7 @@ class TimeslotMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = "Timeslots"
+        context["active_tab"] = "timeslots"
         return context
 
 

--- a/src/argus/htmx/urls.py
+++ b/src/argus/htmx/urls.py
@@ -17,10 +17,17 @@ urlpatterns = [
     # path("accounts/", include("django.contrib.auth.urls")),
     path("styleguide/", StyleGuideView.as_view(), name="styleguide"),
     path("incidents/", include(incident_urls)),
-    path("timeslots/", include(timeslot_urls)),
-    path("notificationprofiles/", include(notificationprofile_urls)),
+    path(
+        "notifications/",
+        include(
+            [
+                path("", include(notificationprofile_urls)),
+                path("timeslots/", include(timeslot_urls)),
+                path("destinations/", include(destination_urls)),
+            ]
+        ),
+    ),
     path("plannedmaintenance/", include(plannedmaintenance_urls)),
-    path("destinations/", include(destination_urls)),
     path("user/", include(user_urls)),
     path("", IncidentListRedirectView.as_view(), name="root"),
 ]

--- a/tests/htmx/notificationprofile/test_views.py
+++ b/tests/htmx/notificationprofile/test_views.py
@@ -16,13 +16,13 @@ class TestNotificationProfileListView(NotificationProfileViewTestCase):
         super().setUp()
         self.url = reverse("htmx:notificationprofile-list")
 
-    def test_context_has_active_tab_profiles(self):
+    def test_it_should_have_active_tab_profiles_in_context(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["active_tab"], "profiles")
 
-    def test_context_has_page_title(self):
+    def test_it_should_have_page_title_in_context(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)

--- a/tests/htmx/notificationprofile/test_views.py
+++ b/tests/htmx/notificationprofile/test_views.py
@@ -1,0 +1,29 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from argus.auth.factories import PersonUserFactory
+
+
+@override_settings(AUTHENTICATION_BACKENDS=["django.contrib.auth.backends.ModelBackend"])
+class NotificationProfileViewTestCase(TestCase):
+    def setUp(self):
+        self.user = PersonUserFactory()
+        self.client.force_login(user=self.user)
+
+
+class TestNotificationProfileListView(NotificationProfileViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("htmx:notificationprofile-list")
+
+    def test_context_has_active_tab_profiles(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["active_tab"], "profiles")
+
+    def test_context_has_page_title(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["page_title"], "Profiles")


### PR DESCRIPTION
## Scope and purpose

Fixes #1795. Dependent on #1797 

Consolidates notification profiles, timeslots, and destinations under a single `/notifications/` route with shared tab navigation. Replaces the three separate dropdown links with a single "Notification preferences" entry.

Also fixes a pre-existing bug where a long version string in the user menu caused the dropdown to overflow. The menu now displays the short version (e.g. `2.7.0`) while the copy button still copies the full version.

### This pull request
* Namespaces all notification routes under `/notifications/`
* Adds `profiles/` prefix to profile detail routes
* Adds shared tab component for navigating between sections
* Replaces three dropdown links with single "Notification preferences" link
* Adds consistent `max-w-4xl` layout across all notification pages
* Shows short version string in user menu to prevent overflow

### Screenshots

<img width="924" height="408" alt="image" src="https://github.com/user-attachments/assets/2bd1c0cd-59ea-4268-97fb-afbd39ad33cd" />
<img width="229" height="417" alt="image" src="https://github.com/user-attachments/assets/5f3f03d2-75c5-43d7-8af2-2c0099766a62" />

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after