### PR TITLE
Fix handling of stateless incidents in age function

### DIFF
--- a/changelog.d/1833.fixed.md
+++ b/changelog.d/1833.fixed.md
@@ -1,0 +1,1 @@
+Fix showing age for stateless incidents

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_age.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_age.html
@@ -1,4 +1,8 @@
 <div class="tooltip"
      data-tip="{{ incident.start_time|date:preferences.argus_htmx.datetime_format }}">
-  <span>{{ incident.humanize_age }}</span>
+  {% if incident.end_time %}
+    <span>{{ incident.humanize_age }}</span>
+  {% else %}
+    <span>-</span>
+  {% endif %}
 </div>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_start_time_and_age.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_start_time_and_age.html
@@ -1,5 +1,9 @@
 <time datetime="{{ incident.start_time }}">{{ incident.start_time|date:preferences.argus_htmx.datetime_format }}</time>
 <div class="text-base-content/60">
   <i class="fa-solid fa-clock"></i>
-  <span>{{ incident.humanize_age }}</span>
+  {% if incident.end_time %}
+    <span>{{ incident.humanize_age }}</span>
+  {% else %}
+    <span>-</span>
+  {% endif %}
 </div>

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -471,12 +471,18 @@ class Incident(models.Model):
         If the incident is open, the age is calculated up to the current time.
         If the incident is closed, the age is calculated up to the end_time.
         """
+        if not self.stateful:
+            return None
+
         end_time = self.end_time if not self.open else timezone.now()
         return end_time - self.start_time
 
     @property
     def humanize_age(self):
         """Return the age of the incident as a human-readable string"""
+        if not self.stateful:
+            return ""
+
         comparison_date = timezone.now() - self.age
         return timesince(comparison_date)
 

--- a/tests/incident/test_incident.py
+++ b/tests/incident/test_incident.py
@@ -89,3 +89,35 @@ class IncidentLevelTests(TestCase):
     def test_level_str_returns_name_of_level(self):
         incident = StatefulIncidentFactory(level=1)
         self.assertEqual(incident.pp_level(), "Critical")
+
+
+class IncidentAgeTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_given_open_incident_then_returns_age_from_start_time_to_now(self):
+        open_incident = StatefulIncidentFactory()
+        self.assertAlmostEqual(open_incident.age, timezone.now() - open_incident.start_time, delta=timedelta(seconds=1))
+
+    def test_given_closed_incident_then_returns_age_from_start_time_to_end_time(self):
+        closed_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=1), end_time=timezone.now()
+        )
+        self.assertEqual(closed_incident.age, closed_incident.end_time - closed_incident.start_time)
+
+    def test_given_stateless_incident_then_return_none(self):
+        self.assertIsNone(StatelessIncidentFactory().age)
+
+
+class IncidentHumanizeAgeTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_given_stateless_incident_then_returns_empty_string(self):
+        self.assertEqual(StatelessIncidentFactory().humanize_age, "")


### PR DESCRIPTION
## Scope and purpose

In a recent demo we got the traceback after filtering for very old incidents (probably the last time we used stateless incidents):

```
File "/home/johanna/Argus/src/argus/incident/models.py", line 475, in age
    return end_time - self.start_time
           ~~~~~~~~~^~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'NoneType' and 'datetime.datetime'
```


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
