### PR TITLE
Remove last mentions of `synced` keyword in destination tests and docs

### DIFF
--- a/docs/integrations/notifications/email-plugin.rst
+++ b/docs/integrations/notifications/email-plugin.rst
@@ -9,9 +9,10 @@ This plugin uses the email server settings provided by Django itself to
 configure the server.
 
 The settings-field for an email-destination contains an
-``email_address``-field. It also contains a read-only ``synced``-field, which
-is used for some magic if the User model-instance has its
-``email_address``-field set. If the email-address has ``synced`` set to True, that
+``email_address``-field.
+
+The managed-field will be set to ``True`` if the User model-instance has its
+``email_address``-field set. If the email-address has ``managed`` set to ``True``, that
 email-address is read-only as far as the API is concerned, because the address
 on the User is synced to that specific destination.
 

--- a/docs/integrations/notifications/writing-notification-plugins.rst
+++ b/docs/integrations/notifications/writing-notification-plugins.rst
@@ -78,7 +78,7 @@ of settings for a possible destination and should return True if a destination
 with such settings exists in the given QuerySet.
 
 ``raise_if_not_deletable`` should check if a given destination can be deleted.
-This is used in case some destinations are synced from an outside source and
+This is used in case some destinations are managed by an outside source and
 should not be able to be deleted by a user. If that is the case a
 ``NotDeletableError`` should be raised. If not simply return None.
 

--- a/tests/notificationprofile/destinations/test_sms.py
+++ b/tests/notificationprofile/destinations/test_sms.py
@@ -341,8 +341,8 @@ class SMSDestinationSendTests(TestCase):
             media=Media.objects.get(slug="email"),
             settings={
                 "email_address": email_address,
-                "synced": False,
             },
+            managed=False,
         )
 
         phone_numbers = SMSNotification.get_relevant_addresses(

--- a/tests/notificationprofile/test_media.py
+++ b/tests/notificationprofile/test_media.py
@@ -33,7 +33,8 @@ class FindDestinationsTest(TestCase):
         self.extra_destination1 = factories.DestinationConfigFactory(
             user=self.user1,
             media=Media.objects.get(slug="email"),
-            settings={"email": "a@b.ca", "synced": False},
+            settings={"email": "a@b.ca"},
+            managed=False,
         )
 
         self.user2 = PersonUserFactory()
@@ -41,7 +42,8 @@ class FindDestinationsTest(TestCase):
         self.extra_destination2 = factories.DestinationConfigFactory(
             user=self.user2,
             media=Media.objects.get(slug="email"),
-            settings={"email": "b@c.de", "synced": False},
+            settings={"email": "b@c.de"},
+            managed=False,
         )
 
         # Create a filter that matches your test incident


### PR DESCRIPTION
## Scope and purpose

Follow up to #1802.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
  - no outside change
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
