### PR TITLE
Move some signals to better homes

### DIFF
--- a/src/argus/incident/apps.py
+++ b/src/argus/incident/apps.py
@@ -8,7 +8,6 @@ class IncidentConfig(AppConfig):
 
     def ready(self):
         from .signals import (
-            add_planned_maintenance_tasks_covering_incident,
             close_token_incident,
             delete_associated_user,
             delete_associated_event,
@@ -18,4 +17,3 @@ class IncidentConfig(AppConfig):
         post_delete.connect(delete_associated_event, "argus_incident.Acknowledgement")
         post_delete.connect(close_token_incident, "authtoken.Token")
         post_save.connect(close_token_incident, "authtoken.Token")
-        post_save.connect(add_planned_maintenance_tasks_covering_incident, "argus_incident.Incident")

--- a/src/argus/incident/apps.py
+++ b/src/argus/incident/apps.py
@@ -12,13 +12,10 @@ class IncidentConfig(AppConfig):
             close_token_incident,
             delete_associated_user,
             delete_associated_event,
-            task_send_notification,  # noqa
-            task_background_send_notification,
         )
 
         post_delete.connect(delete_associated_user, "argus_incident.SourceSystem")
         post_delete.connect(delete_associated_event, "argus_incident.Acknowledgement")
         post_delete.connect(close_token_incident, "authtoken.Token")
         post_save.connect(close_token_incident, "authtoken.Token")
-        post_save.connect(task_background_send_notification, "argus_incident.Event", dispatch_uid="send_notification")
         post_save.connect(add_planned_maintenance_tasks_covering_incident, "argus_incident.Incident")

--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -1,7 +1,6 @@
 from django.db.models import Q
 from rest_framework.authtoken.models import Token
 
-from argus.plannedmaintenance.utils import connect_incident_with_planned_maintenance_tasks
 from .models import (
     Acknowledgement,
     Incident,
@@ -48,7 +47,3 @@ def close_token_incident(instance: Token, **kwargs):
         return
 
     token_expiry_incident.set_end(actor=argus_user)
-
-
-def add_planned_maintenance_tasks_covering_incident(instance: Incident, **kwargs):
-    connect_incident_with_planned_maintenance_tasks(incident=instance)

--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -27,6 +27,7 @@ def delete_associated_event(sender, instance: Acknowledgement, *args, **kwargs):
         instance.event.delete()
 
 
+# the rest_framework.authtoken is not under our control so keep the signal here
 def close_token_incident(instance: Token, **kwargs):
     if not hasattr(instance.user, "source_system"):
         return

--- a/src/argus/incident/signals.py
+++ b/src/argus/incident/signals.py
@@ -1,16 +1,9 @@
 from django.db.models import Q
 from rest_framework.authtoken.models import Token
 
-from argus.notificationprofile.media import send_notifications_to_users
-from argus.notificationprofile.media import background_send_notification
-from argus.notificationprofile.media import send_notification
-from argus.plannedmaintenance.utils import (
-    connect_incident_with_planned_maintenance_tasks,
-    event_covered_by_planned_maintenance,
-)
+from argus.plannedmaintenance.utils import connect_incident_with_planned_maintenance_tasks
 from .models import (
     Acknowledgement,
-    Event,
     Incident,
     SourceSystem,
     Tag,
@@ -20,7 +13,6 @@ from .models import (
 
 __all__ = [
     "delete_associated_user",
-    "send_notification",
     "delete_associated_event",
     "close_token_incident",
 ]
@@ -29,18 +21,6 @@ __all__ = [
 def delete_associated_user(sender, instance: SourceSystem, *args, **kwargs):
     if hasattr(instance, "user") and instance.user:
         instance.user.delete()
-
-
-def task_send_notification(sender, instance: Event, *args, **kwargs):
-    if event_covered_by_planned_maintenance(event=instance):
-        return
-    send_notifications_to_users(instance)
-
-
-def task_background_send_notification(sender, instance: Event, *args, **kwargs):
-    if event_covered_by_planned_maintenance(event=instance):
-        return
-    send_notifications_to_users(instance, send=background_send_notification)
 
 
 def delete_associated_event(sender, instance: Acknowledgement, *args, **kwargs):

--- a/src/argus/notificationprofile/apps.py
+++ b/src/argus/notificationprofile/apps.py
@@ -12,8 +12,13 @@ class NotificationprofileConfig(AppConfig):
             create_default_timeslot,
             sync_email_destination,
             sync_media,
+            task_send_notification,  # noqa
+            task_background_send_notification,
         )
 
         post_save.connect(create_default_timeslot, "argus_auth.User")
         post_save.connect(sync_email_destination, "argus_auth.User")
         post_migrate.connect(sync_media, sender=self)
+
+        # sending notifications
+        post_save.connect(task_background_send_notification, "argus_incident.Event", dispatch_uid="send_notification")

--- a/src/argus/plannedmaintenance/apps.py
+++ b/src/argus/plannedmaintenance/apps.py
@@ -1,6 +1,12 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_save
 
 
 class PlannedmaintenanceConfig(AppConfig):
     name = "argus.plannedmaintenance"
     label = "argus_plannedmaintenance"
+
+    def ready(self):
+        from .signals import add_planned_maintenance_tasks_covering_incident
+
+        post_save.connect(add_planned_maintenance_tasks_covering_incident, "argus_incident.Incident")

--- a/src/argus/plannedmaintenance/signals.py
+++ b/src/argus/plannedmaintenance/signals.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from argus.plannedmaintenance.utils import connect_incident_with_planned_maintenance_tasks
+
+if TYPE_CHECKING:
+    from argus.incident.models import Incident
+
+
+def add_planned_maintenance_tasks_covering_incident(instance: Incident, **kwargs):
+    connect_incident_with_planned_maintenance_tasks(incident=instance)

--- a/src/argus/util/testing.py
+++ b/src/argus/util/testing.py
@@ -1,9 +1,9 @@
 from django.db.models.signals import post_save
 
-from argus.incident.signals import send_notification
-from argus.incident.signals import background_send_notification
-from argus.incident.signals import add_planned_maintenance_tasks_covering_incident
 from argus.incident.models import Event, Incident
+from argus.notificationprofile.signals import task_send_notification
+from argus.notificationprofile.signals import task_background_send_notification
+from argus.plannedmaintenance.signals import add_planned_maintenance_tasks_covering_incident
 
 
 __all__ = [
@@ -16,12 +16,12 @@ __all__ = [
 
 
 def disconnect_signals():
-    post_save.disconnect(send_notification, Event, dispatch_uid="send_notification")
-    post_save.disconnect(background_send_notification, Event, dispatch_uid="send_notification")
+    post_save.disconnect(task_send_notification, Event, dispatch_uid="send_notification")
+    post_save.disconnect(task_background_send_notification, Event, dispatch_uid="send_notification")
     post_save.disconnect(add_planned_maintenance_tasks_covering_incident, Incident)
 
 
 def connect_signals():
-    post_save.connect(send_notification, Event, dispatch_uid="send_notification")
-    post_save.connect(background_send_notification, Event, dispatch_uid="send_notification")
+    post_save.connect(task_send_notification, Event, dispatch_uid="send_notification")
+    post_save.connect(task_background_send_notification, Event, dispatch_uid="send_notification")
     post_save.connect(add_planned_maintenance_tasks_covering_incident, Incident)


### PR DESCRIPTION
## Scope and purpose

This turns argus.incident into more of a library by making it less coupled and less dependent on other apps. argus is nothing without its incidents, but both notifications and 
planned maintenance are something that depend on incidents.

It still depends on `rest_framework.authtoken`. We can't alter that app, so doing so is considered out of scope for this quick fix.

Nobody should notice this change.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
