### PR TITLE
Fix compact severity column filter dropdown width

### DIFF
--- a/changelog.d/1866.fixed.md
+++ b/changelog.d/1866.fixed.md
@@ -1,0 +1,1 @@
+Fix compact severity column filter dropdown being constrained by narrow column width

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_compact_severity_filter.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_compact_severity_filter.html
@@ -9,7 +9,7 @@
     <i class="fa-solid fa-magnifying-glass text-xs"></i>
   </button>
   <div id="{{ column.name }}-dropdown-content"
-       class="dropdown-content bg-base-100 p-2 mt-1 rounded-box shadow border-2 border-primary z-10"
+       class="dropdown-content bg-base-100 p-2 mt-1 rounded-box shadow border-2 border-primary z-10 w-max h-max"
        tabindex="-1">
     <form class="incident-list-param">
       <div aria-labelledby="{{ field.name }}-label">


### PR DESCRIPTION
## Scope and purpose

Fixes #1866.

Add `w-max h-max` to the compact severity filter dropdown, matching the regular filterable column header. Without this, the dropdown is constrained by the narrow `w-[1%]` column width.

### Screenshots

| Before | After |
| --- | --- |
| <img width="175" height="194" alt="image" src="https://github.com/user-attachments/assets/3486ffb0-a80e-4c92-9b6a-8a1213140842" /> | <img width="182" height="156" alt="image" src="https://github.com/user-attachments/assets/22620d27-38e9-4b41-9dbf-37b300012f3a" /> |


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->