### PR TITLE
Fix theme preview foreground color on color swatches

### DIFF
--- a/changelog.d/1834.fixed.md
+++ b/changelog.d/1834.fixed.md
@@ -1,0 +1,1 @@
+Fix theme preview showing wrong foreground text color on color swatches

--- a/src/argus/htmx/tailwindtheme/snippets/10-tailwind.css
+++ b/src/argus/htmx/tailwindtheme/snippets/10-tailwind.css
@@ -42,3 +42,4 @@
 }
 
 @source inline("htmx-request");
+@source inline("bg-base-100 bg-base-200 bg-base-300 bg-primary bg-secondary bg-accent bg-neutral bg-info bg-success bg-warning bg-error text-base-content text-primary-content text-secondary-content text-accent-content text-neutral-content text-info-content text-success-content text-warning-content text-error-content");

--- a/src/argus/htmx/templates/htmx/user/_preference_choice_preview_theme.html
+++ b/src/argus/htmx/templates/htmx/user/_preference_choice_preview_theme.html
@@ -1,14 +1,9 @@
 <!-- htmx/user/_preference_choice_preview_theme.html -->
 <div class="flex items-center gap-1 p-1 rounded-sm bg-transparent"
      data-theme="{{ current_theme }}">
-  {% comment %}
-        // Necessary for tailwind to include these classes in the build
-        bg-primary, bg-secondary, bg-accent, bg-neutral, bg-info, bg-success, bg-warning, bg-error, bg-base-100,
-        bg-base-200, bg-base-300
-  {% endcomment %}
   {% for color_class in theme_colors %}
     <div class="tooltip tooltip-left" data-tip="{{ color_class|slice:"3:" }}">
-      <div class="flex items-center justify-center h-5 w-5 rounded-sm border-1 border-base-300 {{ color_class }} badge-{{ color_class|slice:"3:" }}">
+      <div class="flex items-center justify-center h-5 w-5 rounded-sm border-1 border-base-300 {{ color_class }} {% if 'base' in color_class %}text-base-content{% else %}text-{{ color_class|slice:"3:" }}-content{% endif %}">
         T
       </div>
     </div>

--- a/src/argus/htmx/templates/tailwind/10-tailwind.css
+++ b/src/argus/htmx/templates/tailwind/10-tailwind.css
@@ -42,3 +42,4 @@
 }
 
 @source inline("htmx-request");
+@source inline("bg-base-100 bg-base-200 bg-base-300 bg-primary bg-secondary bg-accent bg-neutral bg-info bg-success bg-warning bg-error text-base-content text-primary-content text-secondary-content text-accent-content text-neutral-content text-info-content text-success-content text-warning-content text-error-content");


### PR DESCRIPTION
## Scope and purpose

Fixes #1834.

The theme preview in user preferences used DaisyUI `badge-*` modifier classes to set text color, but in DaisyUI v5 these only set CSS variables that require the `.badge` base class. Replace with `text-*-content` utility classes and source them via `@source inline` in the Tailwind config.

<img width="709" height="220" alt="image" src="https://github.com/user-attachments/assets/9e4157b1-5551-4630-a325-3abfcaa424e5" />

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If this results in changes in the UI: Added screenshots of the before and after