### PR TITLE
Make sure SEND_NOTIFICATIONS is honored

### DIFF
--- a/changelog.d/1808.fixed.md
+++ b/changelog.d/1808.fixed.md
@@ -1,0 +1,3 @@
+Fixed a bug where the setting that controls whether notifications will be sent
+was ignored when sending notifications in the background. The notifications
+were sent regardless.

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
+
+from argus.notificationprofile.utils import are_notifications_enabled
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -19,6 +22,7 @@ if TYPE_CHECKING:
 
 
 __all__ = ["NotificationMedium"]
+LOG = logging.getLogger(__name__)
 
 
 class NotificationMedium(ABC):
@@ -86,20 +90,21 @@ class NotificationMedium(ABC):
         return set(addresses)
 
     @classmethod
-    @abstractmethod
     def send(cls, event: Event, destinations: Iterable[DestinationConfig], **kwargs) -> bool:
         """
         Sends message about a given event to the given destinations
 
         Loops over the destinations from ``cls.get_relevant_destinations`` and
-        coneverts each destination to a medium-specifoc "address" via
+        converts each destination to a medium-specific "address" via
         ``cls.get_relevant_address``.
 
         Returns a boolean:
         * True: everything ok
         * False: at least one destination failed
         """
-        pass
+        if not are_notifications_enabled():
+            LOG.info("notifications: turned off sitewide, not sending")
+            return False
 
     @classmethod
     def raise_if_not_deletable(cls, destination: DestinationConfig) -> NoneType:

--- a/src/argus/notificationprofile/utils.py
+++ b/src/argus/notificationprofile/utils.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def are_notifications_enabled():
+    return getattr(settings, "SEND_NOTIFICATIONS", False)


### PR DESCRIPTION
## Scope and purpose

During working on #1608 we discovered that when sending notifications via a backgrounded process, the SEND_NOTIFICATIONS setting was not honored. This PR fixes that.

While the baseclass for media plugins now check directly, we cannot depend on 3rd party plugins to behave properly so we also check in `send_notification` in addition to the original spot.

Hopefully we can later refactor the base class to make plugins easier to rewrite by putting more default logic in the base class.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
