### PR TITLE
Restore 2px borders on filter boxes after Tailwind v4 upgrade

### DIFF
--- a/src/argus/htmx/templates/htmx/incident/_incident_toolbar.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_toolbar.html
@@ -1,9 +1,9 @@
 <section class="flex flex-wrap gap-2 items-center mt-1">
-  <div class="border border-primary rounded-box p-2 flex gap-2 items-center">
+  <div class="border-2 border-primary rounded-box p-2 flex gap-2 items-center">
     {% include "htmx/incident/_filter_controls.html" %}
   </div>
   <div id="bulk-actions"
-       class="invisible flex gap-2 border border-primary/50 bg-primary/10 rounded-box p-1">
+       class="invisible flex gap-2 border-2 border-primary/50 bg-primary/10 rounded-box p-1">
     {% include "htmx/incident/_incident_list_update_menu.html" %}
   </div>
 </section>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_compact_severity_filter.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_compact_severity_filter.html
@@ -9,7 +9,7 @@
     <i class="fa-solid fa-magnifying-glass text-xs"></i>
   </button>
   <div id="{{ column.name }}-dropdown-content"
-       class="dropdown-content bg-base-100 p-2 mt-1 rounded-lg shadow border border-primary z-10"
+       class="dropdown-content bg-base-100 p-2 mt-1 rounded-lg shadow border-2 border-primary z-10"
        tabindex="-1">
     <form class="incident-list-param">
       <div aria-labelledby="{{ field.name }}-label">

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -15,7 +15,7 @@
         <i class="fa-solid fa-magnifying-glass"></i>
       </button>
       <div id="{{ column.name }}-dropdown-content"
-           class="dropdown-content bg-base-100 p-2 mt-1 rounded-lg shadow border border-primary z-10 w-max h-max"
+           class="dropdown-content bg-base-100 p-2 mt-1 rounded-lg shadow border-2 border-primary z-10 w-max h-max"
            tabindex="-1">
         <form class="incident-list-param">
           <div aria-labelledby="{{ field.name }}-label">

--- a/src/argus/htmx/templates/htmx/incident/incident_list.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_list.html
@@ -9,7 +9,7 @@
     {% include "htmx/incident/_incident_list_menubar.html" %}
   {% endif %}
   <div id="filterbox"
-       class="flex flex-wrap items-center p-2 border border-primary rounded-box">
+       class="flex flex-wrap items-center p-2 border-2 border-primary rounded-box">
     {% include "htmx/incident/_incident_filterbox.html" %}
   </div>
   <section id="incident-list" class="loading-box overflow-x-auto relative">

--- a/src/argus/htmx/templates/registration/login.html
+++ b/src/argus/htmx/templates/registration/login.html
@@ -2,7 +2,7 @@
 {% load widget_tweaks %}
 {% block main %}
   <div class="p-6 flex flex-col items-center gap-2">
-    <div class="card border border-primary p-2 w-full sm:w-96 flex items-center">
+    <div class="card border-2 border-primary p-2 w-full sm:w-96 flex items-center">
       <h2 class="card-title">Log In</h2>
       <section class="card-body">
         {% if "local" in backends %}


### PR DESCRIPTION
## Scope and purpose

The Tailwind v4 / DaisyUI v5 upgrade (#1723) changed the default border width from 2px to 1px, causing a visual regression where filter boxes and filter select dropdowns lost their 2px borders.

This PR explicitly uses `border-2` on the affected elements to restore the previous appearance.

## Screenshots

### Before
<img width="1349" height="334" alt="image" src="https://github.com/user-attachments/assets/79bc7109-85a5-420d-b3f1-ed624a16cdb2" />

### After
<img width="1349" height="335" alt="image" src="https://github.com/user-attachments/assets/79ff5dcf-89ae-4024-aecc-d1673c599a44" />


### This pull request
* fixes a visual regression from the Tailwind v4 upgrade

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If this results in changes in the UI: Added screenshots of the before and after