### PR TITLE
Add Sikt light and dark DaisyUI themes

### DIFF
--- a/changelog.d/1822.added.md
+++ b/changelog.d/1822.added.md
@@ -1,0 +1,1 @@
+Add Sikt light and dark DaisyUI themes based on Sikt Design System color tokens

--- a/src/argus/htmx/defaults.py
+++ b/src/argus/htmx/defaults.py
@@ -52,6 +52,8 @@ DEFAULT_THEMES = [
     "dark",
     "light",
     "argus",
+    "sikt",
+    "sikt-dark",
 ]
 DAISYUI_THEMES = get_json_env("DAISYUI_THEMES", DEFAULT_THEMES, quiet=True)
 THEME_DEFAULT = get_str_env("ARGUS_THEME_DEFAULT", "argus")

--- a/src/argus/htmx/tailwindtheme/snippets/10-tailwind.css
+++ b/src/argus/htmx/tailwindtheme/snippets/10-tailwind.css
@@ -3,7 +3,7 @@
 @source "../../templates";
 
 @plugin "daisyui" {
-  themes: dark, light, argus;
+  themes: dark, light, argus, sikt, sikt-dark;
 }
 
 /*

--- a/src/argus/htmx/tailwindtheme/styles.css
+++ b/src/argus/htmx/tailwindtheme/styles.css
@@ -7,3 +7,5 @@
 @import './snippets/30-incident-table.css';
 @import './snippets/35-cards.css';
 @import './themes/argus.css';
+@import './themes/sikt.css';
+@import './themes/sikt-dark.css';

--- a/src/argus/htmx/tailwindtheme/themes/sikt-dark.css
+++ b/src/argus/htmx/tailwindtheme/themes/sikt-dark.css
@@ -1,0 +1,38 @@
+@plugin "daisyui/theme" {
+  name: "sikt-dark";
+  color-scheme: "dark";
+  --color-primary: #7351FB; /* interaction.primary: purple.65-100 */
+  --color-primary-content: #FFFFFF; /* neutral.100-100 */
+  --color-secondary: #1D1D1D; /* neutral.11-100 */
+  --color-secondary-content: #FFFFFF; /* neutral.100-100 */
+  --color-accent: #4324C8; /* purple.46-100 */
+  --color-accent-content: #FFFFFF; /* neutral.100-100 */
+  --color-neutral: #595959; /* neutral.35-100 */
+  --color-neutral-content: #FFFFFF; /* neutral.100-100 */
+  --color-base-100: #262626; /* neutral.15-100 */
+  --color-base-200: #1A1A1A; /* neutral.10-100 */
+  --color-base-300: #595959; /* neutral.35-100 */
+  --color-base-content: #FFFFFF; /* neutral.100-100 */
+  --color-info: #005AEA; /* support.info.strong(dark): blue.46-100 */
+  --color-info-content: #FFFFFF; /* neutral.100-100 */
+  --color-success: #138849; /* support.success.strong: green.30-100 */
+  --color-success-content: #FFFFFF; /* neutral.100-100 */
+  --color-warning: #FFB700; /* support.warning.strong: yellow.50-100 */
+  --color-warning-content: #FFFFFF; /* neutral.100-100 */
+  --color-error: #D74033; /* support.critical.strong: red.52-100 */
+  --color-error-content: #FFFFFF; /* neutral.100-100 */
+}
+
+/* Severity colors from Sikt datavisualization category tokens */
+[data-theme="sikt-dark"] {
+  --color-severity-primary-1: #FF957A;
+  --color-severity-primary-2: #FFAC70;
+  --color-severity-primary-3: #FBE774;
+  --color-severity-primary-4: #82E3CB;
+  --color-severity-primary-5: #75C7F0;
+  --color-severity-secondary-1: #0A0132;
+  --color-severity-secondary-2: #0A0132;
+  --color-severity-secondary-3: #0A0132;
+  --color-severity-secondary-4: #0A0132;
+  --color-severity-secondary-5: #0A0132;
+}

--- a/src/argus/htmx/tailwindtheme/themes/sikt.css
+++ b/src/argus/htmx/tailwindtheme/themes/sikt.css
@@ -1,0 +1,38 @@
+@plugin "daisyui/theme" {
+  name: "sikt";
+  color-scheme: "light";
+  --color-primary: #7351FB; /* interaction.primary: purple.65-100 */
+  --color-primary-content: #FFFFFF; /* neutral.100-100 */
+  --color-secondary: #150266; /* interaction.secondary: purple.20-100 */
+  --color-secondary-content: #FFFFFF; /* neutral.100-100 */
+  --color-accent: #D1CDFF; /* purple.90-100 */
+  --color-accent-content: #0A0132; /* purple.10-100 */
+  --color-neutral: #595959; /* neutral.35-100 */
+  --color-neutral-content: #FFFFFF; /* neutral.100-100 */
+  --color-base-100: #FFFFFF; /* neutral.100-100 */
+  --color-base-200: #F1F1F1; /* neutral.95-100 */
+  --color-base-300: #DEDEDE; /* neutral.87-100 */
+  --color-base-content: #0A0132; /* purple.10-100 */
+  --color-info: #004FCF; /* support.info.strong: blue.41-100 */
+  --color-info-content: #FFFFFF; /* neutral.100-100 */
+  --color-success: #138849; /* support.success.strong: green.30-100 */
+  --color-success-content: #FFFFFF; /* neutral.100-100 */
+  --color-warning: #FFB700; /* support.warning.strong: yellow.50-100 */
+  --color-warning-content: #0A0132; /* purple.10-100 */
+  --color-error: #D74033; /* support.critical.strong: red.52-100 */
+  --color-error-content: #FFFFFF; /* neutral.100-100 */
+}
+
+/* Severity colors from Sikt datavisualization category tokens */
+[data-theme="sikt"] {
+  --color-severity-primary-1: #FF957A;
+  --color-severity-primary-2: #FFAC70;
+  --color-severity-primary-3: #FBE774;
+  --color-severity-primary-4: #82E3CB;
+  --color-severity-primary-5: #75C7F0;
+  --color-severity-secondary-1: #0A0132;
+  --color-severity-secondary-2: #0A0132;
+  --color-severity-secondary-3: #0A0132;
+  --color-severity-secondary-4: #0A0132;
+  --color-severity-secondary-5: #0A0132;
+}


### PR DESCRIPTION
## Scope and purpose

Add "sikt" and "sikt-dark" DaisyUI v5 themes based on the Sikt Design System color tokens.

There is of course the question if we want to add Sikt branding as an option in Argus.

### This pull request
* Adds `sikt.css` and `sikt-dark.css` theme files with colors mapped from Sikt design tokens
* Adds both themes to `DEFAULT_THEMES` (default theme remains "argus")
* Includes Sikt datavisualization category colors for severity level badges
* Uses `#595959` for neutral (WCAG AAA compliant with white text)

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after