### PR TITLE
Remove color_status from default column preset

### DIFF
--- a/changelog.d/1683.changed.md
+++ b/changelog.d/1683.changed.md
@@ -1,0 +1,1 @@
+Remove color_status from the default built-in column preset

--- a/src/argus/htmx/defaults.py
+++ b/src/argus/htmx/defaults.py
@@ -8,7 +8,6 @@ from argus.site.settings import get_json_env, get_str_env
 HTMX_PATH_DEFAULT = "htmx-2.0.2.min.js"
 HYPERSCRIPT_PATH_DEFAULT = "hyperscript-0.9.13.min.js"
 INCIDENT_TABLE_COLUMNS = [
-    "color_status",
     "row_select",
     "start_time",
     "combined_status",


### PR DESCRIPTION
## Scope and purpose

Fixes #1683.

The color status indicator column is redundant with the combined status column. This removes it from the default built-in column preset.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)