### PR TITLE
Add type-ahead search to sources filter

### DIFF
--- a/changelog.d/1864.changed.md
+++ b/changelog.d/1864.changed.md
@@ -1,0 +1,1 @@
+Add type-ahead search to sources filter

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -2,7 +2,6 @@ import logging
 
 from django import forms
 from django.contrib import messages
-from django.http import QueryDict
 from django.urls import reverse
 from django.views.generic import ListView
 
@@ -26,24 +25,7 @@ class RangeInput(forms.NumberInput):
     template_name = "django/forms/widgets/range.html"
 
 
-class TagFieldMixin:
-    def _init_tag_field(self, *args, **kwargs):
-        """
-        Initializes the 'tags' field widget and choices as key=value strings, and dynamically adds submitted tags.
-        """
-        self.fields["tags"].widget.partial_get = reverse("htmx:search-tags")
-        data = args[0] if args else None
-        if not data:
-            self.fields["tags"].choices = []
-            return
-
-        tags = data.getlist("tags") if isinstance(data, QueryDict) else data.get("tags", [])
-
-        choices = [(tag, tag) for tag in tags]
-        self.fields["tags"].choices = choices
-
-
-class IncidentFilterForm(TagFieldMixin, forms.Form):
+class IncidentFilterForm(forms.Form):
     open = forms.IntegerField(
         widget=RangeInput(attrs={"step": "1", "min": min(OpenStatus).value, "max": max(OpenStatus).value}),
         label="Open State",
@@ -65,9 +47,10 @@ class IncidentFilterForm(TagFieldMixin, forms.Form):
         label="Source Types",
     )
     sourceSystemIds = forms.MultipleChoiceField(
-        widget=BadgeDropdownMultiSelect(
-            attrs={"placeholder": "select sources..."},
+        widget=SearchDropdownMultiSelect(
+            attrs={"placeholder": "search sources..."},
             partial_get=None,
+            extra={"preload": True, "display_name": "sources"},
         ),
         required=False,
         label="Sources",
@@ -113,9 +96,7 @@ class IncidentFilterForm(TagFieldMixin, forms.Form):
         # mollify tests
         partial_get = reverse("htmx:incident-filter")
 
-        self.fields["sourceSystemIds"].widget.partial_get = partial_get
-        source_choices = SourceSystem.objects.order_by("name").values_list("id", "name")
-        self.fields["sourceSystemIds"].choices = tuple(source_choices)
+        self._init_source_field()
         self._init_tag_field(*args, **kwargs)
 
         self.fields["source_types"].widget.partial_get = partial_get
@@ -125,6 +106,29 @@ class IncidentFilterForm(TagFieldMixin, forms.Form):
         self.fields["event_types"].widget.partial_get = partial_get
         event_type_choices = Event.Type.choices
         self.fields["event_types"].choices = event_type_choices
+
+    def _init_tag_field(self, *args, **kwargs):
+        """
+        Initializes the 'tags' field widget and choices as key=value strings, and dynamically adds submitted tags.
+        """
+        self.fields["tags"].widget.partial_get = reverse("htmx:search-tags")
+        query_dict = args[0] if args else None
+        if not query_dict:
+            self.fields["tags"].choices = []
+            return
+
+        tags = query_dict.get("tags", [])
+
+        choices = [(tag, tag) for tag in tags]
+        self.fields["tags"].choices = choices
+
+    def _init_source_field(self):
+        """
+        Initializes the 'sourceSystemIds' field widget for type-ahead search,
+        pre-loading all sources for client-side filtering.
+        """
+        source_choices = SourceSystem.objects.order_by("name").values_list("id", "name")
+        self.fields["sourceSystemIds"].choices = tuple(source_choices)
 
     def clean_tags(self):
         tags = self.cleaned_data["tags"]

--- a/src/argus/htmx/templates/htmx/forms/search_select_multiple.html
+++ b/src/argus/htmx/templates/htmx/forms/search_select_multiple.html
@@ -6,9 +6,10 @@
         multiple="true">
   {% for _, options, _ in widget.optgroups %}
     {% for option in options %}
-      {% if option.selected %}
+      {% if option.selected or widget.extra.preload %}
         {% block show_selected %}
-          <option value="{{ option.value }}" selected="selected">{{ option.label }}</option>
+          <option value="{{ option.value }}"
+                  {% if option.selected %}selected="selected"{% endif %}>{{ option.label }}</option>
         {% endblock show_selected %}
       {% endif %}
     {% endfor %}
@@ -17,8 +18,9 @@
 <script>
 (function () {
     const selectId = '#id_{{ widget.name }}';
-    const parameterName = '{{ widget.name }}';
+    const parameterName = '{% if widget.extra.display_name %}{{ widget.extra.display_name }}{% else %}{{ widget.name }}{% endif %}';
     const searchUrl = '{{ widget.partial_get }}';
+    const preload = {{ widget.extra.preload|yesno:"true,false" }};
 
     const choices = new Choices(selectId, {
         removeItemButton: true,
@@ -26,12 +28,16 @@
         duplicateItemsAllowed: false,
         shouldSort: false,
         searchEnabled: true,
-        searchChoices: false,
+        searchChoices: preload,
         loadingText: 'Loading...',
         noResultsText: `No ${parameterName} found`,
         noChoicesText: `No ${parameterName} to choose from`,
         itemSelectText: '',
-        searchFloor: 2,
+        searchFloor: preload ? 1 : 2,
+        fuseOptions: {
+            threshold: 0.4,
+            ignoreLocation: true,
+        },
         removeItemIconText: () => '',
         classNames: {
             containerOuter: ['choices', 'dropdown', 'max-w-sm', 'self-center'],
@@ -40,6 +46,8 @@
             listItems: ['choices-list-items'],
         }
     });
+
+    if (preload) return;
 
     const choicesElement = choices.passedElement.element;
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1864.

Replace the static badge dropdown for the sources filter with a Choices.js type-ahead search. All sources are pre-loaded for client-side filtering, keeping the UX snappy while allowing users to quickly find sources by name.

### Screenshots

#### All available sources are shown by default, and uses client-side filtering
<img width="285" height="196" alt="image" src="https://github.com/user-attachments/assets/5f950e7d-3c21-434d-9ab2-3724d28cf563" />

#### The search is fuzzy with a slight tolerance for typos, will match options that almost match.
<img width="279" height="101" alt="image" src="https://github.com/user-attachments/assets/df80e39c-8277-47b2-9f76-07f45c613097" />

#### Selecting a source adds a badge, exactly like for Tags
<img width="271" height="94" alt="image" src="https://github.com/user-attachments/assets/66944847-7619-4df9-9c5f-af4050f89b52" />

#### No results dropdown
<img width="300" height="116" alt="image" src="https://github.com/user-attachments/assets/ea16237f-9887-4551-a489-dfce578e3515" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)