### PR TITLE
Fix updating of managed destinations

### DIFF
--- a/changelog.d/1860.fixed.md
+++ b/changelog.d/1860.fixed.md
@@ -1,1 +1,2 @@
 Fixed updating managed destinations
+Make it possible to change the label of managed destinations

--- a/changelog.d/1860.fixed.md
+++ b/changelog.d/1860.fixed.md
@@ -1,0 +1,1 @@
+Fixed updating managed destinations

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -136,9 +136,14 @@ class NotificationMedium(ABC):
     def update(destination: DestinationConfig, validated_data: dict) -> DestinationConfig | NoneType:
         """Updates a destination
 
-        If the destination is marked as managed, a copy of the original will be
-        made before changing the destination.
+        If the destination is marked as managed and the settings are being updated,
+        a copy of the original will be made before changing the destination.
         """
+        if "label" in validated_data and "settings" not in validated_data:
+            destination.label = validated_data.get("label")
+            destination.save()
+            return destination
+
         original_destination = {}
         if destination.managed:
             # copy the managed destination to create a clone after the changes are

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -139,20 +139,29 @@ class NotificationMedium(ABC):
         If the destination is marked as managed, a copy of the original will be
         made before changing the destination.
         """
+        original_destination = {}
         if destination.managed:
-            # clone the mananged destination so that it doesn't need to be resynced
-            managed_destination = DestinationConfig(
-                user=destination.user,
-                media_id=destination.media_id,
+            # copy the managed destination to create a clone after the changes are
+            # applied to the original destination
+            # this needs to be done this way due to the 'unique_destination_per_user'
+            # constraint on destinations
+            original_destination = {
+                "user": destination.user,
+                "media_id": destination.media_id,
                 # don't create a label in order to avoid duplicate label
-                settings=destination.settings,
-                managed=True,
-            )
-            managed_destination.save()
+                "settings": destination.settings.copy(),
+                "managed": True,
+            }
 
         # update destination with known id instead of returning a new one
         destination.label = validated_data.get("label", destination.label)
         destination.settings = validated_data.get("settings", destination.settings)
         destination.managed = False
         destination.save()
+
+        if original_destination:
+            # finally clone the original destination
+            managed_destination = DestinationConfig(**original_destination)
+            managed_destination.save()
+
         return destination

--- a/tests/notificationprofile/destinations/test_email.py
+++ b/tests/notificationprofile/destinations/test_email.py
@@ -346,6 +346,20 @@ class EmailDestinationViewTests(APITestCase):
             new_settings["email_address"],
         )
 
+    def test_given_label_to_update_managed_email_destination_then_it_should_update(self):
+        data = {"label": "new_label"}
+        response = self.user1_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.managed_email_destination.pk}/",
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.managed_email_destination.refresh_from_db()
+        self.assertEqual(
+            self.managed_email_destination.label,
+            data["label"],
+        )
+        self.assertTrue(self.managed_email_destination.managed)
+
     def test_given_settings_to_update_managed_email_destination_then_it_should_update_and_create_copy_of_old_settings(
         self,
     ):

--- a/tests/notificationprofile/destinations/test_email.py
+++ b/tests/notificationprofile/destinations/test_email.py
@@ -346,6 +346,26 @@ class EmailDestinationViewTests(APITestCase):
             new_settings["email_address"],
         )
 
+    def test_given_settings_to_update_managed_email_destination_then_it_should_update_and_create_copy_of_old_settings(
+        self,
+    ):
+        old_settings = self.managed_email_destination.settings.copy()
+        new_settings = {
+            "email_address": "test2@example.com",
+        }
+        response = self.user1_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.managed_email_destination.pk}/",
+            data={"settings": new_settings},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.managed_email_destination.refresh_from_db()
+        self.assertEqual(
+            self.managed_email_destination.settings["email_address"],
+            new_settings["email_address"],
+        )
+        self.assertFalse(self.managed_email_destination.managed)
+        self.assertTrue(DestinationConfig.objects.filter(managed=True, settings=old_settings).exists())
+
     def test_should_not_allow_updating_email_destination_with_duplicate_email_address(self):
         settings = {"email_address": "test2@example.com"}
         email_destination_pk = DestinationConfigFactory(


### PR DESCRIPTION
## Scope and purpose

When working on reproducing #930 I noticed that it was not possible to change the managed email destination I have. I always got the error 

```trb
Traceback (most recent call last):
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "unique_destination_per_user"
DETAIL:  Key (user_id, settings)=(2, {"email_address": "hannah.stewart@<factory.faker.Faker object at 0x75bcff1deb10>"}) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/johanna/Argus/tests/notificationprofile/destinations/test_email.py", line 369, in test_given_settings_to_update_managed_email_destination_then_it_should_update_and_create_copy_of_old_settings
    response = self.user1_rest_client.patch(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/test.py", line 315, in patch
    response = super().patch(
               ^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/test.py", line 221, in patch
    return self.generic('PATCH', path, data, content_type, **extra)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/test.py", line 237, in generic
    return super().generic(
           ^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/test/client.py", line 671, in generic
    return self.request(**r)
           ^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/test.py", line 289, in request
    return super().request(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/test.py", line 241, in request
    request = super().request(**kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/test/client.py", line 1087, in request
    self.check_exception(response)
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/test/client.py", line 802, in check_exception
    raise exc_value
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/views.py", line 515, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/views.py", line 475, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
    raise exc
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/views.py", line 512, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/drf_spectacular/drainage.py", line 207, in wrapped_method
    return method(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/mixins.py", line 82, in partial_update
    return self.update(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/drf_spectacular/drainage.py", line 207, in wrapped_method
    return method(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/drf_rw_serializers/mixins.py", line 13, in update
    self.perform_update(write_serializer)
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/mixins.py", line 78, in perform_update
    serializer.save()
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/rest_framework/serializers.py", line 205, in save
    self.instance = self.update(self.instance, validated_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/src/argus/notificationprofile/v2/serializers.py", line 167, in update
    updated_destination = medium.update(destination, validated_data)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/src/argus/notificationprofile/media/base.py", line 151, in update
    managed_destination.save()
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/base.py", line 902, in save
    self.save_base(
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/base.py", line 1008, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/base.py", line 1169, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/base.py", line 1210, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/query.py", line 1873, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1882, in execute_sql
    cursor.execute(sql, params)
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/johanna/Argus/.tox/py311-django52/lib/python3.11/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.IntegrityError: duplicate key value violates unique constraint "unique_destination_per_user"
DETAIL:  Key (user_id, settings)=(2, {"email_address": "hannah.stewart@<factory.faker.Faker object at 0x75bcff1deb10>"}) already exists.
```

This bug was introduced in #1802. It tries to create a copy of a destination before applying the changes, but the problem is that the constraint `unique_destination_per_user` forbids a user from having multiple destinations with the same settings.

Therefore we will first copy all attributes from the original destination into a dict, then do the changes and then afterwards create a new destination with these copied values. 

This PR also does an early exit if only the label should be changed and no settings, because for that no copy needs to be made and the label can simply be changed in the destination.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
