### PR TITLE
Remove outdated instruction to commit generated styles.css

### DIFF
--- a/docs/development/makefile-rules.rst
+++ b/docs/development/makefile-rules.rst
@@ -88,6 +88,3 @@ After a change in version, running ``upgrade-tailwind`` should be followed by
 running::
 
     $ python3 manage.py tailwind_config && make tailwind
-
-... and a commit so that the correct ``src/argus/htmx/static/styles.css`` is
-available to everyone.


### PR DESCRIPTION
## Scope and purpose

Since `styles.css` is no longer checked into git, the documentation for `upgrade-tailwind` no longer needs to instruct developers to commit it.

<!-- remove things that do not apply -->

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->