### PR TITLE
Add maxlength and character counter to filter name input

### DIFF
--- a/changelog.d/1801.fixed.md
+++ b/changelog.d/1801.fixed.md
@@ -1,0 +1,1 @@
+Add maxlength and character counter to filter name input

--- a/src/argus/htmx/templates/htmx/forms/input_field.html
+++ b/src/argus/htmx/templates/htmx/forms/input_field.html
@@ -20,6 +20,7 @@
                type="{{ type|default:"" }}"
                placeholder="{{ placeholder|default:"" }}"
                value="{{ value|default:"" }}"
+               {% if maxlength %}maxlength="{{ maxlength }}" _="on input put `${my.value.length}/{{ maxlength }}` into next .char-counter" {% endif %}
                {% if is_required %}required{% endif %}
                autocomplete="off"
                class="{{ input_classes|default:"input input-bordered border-b w-full" }}" />
@@ -34,6 +35,11 @@
     <div class="label">
       {% if help_text %}<span class="label-text-alt">{{ help_text }}</span>{% endif %}
       {% for error in errors %}<span class="label-text-alt text-error">{{ error }}</span>{% endfor %}
+    </div>
+  {% endif %}
+  {% if maxlength %}
+    <div class="text-right text-xs opacity-80">
+      <span class="char-counter">0/{{ maxlength }}</span>
     </div>
   {% endif %}
 </div>

--- a/src/argus/htmx/templates/htmx/incident/_filter_create_modal.html
+++ b/src/argus/htmx/templates/htmx/incident/_filter_create_modal.html
@@ -4,5 +4,5 @@
   hx-include="#incident-filter-box fieldset, [name='filter_name']"
 {% endblock form_control %}
 {% block dialogform %}
-  {% include "htmx/forms/input_field.html" with label=" Filter name" is_required="true" name="filter_name" type="text" %}
+  {% include "htmx/forms/input_field.html" with label=" Filter name" is_required="true" name="filter_name" type="text" maxlength="40" %}
 {% endblock dialogform %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1801.

The filter name field had no indication of the 40-character limit. When exceeded, users only saw "Failed to create filter" with no explanation.

This adds `maxlength="40"` to the input (preventing the issue entirely) and a live character counter (`0/40`) so users know the limit upfront.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after