### PR TITLE
Improve banner message styling

### DIFF
--- a/changelog.d/1867.changed.md
+++ b/changelog.d/1867.changed.md
@@ -1,0 +1,1 @@
+Improve banner message styling and make it themeable via CSS variables

--- a/docs/customization/htmx-frontend.rst
+++ b/docs/customization/htmx-frontend.rst
@@ -38,6 +38,8 @@ You can merge your urlpatterns with the apps' urlpatterns via the
 ``argus.site.utils.get_urlpatterns`` function, see ``argus.htmx.urls`` for an
 example.
 
+.. _themes-and-styling:
+
 Themes and styling
 ==================
 

--- a/docs/reference/site-specific-settings.rst
+++ b/docs/reference/site-specific-settings.rst
@@ -390,6 +390,12 @@ Special environment settings
   processors list in the ``django.template.backends.django.DjangoTemplates``
   template backend.
 
+* The banner can be customized per theme by setting CSS variables in a theme
+  definition: ``--color-banner`` (border/background accent),
+  ``--color-banner-content`` (text), and ``--banner-bg-opacity`` (background
+  opacity as a percentage, default ``25%``). See :ref:`themes-and-styling` for
+  how to customize themes.
+
 Debugging settings
 ------------------
 

--- a/src/argus/htmx/tailwindtheme/snippets/16-site-banner.css
+++ b/src/argus/htmx/tailwindtheme/snippets/16-site-banner.css
@@ -1,0 +1,21 @@
+@layer base {
+  :root {
+    --color-banner: #75C7F0;
+    --color-banner-content: var(--color-base-content);
+    --banner-bg-opacity: 25%;
+  }
+}
+.site-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.375rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 600;
+  border: 1.5px solid var(--color-banner);
+  border-radius: var(--radius-box, 1rem);
+  background-color: color-mix(in srgb, var(--color-banner) var(--banner-bg-opacity), transparent);
+  color: var(--color-banner-content);
+}

--- a/src/argus/htmx/templates/htmx/incident/_incident_toolbar.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_toolbar.html
@@ -1,4 +1,4 @@
-<section class="flex flex-col gap-2 mt-1">
+<section class="flex flex-col gap-2">
   <div id="filter-controls-box"
        class="border-2 border-primary rounded-box p-2 flex flex-wrap gap-0.5 items-center">
     {% include "htmx/incident/_filter_controls.html" %}

--- a/src/argus/htmx/templates/htmx_base.html
+++ b/src/argus/htmx/templates/htmx_base.html
@@ -34,28 +34,13 @@
     {% block header %}
       <h1>Argus Server: {{ page_title }}</h1>
     {% endblock header %}
-    {% if banner_message %}
-      {# djlint:off H021 #}
-      <div class="relative isolate flex justify-center gap-x-4 overflow-hidden bg-red-700 px-4 py-1.5">
-        <div class="absolute left-[max(-7rem,calc(50%-52rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
-             aria-hidden="true">
-          <div class="aspect-[577/310] w-[36.0625rem] bg-linear-to-r from-red-100 to-red-950 opacity-30"
-               style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)">
-          </div>
-        </div>
-        <div class="absolute left-[max(45rem,calc(50%+8rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
-             aria-hidden="true">
-          <div class="aspect-[577/310] w-[36.0625rem] bg-linear-to-r from-red-100 to-red-950 opacity-30"
-               style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)">
-          </div>
-        </div>
-        <p class="text-sm leading-6 text-white">
-          <strong>{{ banner_message }}</strong>
-        </p>
-      </div>
-      {# djlint:on H021 #}
-    {% endif %}
     <main class="flex flex-col flex-1 min-h-0 space-y-2 p-1">
+      {% if banner_message %}
+        <output class="site-banner mt-1">
+          <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+          <span>{{ banner_message }}</span>
+        </output>
+      {% endif %}
       {% block main %}
       {% endblock main %}
     </main>


### PR DESCRIPTION
## Scope and purpose

Fixes #1867.

Replace the hardcoded red banner with a themeable, polished banner component. The banner color can be customized per theme via `--color-banner` and `--color-banner-content` CSS variables.

### Screenshots

<img width="792" height="262" alt="image" src="https://github.com/user-attachments/assets/31d1e3c6-9982-4dab-a941-67f5921deabf" />
<img width="907" height="237" alt="image" src="https://github.com/user-attachments/assets/f68d54e8-4976-45c7-bdc2-ac1d2dc97e10" />

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)