### PR TITLE
Allow for multiple profiles without name

### DIFF
--- a/changelog.d/1828.fixed.md
+++ b/changelog.d/1828.fixed.md
@@ -1,0 +1,1 @@
+Allow for multiple notification profiles with no name

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -89,6 +89,9 @@ class NotificationProfileForm(DestinationFieldMixin, FilterFieldMixin, NoColonMi
 
     def clean_name(self):
         name = self.cleaned_data["name"]
+        if name is None:
+            return name
+
         # Making sure to check for duplicate names, but allow updating of profiles
         profiles_with_same_name = NotificationProfile.objects.filter(user=self.user, name=name).exclude(
             pk=getattr(self.instance, "pk", None)

--- a/tests/htmx/notificationprofile/test_forms.py
+++ b/tests/htmx/notificationprofile/test_forms.py
@@ -49,6 +49,17 @@ class NotificationProfileFormTests(TestCase):
             form=form, field="name", errors=f"A profile by this user with the name '{self.name1}' already exists."
         )
 
+    def test_form_with_no_name_and_other_profile_no_name_is_valid(self):
+        NotificationProfileFactory(name=None, user=self.user, timeslot=self.timeslot)
+        data = {
+            "name": None,
+            "timeslot": self.notification_profile1.timeslot,
+            "filters": [self.filter],
+        }
+        form = NotificationProfileForm(data=data, user=self.notification_profile1.user)
+
+        self.assertTrue(form.is_valid())
+
     def test_updating_form_with_same_name_as_self_is_valid(self):
         data = {
             "name": self.name1,
@@ -74,3 +85,16 @@ class NotificationProfileFormTests(TestCase):
         self.assertFormError(
             form=form, field="name", errors=f"A profile by this user with the name '{self.name2}' already exists."
         )
+
+    def test_updating_form_with_no_name_and_other_profile_no_name_is_valid(self):
+        NotificationProfileFactory(name=None, user=self.user, timeslot=self.timeslot)
+        data = {
+            "name": None,
+            "timeslot": self.notification_profile1.timeslot,
+            "filters": [self.filter],
+        }
+        form = NotificationProfileForm(
+            data=data, instance=self.notification_profile1, user=self.notification_profile1.user
+        )
+
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
## Scope and purpose

Caused by #1218. I realized it was not possible to create more than one notification profile that doesn't have a name. We have a constraint that specifies that no two profiles of the same user can have the same name, but that should obviously not be the case for profiles with no names.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
