### PR TITLE
Make version string selectable

### DIFF
--- a/changelog.d/1661.fixed.md
+++ b/changelog.d/1661.fixed.md
@@ -1,0 +1,1 @@
+Make version string selectable by separating text from copy button

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -26,16 +26,17 @@
   <li class="menu-title menu-divider" aria-hidden="true">
     <div class="divider divider-secondary my-0"></div>
   </li>
-  <li class="overflow-hidden">
-    <button class="text-xs tooltip grid! grid-cols-[1fr_auto] w-full gap-2"
+  <li aria-hidden="true" class="pointer-events-none h-0 p-0 m-0"></li>
+  <div class="text-xs grid grid-cols-[1fr_auto] gap-2 px-3 py-1.5">
+    <div class="space-y-2 text-left overflow-hidden select-text">
+      <span>Argus version:</span>
+      <span class="block truncate">{{ short_version }}</span>
+    </div>
+    <button class="btn btn-ghost btn-xs pointer-events-auto"
             aria-label="Copy Argus version to clipboard"
-            data-tip="Copy version to clipboard"
+            title="Copy version to clipboard"
             onclick="navigator.clipboard.writeText('{{ version }}')">
-      <div class="space-y-2 text-left overflow-hidden">
-        <span>Argus version:</span>
-        <span class="block truncate">{{ short_version }}</span>
-      </div>
       <i class="fa-solid fa-copy"></i>
     </button>
-  </li>
+  </div>
 </ul>

--- a/src/argus/htmx/templates/registration/login.html
+++ b/src/argus/htmx/templates/registration/login.html
@@ -21,13 +21,13 @@
           {% endfor %}
         {% endif %}
       </section>
-      <div class="w-full flex justify-start mt-2">
-        <button class="btn btn-ghost btn-sm text-xs font-normal opacity-70 hover:opacity-100 transition tooltip flex items-center gap-1"
+      <div class="w-full flex justify-start items-center gap-1 mt-2 px-1 text-xs font-normal opacity-70">
+        <span class="select-text">Argus version:</span>
+        <span class="truncate select-text">{{ version }}</span>
+        <button class="btn btn-ghost btn-xs tooltip"
                 aria-label="Copy Argus version to clipboard"
                 data-tip="Copy version to clipboard"
                 onclick="navigator.clipboard.writeText('{{ version }}')">
-          <span>Argus version:</span>
-          <span class="truncate">{{ version }}</span>
           <i class="fa-solid fa-copy"></i>
         </button>
       </div>


### PR DESCRIPTION
## Scope and purpose

Fixes #1661.

The version string was rendered entirely inside a `<button>`, preventing users from selecting/copying the text with the mouse. This separates the version text from the copy-to-clipboard button so the text is selectable while still providing a copy icon.

### Screenshots

<img width="256" height="387" alt="image" src="https://github.com/user-attachments/assets/602c0fcd-b857-4900-8fbd-adc90b9b6d41" />
<img width="339" height="95" alt="image" src="https://github.com/user-attachments/assets/ff2dfc8a-5688-4994-8358-3513603a4165" />


## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after