### PR TITLE
Add copy button for planned maintenance tasks

### DIFF
--- a/changelog.d/1613.added.md
+++ b/changelog.d/1613.added.md
@@ -1,0 +1,1 @@
+Add "Create copy" action for planned maintenance tasks

--- a/src/argus/htmx/plannedmaintenance/views.py
+++ b/src/argus/htmx/plannedmaintenance/views.py
@@ -127,6 +127,16 @@ class PlannedMaintenanceCreateView(UserIsStaffMixin, FilterWidgetMixin, PlannedM
         initial = super().get_initial()
         initial["start_time"] = timezone.now()
         # end_time defaults to infinite (no initial value)
+
+        copy_from = self.request.GET.get("copy_from")
+        if copy_from:
+            try:
+                source = PlannedMaintenanceTask.objects.get(pk=copy_from)
+                initial["description"] = source.description
+                initial["filters"] = list(source.filters.values_list("pk", flat=True))
+            except PlannedMaintenanceTask.DoesNotExist:
+                pass
+
         return initial
 
     def form_valid(self, form):

--- a/src/argus/htmx/templates/htmx/plannedmaintenance/_cancel_confirm_dialog.html
+++ b/src/argus/htmx/templates/htmx/plannedmaintenance/_cancel_confirm_dialog.html
@@ -1,6 +1,3 @@
-<button class="btn btn-sm btn-outline w-[84px]"
-        type="button"
-        onclick="document.getElementById('end-dialog-{{ task.pk }}').showModal()">End now</button>
 <dialog id="end-dialog-{{ task.pk }}" class="modal">
   <div class="modal-box">
     <h3 class="font-bold text-xl text-left">End Maintenance Task</h3>

--- a/src/argus/htmx/templates/htmx/plannedmaintenance/_delete_confirm_dialog.html
+++ b/src/argus/htmx/templates/htmx/plannedmaintenance/_delete_confirm_dialog.html
@@ -1,6 +1,3 @@
-<button class="btn btn-sm btn-error btn-outline w-[84px]"
-        type="button"
-        onclick="document.getElementById('delete-dialog-{{ task.pk }}').showModal()">Delete</button>
 <dialog id="delete-dialog-{{ task.pk }}" class="modal">
   <div class="modal-box">
     <h3 class="font-semibold text-xl text-left">Delete Maintenance Task</h3>

--- a/src/argus/htmx/templates/htmx/plannedmaintenance/plannedmaintenance_form.html
+++ b/src/argus/htmx/templates/htmx/plannedmaintenance/plannedmaintenance_form.html
@@ -141,20 +141,28 @@
               </div>
             {% endif %}
           </div>
-          <div class="card-actions justify-end mt-6">
-            {% if object.pk and not object.modifiable or not request.user.is_staff %}
-              <a href="{% if object.past %}{% url 'htmx:plannedmaintenance-list' tab='past' %}{% else %}{% url 'htmx:plannedmaintenance-list' %}{% endif %}"
-                 class="btn">Back</a>
-            {% else %}
-              <button type="submit" class="btn btn-primary">
-                {% if object.pk %}
-                  Save changes
-                {% else %}
-                  Create
-                {% endif %}
-              </button>
-              <a href="{% url 'htmx:plannedmaintenance-list' %}" class="btn">Cancel</a>
-            {% endif %}
+          <div class="card-actions justify-between mt-6">
+            <div>
+              {% if object.pk and request.user.is_staff %}
+                <a href="{% url 'htmx:plannedmaintenance-create' %}?copy_from={{ object.pk }}"
+                   class="btn">Create copy</a>
+              {% endif %}
+            </div>
+            <div class="flex gap-2">
+              {% if object.pk and not object.modifiable or not request.user.is_staff %}
+                <a href="{% if object.past %}{% url 'htmx:plannedmaintenance-list' tab='past' %}{% else %}{% url 'htmx:plannedmaintenance-list' %}{% endif %}"
+                   class="btn">Back</a>
+              {% else %}
+                <button type="submit" class="btn btn-primary">
+                  {% if object.pk %}
+                    Save changes
+                  {% else %}
+                    Create
+                  {% endif %}
+                </button>
+                <a href="{% url 'htmx:plannedmaintenance-list' %}" class="btn">Cancel</a>
+              {% endif %}
+            </div>
           </div>
         </form>
       </div>

--- a/src/argus/htmx/templates/htmx/plannedmaintenance/plannedmaintenance_list.html
+++ b/src/argus/htmx/templates/htmx/plannedmaintenance/plannedmaintenance_list.html
@@ -59,19 +59,59 @@
               </div>
             </td>
             <td class="border-b border-neutral-content group-last:border-b-0">{{ task.created_by }}</td>
-            <td class="border-b border-neutral-content group-last:border-b-0 text-right">
+            <td class="border-b border-neutral-content group-last:border-b-0 text-right overflow-visible">
               <div class="flex gap-1 justify-end">
                 {% if request.user.is_staff and task.modifiable %}
                   <a href="{% url 'htmx:plannedmaintenance-update' pk=task.pk %}"
                      class="btn btn-sm btn-ghost">Edit</a>
-                  {% if task.current %}
-                    {% include "./_cancel_confirm_dialog.html" with task=task %}
-                  {% elif task.future %}
-                    {% include "./_delete_confirm_dialog.html" with task=task %}
-                  {% endif %}
                 {% else %}
                   <a href="{% url 'htmx:plannedmaintenance-detail' pk=task.pk %}"
                      class="btn btn-sm btn-ghost">View</a>
+                {% endif %}
+                {% if request.user.is_staff %}
+                  <div class="dropdown dropdown-end">
+                    <button tabindex="0" class="btn btn-sm btn-ghost btn-square">
+                      <svg xmlns="http://www.w3.org/2000/svg"
+                           class="h-4 w-4"
+                           viewBox="0 0 20 20"
+                           fill="currentColor">
+                        <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+                      </svg>
+                    </button>
+                    <ul tabindex="0"
+                        class="dropdown-content z-[50] menu menu-sm p-2 shadow bg-base-100 rounded-box w-max border border-base-300">
+                      <li>
+                        <a href="{% url 'htmx:plannedmaintenance-create' %}?copy_from={{ task.pk }}">
+                          <i class="fa-regular fa-copy" aria-hidden="true"></i> Create copy
+                        </a>
+                      </li>
+                      {% if task.modifiable %}
+                        {% if task.current %}
+                          <li>
+                            <button type="button"
+                                    onclick="document.getElementById('end-dialog-{{ task.pk }}').showModal()">
+                              <i class="fa-regular fa-circle-stop" aria-hidden="true"></i> End now
+                            </button>
+                          </li>
+                        {% elif task.future %}
+                          <li>
+                            <button type="button"
+                                    class="text-error"
+                                    onclick="document.getElementById('delete-dialog-{{ task.pk }}').showModal()">
+                              <i class="fa-regular fa-trash-can" aria-hidden="true"></i> Delete
+                            </button>
+                          </li>
+                        {% endif %}
+                      {% endif %}
+                    </ul>
+                  </div>
+                  {% if task.modifiable %}
+                    {% if task.current %}
+                      {% include "./_cancel_confirm_dialog.html" with task=task %}
+                    {% elif task.future %}
+                      {% include "./_delete_confirm_dialog.html" with task=task %}
+                    {% endif %}
+                  {% endif %}
                 {% endif %}
               </div>
             </td>

--- a/src/argus/htmx/templates/htmx_base.html
+++ b/src/argus/htmx/templates/htmx_base.html
@@ -22,6 +22,9 @@
     <link href="{% static 'fontawesomefree/css/solid.css' %}"
           rel="stylesheet"
           type="text/css">
+    <link href="{% static 'fontawesomefree/css/regular.css' %}"
+          rel="stylesheet"
+          type="text/css">
     {% block head %}
     {% endblock head %}
   </head>


### PR DESCRIPTION
## Scope and purpose

Fixes #1613.

Add a "Create copy" action for planned maintenance tasks. This opens the create form pre-populated with the source task's description and filters, making it easy to create similar tasks without re-selecting filters manually.

### This pull request
* Adds `copy_from` query parameter support to the create view
* Adds a dropdown menu with secondary actions (Create copy, End now, Delete) in the list view
* Adds a "Create copy" button to the detail/edit form
* Loads FontAwesome regular icons in the base template

### Screenshots
<img width="870" height="416" alt="image" src="https://github.com/user-attachments/assets/ab841c11-27f4-48e0-97d9-471638125afb" />
<img width="725" height="207" alt="image" src="https://github.com/user-attachments/assets/254b21bb-d10d-4d69-981d-75aa20e4be5b" />

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after