### PR TITLE
Add REANNZ Prometheus glue service to list of integrations

### DIFF
--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -75,10 +75,10 @@ Alertmanager (Prometheus)
 | Home: https://prometheus.io/docs/alerting/latest/alertmanager/
 | Source: https://github.com/REANNZ/prometheus-argus-glue
 
-Made by`REANNZ <https://www.reannz.co.nz/>`_.
+Made by `REANNZ <https://www.reannz.co.nz/>`_.
 
 ``prometheus-argus-glue`` is a webhook the alertmanager talks to. In addition
-there is a sync script ``argys-sync`` that cleans up alerts that have been
+there is a sync script ``argus-sync`` that cleans up alerts that have been
 silenced in alertmanager.
 
 NAGIOS

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -69,6 +69,18 @@ This will be available as source and on PyPI after more polish is done.
 Other glue services
 -------------------
 
+Alertmanager (Prometheus)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Home: https://prometheus.io/docs/alerting/latest/alertmanager/
+| Source: https://github.com/REANNZ/prometheus-argus-glue
+
+Made by`REANNZ <https://www.reannz.co.nz/>`_.
+
+``prometheus-argus-glue`` is a webhook the alertmanager talks to. In addition
+there is a sync script ``argys-sync`` that cleans up alerts that have been
+silenced in alertmanager.
+
 NAGIOS
 ~~~~~~
 


### PR DESCRIPTION
## Scope and purpose

Add the REANNZ glue services for alertmanager (Prometheus) to the known glue services list. 


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
