### PR TITLE
Improve notification profile form design

### DIFF
--- a/changelog.d/1796.changed.md
+++ b/changelog.d/1796.changed.md
@@ -1,0 +1,1 @@
+Improve notification profile form with collapsible cards and inline actions

--- a/src/argus/htmx/notificationprofile/urls.py
+++ b/src/argus/htmx/notificationprofile/urls.py
@@ -7,19 +7,7 @@ app_name = "htmx"
 urlpatterns = [
     path("", views.NotificationProfileListView.as_view(), name="notificationprofile-list"),
     path("profiles/create/", views.NotificationProfileCreateView.as_view(), name="notificationprofile-create"),
-    path("profiles/field/filters/", views.filters_form_view, name="notificationprofile-filters-field-create"),
-    path(
-        "profiles/field/destinations/",
-        views.destinations_form_view,
-        name="notificationprofile-destinations-field-create",
-    ),
     path("profiles/<pk>/", views.NotificationProfileDetailView.as_view(), name="notificationprofile-detail"),
     path("profiles/<pk>/update/", views.NotificationProfileUpdateView.as_view(), name="notificationprofile-update"),
     path("profiles/<pk>/delete/", views.NotificationProfileDeleteView.as_view(), name="notificationprofile-delete"),
-    path("profiles/<pk>/field/filters/", views.filters_form_view, name="notificationprofile-filters-field-update"),
-    path(
-        "profiles/<pk>/field/destinations/",
-        views.destinations_form_view,
-        name="notificationprofile-destinations-field-update",
-    ),
 ]

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -61,9 +61,9 @@ class FilterFieldMixin:
 class NotificationProfileForm(DestinationFieldMixin, FilterFieldMixin, NoColonMixin, forms.ModelForm):
     class Meta:
         model = NotificationProfile
-        fields = ["name", "timeslot", "filters", "active", "destinations"]
+        fields = ["name", "timeslot", "filters", "destinations", "active"]
         widgets = {
-            "timeslot": forms.Select(attrs={"class": "select input-bordered w-full max-w-xs"}),
+            "timeslot": forms.Select(attrs={"class": "select input-bordered w-full"}),
         }
 
     def __init__(self, *args, **kwargs):
@@ -74,8 +74,8 @@ class NotificationProfileForm(DestinationFieldMixin, FilterFieldMixin, NoColonMi
 
         self.fields["filters"].help_text = "Multiple filters increase precision, not recall. They are AND-ed together."
         self.fields["timeslot"].queryset = Timeslot.objects.filter(user=self.user)
-        self.fields["active"].widget.attrs["class"] = "checkbox checkbox-sm border"
         self.fields["active"].widget.attrs["autocomplete"] = "off"
+        self.fields["active"].help_text = "When inactive, no notifications will be sent for this profile."
         self.fields["name"].widget.attrs["class"] = "input input-bordered"
 
         self.action = self.get_action()

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -6,12 +6,15 @@ See https://ccbv.co.uk/ to grok class-based views.
 
 from django import forms
 from django.shortcuts import redirect, render
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils import timezone
 from django.views.decorators.http import require_GET
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
+from django_htmx.http import HttpResponseClientRedirect
 
 from argus.htmx.request import HtmxHttpRequest
-from argus.htmx.widgets import DropdownMultiSelect
 from argus.notificationprofile.media import MEDIA_CLASSES_DICT
 from argus.htmx.modals import DeleteModal
 from argus.notificationprofile.models import NotificationProfile, Timeslot, Filter, DestinationConfig
@@ -36,20 +39,10 @@ class DestinationFieldMixin:
     def _init_destinations(self, user):
         qs = DestinationConfig.objects.filter(user=user)
         self.fields["destinations"].queryset = qs
-        if self.instance.id:
-            partial_get = reverse(
-                "htmx:notificationprofile-destinations-field-update",
-                kwargs={"pk": self.instance.pk},
-            )
-        else:
-            partial_get = reverse("htmx:notificationprofile-destinations-field-create")
-        self.fields["destinations"].widget = DropdownMultiSelect(
-            partial_get=partial_get,
-            attrs={
-                "placeholder": "select destination...",
-                "field_styles": "input input-bordered border-b max-w-xs",
-            },
+        self.fields["destinations"].widget = forms.SelectMultiple(
+            attrs={"placeholder": "Select destinations..."},
         )
+        self.fields["destinations"].widget.template_name = "htmx/forms/choices_select_multiple.html"
         self.fields["destinations"].choices = self._get_destination_choices(user)
 
 
@@ -58,21 +51,10 @@ class FilterFieldMixin:
         qs = Filter.objects.usable_by(user=user)
         qs = annotate_public_filters_with_usernames(qs=qs, user=user)
         self.fields["filters"].queryset = qs
-
-        if self.instance.id:
-            partial_get = reverse(
-                "htmx:notificationprofile-filters-field-update",
-                kwargs={"pk": self.instance.pk},
-            )
-        else:
-            partial_get = reverse("htmx:notificationprofile-filters-field-create")
-        self.fields["filters"].widget = DropdownMultiSelect(
-            partial_get=partial_get,
-            attrs={
-                "placeholder": "select filter...",
-                "field_styles": "input input-bordered border-b max-w-xs",
-            },
+        self.fields["filters"].widget = forms.SelectMultiple(
+            attrs={"placeholder": "Select filters..."},
         )
+        self.fields["filters"].widget.template_name = "htmx/forms/choices_select_multiple.html"
         self.fields["filters"].choices = tuple(qs.values_list("id", "label"))
 
 
@@ -174,14 +156,23 @@ class NotificationProfileMixin:
 
     model = NotificationProfile
 
-    def _set_delete_modal(self, form, obj):
-        form.modal = DeleteModal(
+    def _make_delete_modal(self, obj, **kwargs):
+        return DeleteModal(
             header="Delete notification profile",
+            button_title="Delete",
+            button_class="btn-sm btn-outline btn-error",
             explanation=f'Delete the notification profile "{obj}"?',
             dialog_id=f"delete-modal-{obj.pk}",
             endpoint=reverse("htmx:notificationprofile-delete", kwargs={"pk": obj.pk}),
+            **kwargs,
         )
+
+    def _set_delete_modal(self, form, obj):
+        form.modal = self._make_delete_modal(obj)
         return form
+
+    def _attach_card_delete_modal(self, obj):
+        obj.delete_modal = self._make_delete_modal(obj, opener_button_template_name="htmx/_blank.html")
 
     def get_queryset(self):
         qs = (
@@ -190,14 +181,13 @@ class NotificationProfileMixin:
             .select_related("timeslot")
             .prefetch_related(
                 "filters",
-                "destinations",
+                "destinations__media",
+                "timeslot__time_recurrences",
             )
         )
         return qs.filter(user_id=self.request.user.id)
 
     def get_template_names(self):
-        if self.request.htmx and hasattr(self, "partial_template_name"):
-            return [self.partial_template_name]
         orig_app_label = self.model._meta.app_label
         orig_model_name = self.model._meta.model_name
         self.model._meta.app_label = "htmx/notificationprofile"
@@ -221,7 +211,6 @@ class ChangeMixin:
     "Common functionality for create and update views"
 
     form_class = NotificationProfileForm
-    partial_template_name = "htmx/notificationprofile/_notificationprofile_form.html"
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -231,7 +220,14 @@ class ChangeMixin:
     def form_valid(self, form):
         self.object = form.save(commit=False)
         self.object.user = self.request.user
-        return super().form_valid(form)
+        self.object.save()
+        form.save_m2m()
+        return self.form_valid_response()
+
+    def form_valid_response(self):
+        if self.request.htmx:
+            return HttpResponseClientRedirect(self.get_success_url())
+        return HttpResponseRedirect(self.get_success_url())
 
     def get_prefix(self):
         if self.object and self.object.pk:
@@ -243,31 +239,56 @@ class ChangeMixin:
 class NotificationProfileListView(NotificationProfileMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        forms = []
-        for obj in self.get_queryset():
-            form = NotificationProfileForm(None, prefix=f"npf{obj.pk}", user=self.request.user, instance=obj)
-            form = self._set_delete_modal(form, obj)
-            forms.append(form)
-        context["form_list"] = forms
+        for obj in context["object_list"]:
+            self._attach_card_delete_modal(obj)
         return context
 
 
 class NotificationProfileDetailView(NotificationProfileMixin, DetailView):
     def dispatch(self, request, *args, **kwargs):
-        object = self.get_object()
-        return redirect("htmx:notificationprofile-update", pk=object.pk)
+        obj = self.get_object()
+        if request.htmx:
+            self._attach_card_delete_modal(obj)
+            return TemplateResponse(
+                request,
+                "htmx/notificationprofile/_notificationprofile_card.html",
+                {"profile": obj},
+            )
+        return redirect("htmx:notificationprofile-update", pk=obj.pk)
 
 
 class NotificationProfileCreateView(ChangeMixin, NotificationProfileMixin, CreateView):
-    pass
+    def get_template_names(self):
+        if self.request.htmx:
+            return ["htmx/notificationprofile/_notificationprofile_form.html"]
+        return super().get_template_names()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_create"] = True
+        return context
 
 
 class NotificationProfileUpdateView(ChangeMixin, NotificationProfileMixin, UpdateView):
+    def get_template_names(self):
+        if self.request.htmx:
+            return ["htmx/notificationprofile/_notificationprofile_form_content.html"]
+        return super().get_template_names()
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         form = context["form"]
         context["form"] = self._set_delete_modal(form, self.object)
         return context
+
+    def form_valid_response(self):
+        if self.request.htmx:
+            context = self.get_context_data()
+            context["profile"] = self.object
+            now = timezone.localtime().strftime("%H:%M:%S")
+            context["success_message"] = f'Saved profile "{self.object}" at {now}.'
+            return self.render_to_response(context)
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class NotificationProfileDeleteView(NotificationProfileMixin, DeleteView):

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -5,16 +5,14 @@ See https://ccbv.co.uk/ to grok class-based views.
 """
 
 from django import forms
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.http import require_GET
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 from django_htmx.http import HttpResponseClientRedirect
 
-from argus.htmx.request import HtmxHttpRequest
 from argus.notificationprofile.media import MEDIA_CLASSES_DICT
 from argus.htmx.modals import DeleteModal
 from argus.notificationprofile.models import NotificationProfile, Timeslot, Filter, DestinationConfig
@@ -98,57 +96,6 @@ class NotificationProfileForm(DestinationFieldMixin, FilterFieldMixin, NoColonMi
         if profiles_with_same_name.exists():
             raise forms.ValidationError(f"A profile by this user with the name '{name}' already exists.")
         return name
-
-
-class NotificationProfileFilterForm(FilterFieldMixin, NoColonMixin, forms.ModelForm):
-    class Meta:
-        model = NotificationProfile
-        fields = ["filters"]
-
-    def __init__(self, *args, **kwargs):
-        user = kwargs.pop("user")
-        super().__init__(*args, **kwargs)
-        self._init_filters(user)
-
-
-class NotificationProfileDestinationForm(DestinationFieldMixin, NoColonMixin, forms.ModelForm):
-    class Meta:
-        model = NotificationProfile
-        fields = ["destinations"]
-
-    def __init__(self, *args, **kwargs):
-        user = kwargs.pop("user")
-        super().__init__(*args, **kwargs)
-        self._init_destinations(user)
-
-
-def _render_form_field(request: HtmxHttpRequest, form, partial_template_name, prefix=None):
-    # Not a view!
-    form = form(request.GET or None, user=request.user, prefix=prefix)
-    context = {"form": form}
-    return render(request, partial_template_name, context=context)
-
-
-@require_GET
-def filters_form_view(request: HtmxHttpRequest, pk: int = None):
-    prefix = f"npf{pk}" if pk else None
-    return _render_form_field(
-        request,
-        NotificationProfileFilterForm,
-        "htmx/notificationprofile/_notificationprofile_form.html",
-        prefix=prefix,
-    )
-
-
-@require_GET
-def destinations_form_view(request: HtmxHttpRequest, pk: int = None):
-    prefix = f"npf{pk}" if pk else None
-    return _render_form_field(
-        request,
-        NotificationProfileDestinationForm,
-        "htmx/notificationprofile/_notificationprofile_form.html",
-        prefix=prefix,
-    )
 
 
 class NotificationProfileMixin:

--- a/src/argus/htmx/tailwindtheme/snippets/25-choices.css
+++ b/src/argus/htmx/tailwindtheme/snippets/25-choices.css
@@ -72,11 +72,11 @@
     }
 
     .choices-list-items {
-        @apply inline space-x-0.5;
+        @apply inline-flex flex-wrap gap-0.5;
     }
 
     .choices__list {
-        @apply flex space-x-0.5 items-center;
+        @apply flex flex-wrap gap-0.5 items-center;
     }
 
     /* Dropdown hidden by default */

--- a/src/argus/htmx/tailwindtheme/snippets/35-cards.css
+++ b/src/argus/htmx/tailwindtheme/snippets/35-cards.css
@@ -38,3 +38,7 @@ tr.row-deleted td.strikethrough::after {
 .card-base > .collapse > .collapse-content .form-control:first-of-type > .label:first-child {
     @apply pt-0;
 }
+
+.card-base > .collapse[open] {
+    @apply overflow-visible;
+}

--- a/src/argus/htmx/templates/htmx/forms/choices_select_multiple.html
+++ b/src/argus/htmx/templates/htmx/forms/choices_select_multiple.html
@@ -11,7 +11,7 @@
 </select>
 <script>
 (function () {
-    const el = document.querySelector('#{{ widget.attrs.id }}');
+    const el = document.querySelector('#{{ widget.attrs.id|escapejs }}');
     if (el.choices) return;
     const instance = new Choices(el, {
         removeItemButton: true,
@@ -22,7 +22,7 @@
         itemSelectText: '',
         removeItemIconText: () => '',
         placeholder: true,
-        placeholderValue: '{{ widget.attrs.placeholder|default:"Select..." }}',
+        placeholderValue: '{{ widget.attrs.placeholder|default:"Select..."|escapejs }}',
         classNames: {
             containerOuter: ['choices', 'dropdown', 'w-full', 'max-w-none', 'self-auto'],
             containerInner: ['choices__inner'],

--- a/src/argus/htmx/templates/htmx/forms/choices_select_multiple.html
+++ b/src/argus/htmx/templates/htmx/forms/choices_select_multiple.html
@@ -1,0 +1,36 @@
+<select id="{{ widget.attrs.id }}"
+        name="{{ widget.name }}"
+        class="hidden"
+        multiple>
+  {% for _, options, _ in widget.optgroups %}
+    {% for option in options %}
+      <option value="{{ option.value }}"
+              {% if option.selected %}selected{% endif %}>{{ option.label }}</option>
+    {% endfor %}
+  {% endfor %}
+</select>
+<script>
+(function () {
+    const el = document.querySelector('#{{ widget.attrs.id }}');
+    if (el.choices) return;
+    const instance = new Choices(el, {
+        removeItemButton: true,
+        duplicateItemsAllowed: false,
+        shouldSort: false,
+        searchEnabled: true,
+        searchChoices: true,
+        itemSelectText: '',
+        removeItemIconText: () => '',
+        placeholder: true,
+        placeholderValue: '{{ widget.attrs.placeholder|default:"Select..." }}',
+        classNames: {
+            containerOuter: ['choices', 'dropdown', 'w-full', 'max-w-none', 'self-auto'],
+            containerInner: ['choices__inner'],
+            listDropdown: ['choices-dropdown'],
+            listItems: ['choices-list-items'],
+        }
+    });
+    // Prevent dropdown from opening immediately when loaded via HTMX
+    instance.hideDropdown();
+})();
+</script>

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_card.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_card.html
@@ -1,0 +1,15 @@
+<div class="card card-base my-4" id="notificationprofile-{{ profile.pk }}">
+  <details class="group collapse collapse-arrow"
+           name="notificationprofile-accordion"
+           hx-get="{% url 'htmx:notificationprofile-update' pk=profile.pk %}"
+           hx-trigger="toggle[this.open]"
+           hx-target="#notificationprofile-form-{{ profile.pk }}"
+           hx-swap="innerHTML">
+    <summary class="collapse-title min-h-0 p-3 pr-12">{% include "./_notificationprofile_summary.html" %}</summary>
+    <div class="collapse-content"
+         id="notificationprofile-form-{{ profile.pk }}">
+      <span class="loading loading-spinner loading-md"></span>
+    </div>
+  </details>
+  {% include profile.delete_modal.template_name with modal=profile.delete_modal %}
+</div>

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form.html
@@ -10,31 +10,36 @@
       {% if form.errors %}
         <div class="alert alert-error flex flex-col items-start gap-2 w-full mb-4"
              role="alert">
-          <div class="flex items-center gap-2 font-semibold">
+          <div class="flex items-end gap-2 mb-2 font-semibold">
             <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
             <span>Please correct the errors below</span>
           </div>
         </div>
       {% endif %}
       <div class="flex flex-col gap-4 w-full">
-        {% if is_create %}<h2 class="text-lg font-semibold">New profile</h2>{% endif %}
-        {{ form.as_div }}
-        <div class="card-actions flex items-center gap-2">
-          {% if form.instance.pk %}
-            <input type="submit" class="btn btn-primary btn-sm" value="Save">
-            <button type="button"
-                    hx-get="{% url 'htmx:notificationprofile-detail' pk=form.instance.pk %}"
-                    hx-target="#notificationprofile-{{ form.instance.pk }}"
-                    hx-swap="outerHTML"
-                    class="btn btn-sm">Cancel</button>
-            {% include form.modal.template_name with modal=form.modal %}
-          {% else %}
-            <input type="submit" class="btn btn-primary btn-sm" value="Create">
-            <button type="button"
-                    _="on click set el to me.closest('[id=notificationprofile-create]') then set el.innerHTML to '' then set el.className to ''"
-                    class="btn btn-sm">Cancel</button>
-          {% endif %}
+        <div class="flex gap-16 justify-between">
+          <div>
+            {% if is_create %}<h2 class="text-lg font-semibold">New profile</h2>{% endif %}
+            {% include "htmx/forms/input_field.html" with label=form.name.label max_width="md" field=form.name %}
+          </div>
+          <div class="card-actions flex items-end gap-2 mb-2">
+            {% if form.instance.pk %}
+              <input type="submit" class="btn btn-primary btn-sm" value="Save">
+              <button type="button"
+                      hx-get="{% url 'htmx:notificationprofile-detail' pk=form.instance.pk %}"
+                      hx-target="#notificationprofile-{{ form.instance.pk }}"
+                      hx-swap="outerHTML"
+                      class="btn btn-sm">Cancel</button>
+              {% include form.modal.template_name with modal=form.modal %}
+            {% else %}
+              <input type="submit" class="btn btn-primary btn-sm" value="Create">
+              <button type="button"
+                      _="on click set el to me.closest('[id=notificationprofile-create]') then set el.innerHTML to '' then set el.className to ''"
+                      class="btn btn-sm">Cancel</button>
+            {% endif %}
+          </div>
         </div>
+        {{ form.as_div }}
       </div>
     </form>
   </section>

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form.html
@@ -1,17 +1,41 @@
-<section class="card-body">
-  <form id="{{ form.prefix }}-form"
-        method="post"
-        action="{{ form.action }}"
-        class="flex flex-row gap-4">
-    {% csrf_token %}
-    <div class="flex items-start justify-between gap-2 w-full flex-nowrap">
-      <div class="flex items-start justify-start gap-2 w-full flex-wrap">{{ form.as_div }}</div>
-      <div class="card-actions justify-end flex-nowrap mt-9">
-        <input class="btn btn-primary" type="submit" value="Save">
-        {% if form.instance.pk %}
-          {% include form.modal.template_name with modal=form.modal %}
-        {% endif %}
+<div class="card card-base {% if is_create %}card-create mt-4 mb-8{% else %}my-4{% endif %}"
+     id="notificationprofile-{{ form.instance.pk|default:'create' }}">
+  <section class="card-body">
+    <form method="post"
+          novalidate
+          hx-post="{% if form.instance.pk %}{% url "htmx:notificationprofile-update" pk=form.instance.pk %}{% else %}{% url "htmx:notificationprofile-create" %}{% endif %}"
+          hx-target="#notificationprofile-{{ form.instance.pk|default:'create' }}"
+          hx-swap="outerHTML">
+      {% csrf_token %}
+      {% if form.errors %}
+        <div class="alert alert-error flex flex-col items-start gap-2 w-full mb-4"
+             role="alert">
+          <div class="flex items-center gap-2 font-semibold">
+            <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+            <span>Please correct the errors below</span>
+          </div>
+        </div>
+      {% endif %}
+      <div class="flex flex-col gap-4 w-full">
+        {% if is_create %}<h2 class="text-lg font-semibold">New profile</h2>{% endif %}
+        {{ form.as_div }}
+        <div class="card-actions flex items-center gap-2">
+          {% if form.instance.pk %}
+            <input type="submit" class="btn btn-primary btn-sm" value="Save">
+            <button type="button"
+                    hx-get="{% url 'htmx:notificationprofile-detail' pk=form.instance.pk %}"
+                    hx-target="#notificationprofile-{{ form.instance.pk }}"
+                    hx-swap="outerHTML"
+                    class="btn btn-sm">Cancel</button>
+            {% include form.modal.template_name with modal=form.modal %}
+          {% else %}
+            <input type="submit" class="btn btn-primary btn-sm" value="Create">
+            <button type="button"
+                    _="on click set el to me.closest('[id=notificationprofile-create]') then set el.innerHTML to '' then set el.className to ''"
+                    class="btn btn-sm">Cancel</button>
+          {% endif %}
+        </div>
       </div>
-    </div>
-  </form>
-</section>
+    </form>
+  </section>
+</div>

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_content.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_content.html
@@ -5,16 +5,19 @@
       hx-swap="innerHTML">
   {% csrf_token %}
   <div class="flex flex-col gap-4 w-full">
-    {{ form.as_div }}
-    <div class="card-actions flex items-center gap-2">
-      <input type="submit" class="btn btn-primary btn-sm" value="Save">
-      <button type="button"
-              onclick="this.closest('details').removeAttribute('open')"
-              class="btn btn-sm">Cancel</button>
-      <button type="button"
-              onclick="htmx.find('#{{ form.modal.dialog_id }}').showModal()"
-              class="btn btn-sm btn-outline btn-error">Delete</button>
+    <div class="flex gap-16 justify-between">
+      <div>{% include "htmx/forms/input_field.html" with label=form.name.label max_width="md" field=form.name %}</div>
+      <div class="card-actions flex items-end gap-2 mb-2">
+        <input type="submit" class="btn btn-primary btn-sm" value="Save">
+        <button type="button"
+                onclick="this.closest('details').removeAttribute('open')"
+                class="btn btn-sm">Cancel</button>
+        <button type="button"
+                onclick="htmx.find('#{{ form.modal.dialog_id }}').showModal()"
+                class="btn btn-sm btn-outline btn-error">Delete</button>
+      </div>
     </div>
+    {{ form.as_div }}
     {% if success_message %}
       <div _="on toggle from closest <details/> if not it.open remove me">
       {% include "messages/_banner.html" with message=success_message level="success" %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_content.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_content.html
@@ -1,0 +1,29 @@
+<form method="post"
+      novalidate
+      hx-post="{% url "htmx:notificationprofile-update" pk=form.instance.pk %}"
+      hx-target="#notificationprofile-form-{{ form.instance.pk }}"
+      hx-swap="innerHTML">
+  {% csrf_token %}
+  <div class="flex flex-col gap-4 w-full">
+    {{ form.as_div }}
+    <div class="card-actions flex items-center gap-2">
+      <input type="submit" class="btn btn-primary btn-sm" value="Save">
+      <button type="button"
+              onclick="this.closest('details').removeAttribute('open')"
+              class="btn btn-sm">Cancel</button>
+      <button type="button"
+              onclick="htmx.find('#{{ form.modal.dialog_id }}').showModal()"
+              class="btn btn-sm btn-outline btn-error">Delete</button>
+    </div>
+    {% if success_message %}
+      <div _="on toggle from closest <details/> if not it.open remove me">
+      {% include "messages/_banner.html" with message=success_message level="success" %}
+    </div>
+  {% elif form.errors %}
+    {% include "messages/_banner.html" with message="Please correct the errors below." level="error" dismissible=False %}
+  {% endif %}
+</div>
+</form>
+{% if profile %}
+  {% include "./_notificationprofile_summary.html" %}
+{% endif %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_content.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_content.html
@@ -28,5 +28,5 @@
 </div>
 </form>
 {% if profile %}
-  {% include "./_notificationprofile_summary.html" %}
+  {% include "./_notificationprofile_summary.html" with oob=True %}
 {% endif %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
@@ -10,10 +10,7 @@
     {% if field.name == "name" %}
       {% comment %}Rendered separately in the form template with action buttons{% endcomment %}
     {% else %}
-      <div {% with classes=field.css_classes %}
-           {% if classes %}class="{{ classes }}"{% endif %}
-           {% endwith %}
-           {% if field.name == "active" %}class="sm:col-start-2"{% endif %}>
+      <div class="{% with classes=field.css_classes %}{{ classes }}{% endwith %}{% if field.name == "active" %} sm:col-start-2{% endif %}">
         {% if field.name == "timeslot" %}
           {% include "htmx/forms/input_field.html" with label=field.label max_width="full" field=field %}
         {% elif field.name == "active" %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
@@ -14,7 +14,7 @@
         {% if field.name == "timeslot" %}
           {% include "htmx/forms/input_field.html" with label=field.label max_width="full" field=field %}
         {% elif field.name == "active" %}
-          <div class="flex flex-col justify-end h-full">
+          <div class="flex flex-col justify-start h-full mt-5">
             <label class="label cursor-pointer justify-start gap-3">
               {% render_field field class+="checkbox checkbox-sm border-b border-1" %}
               <span class="label-text"><em>{{ field.label }}</em></span>

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
@@ -5,18 +5,19 @@
     {% for field in hidden_fields %}{{ field }}{% endfor %}
   </div>
 {% endif %}
-<div class="flex items-start justify-start gap-2 w-full flex-wrap">
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 w-full">
   {% for field, errors in fields %}
     <div {% with classes=field.css_classes %}
-         {% if classes %}class="{{ classes }}"{% elif field.name != "active" %}class="basis-1/5 shrink-0 grow-0"{% endif %}
+         {% if classes %}class="{{ classes }}"{% endif %}
          {% endwith %}>
       {% if field.name == "name" or field.name == "timeslot" %}
-        {% include "htmx/forms/input_field.html" with label=field.label max_width="md" field=field %}
+        {% include "htmx/forms/input_field.html" with label=field.label max_width="full" field=field %}
       {% elif field.name == "active" %}
         {% include "htmx/forms/input_field.html" with label=field.label field=field input_classes="checkbox border-b border-1" %}
       {% else %}
-        <div class="form-control">
-          <label class="label label-text" for={{ field.auto_id }}><em>{{ field.label }}</em>
+        <div class="form-control w-full">
+          <label class="label" for="{{ field.auto_id }}">
+            <span class="label-text"><em>{{ field.label }}</em></span>
           </label>
           {% render_field field %}
           {% if field.help_text %}<div class="helptext text-xs">{{ field.help_text }}</div>{% endif %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
@@ -7,27 +7,38 @@
 {% endif %}
 <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 w-full">
   {% for field, errors in fields %}
-    <div {% with classes=field.css_classes %}
-         {% if classes %}class="{{ classes }}"{% endif %}
-         {% endwith %}>
-      {% if field.name == "name" or field.name == "timeslot" %}
-        {% include "htmx/forms/input_field.html" with label=field.label max_width="full" field=field %}
-      {% elif field.name == "active" %}
-        {% include "htmx/forms/input_field.html" with label=field.label field=field input_classes="checkbox border-b border-1" %}
-      {% else %}
-        <div class="form-control w-full">
-          <label class="label" for="{{ field.auto_id }}">
-            <span class="label-text"><em>{{ field.label }}</em></span>
-          </label>
-          {% render_field field %}
-          {% if field.help_text %}<div class="helptext text-xs">{{ field.help_text }}</div>{% endif %}
-          {{ errors }}
-        </div>
-      {% endif %}
-      {% if forloop.last %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
-      {% endif %}
-    </div>
+    {% if field.name == "name" %}
+      {% comment %}Rendered separately in the form template with action buttons{% endcomment %}
+    {% else %}
+      <div {% with classes=field.css_classes %}
+           {% if classes %}class="{{ classes }}"{% endif %}
+           {% endwith %}
+           {% if field.name == "active" %}class="sm:col-start-2"{% endif %}>
+        {% if field.name == "timeslot" %}
+          {% include "htmx/forms/input_field.html" with label=field.label max_width="full" field=field %}
+        {% elif field.name == "active" %}
+          <div class="flex flex-col justify-end h-full">
+            <label class="label cursor-pointer justify-start gap-3">
+              {% render_field field class+="checkbox checkbox-sm border-b border-1" %}
+              <span class="label-text"><em>{{ field.label }}</em></span>
+            </label>
+            {% if field.help_text %}<div class="helptext text-xs pl-8">{{ field.help_text }}</div>{% endif %}
+          </div>
+        {% else %}
+          <div class="form-control w-full">
+            <label class="label" for="{{ field.auto_id }}">
+              <span class="label-text"><em>{{ field.label }}</em></span>
+            </label>
+            {% render_field field %}
+            {% if field.help_text %}<div class="helptext text-xs">{{ field.help_text }}</div>{% endif %}
+            {{ errors }}
+          </div>
+        {% endif %}
+        {% if forloop.last %}
+          {% for field in hidden_fields %}{{ field }}{% endfor %}
+        {% endif %}
+      </div>
+    {% endif %}
   {% endfor %}
 </div>
 {% if not fields and not errors %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_form_div.html
@@ -5,7 +5,7 @@
     {% for field in hidden_fields %}{{ field }}{% endfor %}
   </div>
 {% endif %}
-<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 w-full">
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 w-full items-start">
   {% for field, errors in fields %}
     {% if field.name == "name" %}
       {% comment %}Rendered separately in the form template with action buttons{% endcomment %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
@@ -1,0 +1,44 @@
+<div class="group-open:hidden flex flex-col gap-1 min-w-0"
+     id="notificationprofile-summary-{{ profile.pk }}"
+     hx-swap-oob="true">
+  <div class="flex items-center gap-2">
+    <h2 class="text-lg font-semibold">{{ profile.name|default:"Unnamed profile" }}</h2>
+    {% if profile.active %}
+      <span class="badge badge-sm badge-success">Active</span>
+    {% else %}
+      <span class="badge badge-sm badge-ghost">Inactive</span>
+    {% endif %}
+  </div>
+  <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-base-content/70">
+    {% if profile.timeslot %}
+      <span class="flex items-center gap-1">
+        <i class="fa-regular fa-clock text-xs" aria-hidden="true"></i>
+        {{ profile.timeslot.name }}
+        {% for tr in profile.timeslot.time_recurrences.all %}
+          <span class="badge badge-sm">{{ tr.short_str }}</span>
+        {% endfor %}
+      </span>
+    {% endif %}
+    {% with filters=profile.filters.all %}
+      {% if filters %}
+        <span class="border-l border-base-content/20 pl-3 flex items-center gap-1">
+          <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
+          {% for filter in filters %}
+            {{ filter.name }}
+            {% if not forloop.last %},{% endif %}
+          {% endfor %}
+        </span>
+      {% endif %}
+    {% endwith %}
+    {% with destinations=profile.destinations.all %}
+      {% if destinations %}
+        <span class="border-l border-base-content/20 pl-3 flex items-center gap-1 flex-wrap">
+          <i class="fa-regular fa-bell text-xs" aria-hidden="true"></i>
+          {% for dest in destinations %}
+            <span class="badge badge-sm badge-outline">{{ dest.media.name }}: {{ dest }}</span>
+          {% endfor %}
+        </span>
+      {% endif %}
+    {% endwith %}
+  </div>
+</div>

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
@@ -34,9 +34,7 @@
       {% if destinations %}
         <span class="border-l border-base-content/20 pl-3 flex items-center gap-1 flex-wrap">
           <i class="fa-regular fa-bell text-xs" aria-hidden="true"></i>
-          {% for dest in destinations %}
-            <span class="badge badge-sm badge-outline">{{ dest.media.name }}: {{ dest }}</span>
-          {% endfor %}
+          {% for dest in destinations %}<span class="badge badge-sm badge-outline">{{ dest }}</span>{% endfor %}
         </span>
       {% endif %}
     {% endwith %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
@@ -1,6 +1,6 @@
 <div class="group-open:hidden flex flex-col gap-1 min-w-0"
      id="notificationprofile-summary-{{ profile.pk }}"
-     hx-swap-oob="true">
+     {% if oob %}hx-swap-oob="true"{% endif %}>
   <div class="flex items-center gap-2">
     <h2 class="text-lg font-semibold">{{ profile.name|default:"Unnamed profile" }}</h2>
     {% if profile.active %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
@@ -1,12 +1,12 @@
 {% extends "./base.html" %}
+{% block tab_action %}
+  <button hx-get="{% url 'htmx:notificationprofile-create' %}"
+          hx-target="#notificationprofile-create"
+          hx-swap="outerHTML"
+          class="btn btn-primary">New profile</button>
+{% endblock tab_action %}
 {% block profile_main %}
   <div>
-    <div class="flex justify-end mb-4">
-      <button hx-get="{% url 'htmx:notificationprofile-create' %}"
-              hx-target="#notificationprofile-create"
-              hx-swap="outerHTML"
-              class="btn btn-primary">New profile</button>
-    </div>
     <div id="notificationprofile-create"></div>
     {% for profile in object_list %}
       {% include "./_notificationprofile_card.html" %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
@@ -3,6 +3,7 @@
   <button hx-get="{% url 'htmx:notificationprofile-create' %}"
           hx-target="#notificationprofile-create"
           hx-swap="outerHTML"
+          _="on click remove #no-profiles-message"
           class="btn btn-primary">New profile</button>
 {% endblock tab_action %}
 {% block profile_main %}
@@ -11,7 +12,7 @@
     {% for profile in object_list %}
       {% include "./_notificationprofile_card.html" %}
     {% empty %}
-      <p class="text-center text-base-content/60">No profiles yet.</p>
+      <p id="no-profiles-message" class="text-center text-base-content/60">No profiles yet.</p>
     {% endfor %}
   </div>
 {% endblock profile_main %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
@@ -3,7 +3,7 @@
   <button hx-get="{% url 'htmx:notificationprofile-create' %}"
           hx-target="#notificationprofile-create"
           hx-swap="outerHTML"
-          _="on click remove #no-profiles-message"
+          _="on click if #no-profiles-message remove #no-profiles-message"
           class="btn btn-primary">New profile</button>
 {% endblock tab_action %}
 {% block profile_main %}
@@ -12,7 +12,7 @@
     {% for profile in object_list %}
       {% include "./_notificationprofile_card.html" %}
     {% empty %}
-      <p id="no-profiles-message" class="text-center text-base-content/60">No profiles yet.</p>
+      <p id="no-profiles-message" class="text-center text-base-content/60">No profiles yet</p>
     {% endfor %}
   </div>
 {% endblock profile_main %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/notificationprofile_list.html
@@ -1,12 +1,17 @@
 {% extends "./base.html" %}
 {% block profile_main %}
   <div>
-    <div class="card card-base card-gray mt-4 mb-8"
-         hx-get="{% url "htmx:notificationprofile-create" %}"
-         hx-swap="innerHTML"
-         hx-trigger="load once"></div>
-    {% for form in form_list %}
-      <div class="card card-base card-border my-4">{% include "./_notificationprofile_form.html" %}</div>
+    <div class="flex justify-end mb-4">
+      <button hx-get="{% url 'htmx:notificationprofile-create' %}"
+              hx-target="#notificationprofile-create"
+              hx-swap="outerHTML"
+              class="btn btn-primary">New profile</button>
+    </div>
+    <div id="notificationprofile-create"></div>
+    {% for profile in object_list %}
+      {% include "./_notificationprofile_card.html" %}
+    {% empty %}
+      <p class="text-center text-base-content/60">No profiles yet.</p>
     {% endfor %}
   </div>
 {% endblock profile_main %}

--- a/tests/htmx/notificationprofile/test_views.py
+++ b/tests/htmx/notificationprofile/test_views.py
@@ -2,6 +2,11 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from argus.auth.factories import PersonUserFactory
+from argus.notificationprofile.factories import (
+    NotificationProfileFactory,
+    TimeslotFactory,
+)
+from argus.notificationprofile.models import Filter
 
 
 @override_settings(AUTHENTICATION_BACKENDS=["django.contrib.auth.backends.ModelBackend"])
@@ -27,3 +32,135 @@ class TestNotificationProfileListView(NotificationProfileViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["page_title"], "Profiles")
+
+    def test_when_get_it_should_list_profiles(self):
+        timeslot = TimeslotFactory(user=self.user)
+        NotificationProfileFactory(user=self.user, timeslot=timeslot)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["object_list"]), 1)
+
+
+class TestNotificationProfileDetailView(NotificationProfileViewTestCase):
+    def setUp(self):
+        super().setUp()
+        timeslot = TimeslotFactory(user=self.user)
+        self.profile = NotificationProfileFactory(user=self.user, timeslot=timeslot)
+        self.url = reverse("htmx:notificationprofile-detail", kwargs={"pk": self.profile.pk})
+
+    def test_when_htmx_get_it_should_return_card_partial(self):
+        response = self.client.get(self.url, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "htmx/notificationprofile/_notificationprofile_card.html")
+
+    def test_when_non_htmx_get_it_should_redirect_to_update(self):
+        response = self.client.get(self.url)
+
+        self.assertRedirects(
+            response,
+            reverse("htmx:notificationprofile-update", kwargs={"pk": self.profile.pk}),
+            fetch_redirect_response=False,
+        )
+
+
+class TestNotificationProfileCreateView(NotificationProfileViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.timeslot = TimeslotFactory(user=self.user)
+        self.filter = Filter.objects.create(user=self.user, name="Test Filter", filter={})
+        self.url = reverse("htmx:notificationprofile-create")
+
+    def _build_post_data(self, **overrides):
+        data = {
+            "name": "Test Profile",
+            "timeslot": self.timeslot.pk,
+            "filters": [self.filter.pk],
+            "destinations": [],
+            "active": "on",
+        }
+        data.update(overrides)
+        return data
+
+    def test_when_get_it_should_render_form(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("form", response.context)
+
+    def test_when_htmx_get_it_should_return_form_partial(self):
+        response = self.client.get(self.url, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "htmx/notificationprofile/_notificationprofile_form.html")
+        self.assertTrue(response.context["is_create"])
+
+    def test_when_valid_post_it_should_redirect_to_list(self):
+        response = self.client.post(self.url, data=self._build_post_data())
+
+        self.assertRedirects(response, reverse("htmx:notificationprofile-list"), fetch_redirect_response=False)
+
+    def test_when_htmx_valid_post_it_should_redirect_via_hx_redirect(self):
+        response = self.client.post(self.url, data=self._build_post_data(), HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("HX-Redirect", response.headers)
+
+
+class TestNotificationProfileUpdateView(NotificationProfileViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.timeslot = TimeslotFactory(user=self.user)
+        self.filter = Filter.objects.create(user=self.user, name="Test Filter", filter={})
+        self.profile = NotificationProfileFactory(user=self.user, timeslot=self.timeslot, name="Test Profile")
+        self.profile.filters.add(self.filter)
+        self.url = reverse("htmx:notificationprofile-update", kwargs={"pk": self.profile.pk})
+
+    def test_when_get_it_should_render_form(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("form", response.context)
+
+    def _build_post_data(self, **overrides):
+        prefix = f"npf{self.profile.pk}"
+        data = {
+            f"{prefix}-name": self.profile.name,
+            f"{prefix}-timeslot": self.timeslot.pk,
+            f"{prefix}-filters": [self.filter.pk],
+            f"{prefix}-destinations": [],
+            f"{prefix}-active": "on",
+        }
+        data.update(overrides)
+        return data
+
+    def test_when_htmx_valid_post_it_should_persist_and_render_success(self):
+        prefix = f"npf{self.profile.pk}"
+        post_data = self._build_post_data(**{f"{prefix}-name": "Updated Name"})
+
+        response = self.client.post(self.url, data=post_data, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.name, "Updated Name")
+        self.assertIn("success_message", response.context)
+
+    def test_when_htmx_invalid_post_it_should_return_form_content_partial_with_errors(self):
+        prefix = f"npf{self.profile.pk}"
+        post_data = self._build_post_data(**{f"{prefix}-timeslot": ""})
+        del post_data[f"{prefix}-active"]
+
+        response = self.client.post(self.url, data=post_data, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "htmx/notificationprofile/_notificationprofile_form_content.html")
+        self.assertTrue(response.context["form"].errors)
+
+    def test_when_valid_post_it_should_redirect_to_list(self):
+        post_data = self._build_post_data()
+
+        response = self.client.post(self.url, data=post_data)
+
+        self.assertRedirects(response, reverse("htmx:notificationprofile-list"), fetch_redirect_response=False)

--- a/tests/htmx/notificationprofile/test_views.py
+++ b/tests/htmx/notificationprofile/test_views.py
@@ -6,7 +6,7 @@ from argus.notificationprofile.factories import (
     NotificationProfileFactory,
     TimeslotFactory,
 )
-from argus.notificationprofile.models import Filter
+from argus.filter.factories import FilterFactory
 
 
 @override_settings(AUTHENTICATION_BACKENDS=["django.contrib.auth.backends.ModelBackend"])
@@ -70,7 +70,7 @@ class TestNotificationProfileCreateView(NotificationProfileViewTestCase):
     def setUp(self):
         super().setUp()
         self.timeslot = TimeslotFactory(user=self.user)
-        self.filter = Filter.objects.create(user=self.user, name="Test Filter", filter={})
+        self.filter = FilterFactory(user=self.user, name="Test Filter", filter={})
         self.url = reverse("htmx:notificationprofile-create")
 
     def _build_post_data(self, **overrides):
@@ -113,7 +113,7 @@ class TestNotificationProfileUpdateView(NotificationProfileViewTestCase):
     def setUp(self):
         super().setUp()
         self.timeslot = TimeslotFactory(user=self.user)
-        self.filter = Filter.objects.create(user=self.user, name="Test Filter", filter={})
+        self.filter = FilterFactory(user=self.user, name="Test Filter", filter={})
         self.profile = NotificationProfileFactory(user=self.user, timeslot=self.timeslot, name="Test Profile")
         self.profile.filters.add(self.filter)
         self.url = reverse("htmx:notificationprofile-update", kwargs={"pk": self.profile.pk})

--- a/tests/htmx/notificationprofile/test_views.py
+++ b/tests/htmx/notificationprofile/test_views.py
@@ -50,7 +50,7 @@ class TestNotificationProfileDetailView(NotificationProfileViewTestCase):
         self.profile = NotificationProfileFactory(user=self.user, timeslot=timeslot)
         self.url = reverse("htmx:notificationprofile-detail", kwargs={"pk": self.profile.pk})
 
-    def test_when_htmx_get_it_should_return_card_partial(self):
+    def test_given_htmx_get_it_should_return_card_partial(self):
         response = self.client.get(self.url, HTTP_HX_REQUEST="true")
 
         self.assertEqual(response.status_code, 200)
@@ -90,7 +90,7 @@ class TestNotificationProfileCreateView(NotificationProfileViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("form", response.context)
 
-    def test_when_htmx_get_it_should_return_form_partial(self):
+    def test_given_htmx_get_it_should_return_form_partial(self):
         response = self.client.get(self.url, HTTP_HX_REQUEST="true")
 
         self.assertEqual(response.status_code, 200)
@@ -102,7 +102,7 @@ class TestNotificationProfileCreateView(NotificationProfileViewTestCase):
 
         self.assertRedirects(response, reverse("htmx:notificationprofile-list"), fetch_redirect_response=False)
 
-    def test_when_htmx_valid_post_it_should_redirect_via_hx_redirect(self):
+    def test_given_htmx_valid_post_it_should_redirect_via_hx_redirect(self):
         response = self.client.post(self.url, data=self._build_post_data(), HTTP_HX_REQUEST="true")
 
         self.assertEqual(response.status_code, 200)
@@ -136,7 +136,7 @@ class TestNotificationProfileUpdateView(NotificationProfileViewTestCase):
         data.update(overrides)
         return data
 
-    def test_when_htmx_valid_post_it_should_persist_and_render_success(self):
+    def test_given_htmx_valid_post_it_should_persist_and_render_success(self):
         prefix = f"npf{self.profile.pk}"
         post_data = self._build_post_data(**{f"{prefix}-name": "Updated Name"})
 
@@ -147,7 +147,7 @@ class TestNotificationProfileUpdateView(NotificationProfileViewTestCase):
         self.assertEqual(self.profile.name, "Updated Name")
         self.assertIn("success_message", response.context)
 
-    def test_when_htmx_invalid_post_it_should_return_form_content_partial_with_errors(self):
+    def test_given_htmx_invalid_post_it_should_return_form_content_partial_with_errors(self):
         prefix = f"npf{self.profile.pk}"
         post_data = self._build_post_data(**{f"{prefix}-timeslot": ""})
         del post_data[f"{prefix}-active"]


### PR DESCRIPTION
## Scope and purpose

Resolves issue #1796, based on PR #1797 and PR #1799

### This pull request

Reworks notification profile forms to match the accordion card pattern from #1794.

- Replace flat list of pre-rendered forms with collapsible accordion cards (lazy-loaded on open)
- Use Choices.js `<select multiple>` for filters and destinations instead of custom `DropdownMultiSelect`
- Rearrange form layout: name + actions inline at top, 2-column grid for remaining fields
- Collapsed "preview" card gets updated when form is saved, so the collapsed card always shows the latest state.

### Screenshots

<img width="921" height="863" alt="image" src="https://github.com/user-attachments/assets/ea349038-6a74-4065-b273-b1cffe821863" />
<img width="918" height="694" alt="image" src="https://github.com/user-attachments/assets/505438ed-f6ef-4458-86a4-8f7d9d043479" />
<img width="924" height="781" alt="image" src="https://github.com/user-attachments/assets/2c2fc320-4de6-41d1-879d-a59468c385f7" />


## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)