### PR TITLE
Replace tri-state range sliders with styled dropdown selects

### DIFF
--- a/changelog.d/1865.changed.md
+++ b/changelog.d/1865.changed.md
@@ -1,0 +1,1 @@
+Replace tri-state range sliders with styled dropdown selects for State and Acknowledged filters

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -7,7 +7,7 @@ from django.views.generic import ListView
 
 from argus.auth.utils import get_preference, get_preference_obj
 from argus.filter import get_filter_backend
-from argus.htmx.widgets import BadgeDropdownMultiSelect, SearchDropdownMultiSelect
+from argus.htmx.widgets import BadgeDropdownMultiSelect, DropdownRadioSelect, SearchDropdownMultiSelect
 from argus.incident.constants import AckedStatus, Level, OpenStatus
 from argus.incident.models import Event, SourceSystem, SourceSystemType, Tag
 from argus.notificationprofile.models import Filter
@@ -26,15 +26,47 @@ class RangeInput(forms.NumberInput):
 
 
 class IncidentFilterForm(forms.Form):
-    open = forms.IntegerField(
-        widget=RangeInput(attrs={"step": "1", "min": min(OpenStatus).value, "max": max(OpenStatus).value}),
-        label="Open State",
+    OPEN_CHOICES = [
+        (OpenStatus.BOTH, "Any"),
+        (OpenStatus.OPEN, "Open"),
+        (OpenStatus.CLOSED, "Closed"),
+    ]
+    ACKED_CHOICES = [
+        (AckedStatus.BOTH, "Any"),
+        (AckedStatus.ACKED, "Yes"),
+        (AckedStatus.UNACKED, "No"),
+    ]
+
+    BADGE_NEUTRAL = "text-base-content/70 bg-base-content/15 rounded px-2 py-0.5"
+    BADGE_SUCCESS = "text-success bg-success/20 rounded px-2 py-0.5"
+    BADGE_ERROR = "text-error bg-error/20 rounded px-2 py-0.5"
+    BADGE_WARNING = "text-warning bg-warning/20 rounded px-2 py-0.5"
+
+    open = forms.TypedChoiceField(
+        coerce=int,
+        choices=OPEN_CHOICES,
+        widget=DropdownRadioSelect(
+            badge_classes={
+                str(OpenStatus.BOTH): BADGE_NEUTRAL,
+                str(OpenStatus.OPEN): BADGE_ERROR,
+                str(OpenStatus.CLOSED): BADGE_SUCCESS,
+            }
+        ),
+        label="State",
         initial=OpenStatus.BOTH.value,
         required=False,
     )
-    acked = forms.IntegerField(
-        widget=RangeInput(attrs={"step": "1", "min": min(AckedStatus).value, "max": max(AckedStatus).value}),
-        label="Acked",
+    acked = forms.TypedChoiceField(
+        coerce=int,
+        choices=ACKED_CHOICES,
+        widget=DropdownRadioSelect(
+            badge_classes={
+                str(AckedStatus.BOTH): BADGE_NEUTRAL,
+                str(AckedStatus.ACKED): BADGE_SUCCESS,
+                str(AckedStatus.UNACKED): BADGE_WARNING,
+            }
+        ),
+        label="Acknowledged",
         initial=AckedStatus.BOTH.value,
         required=False,
     )
@@ -107,6 +139,14 @@ class IncidentFilterForm(forms.Form):
         event_type_choices = Event.Type.choices
         self.fields["event_types"].choices = event_type_choices
 
+    def _init_source_field(self):
+        """
+        Initializes the 'sourceSystemIds' field widget for type-ahead search,
+        pre-loading all sources for client-side filtering.
+        """
+        source_choices = SourceSystem.objects.order_by("name").values_list("id", "name")
+        self.fields["sourceSystemIds"].choices = tuple(source_choices)
+
     def _init_tag_field(self, *args, **kwargs):
         """
         Initializes the 'tags' field widget and choices as key=value strings, and dynamically adds submitted tags.
@@ -121,14 +161,6 @@ class IncidentFilterForm(forms.Form):
 
         choices = [(tag, tag) for tag in tags]
         self.fields["tags"].choices = choices
-
-    def _init_source_field(self):
-        """
-        Initializes the 'sourceSystemIds' field widget for type-ahead search,
-        pre-loading all sources for client-side filtering.
-        """
-        source_choices = SourceSystem.objects.order_by("name").values_list("id", "name")
-        self.fields["sourceSystemIds"].choices = tuple(source_choices)
 
     def clean_tags(self):
         tags = self.cleaned_data["tags"]

--- a/src/argus/htmx/templates/htmx/forms/dropdown_radio_select.html
+++ b/src/argus/htmx/templates/htmx/forms/dropdown_radio_select.html
@@ -1,0 +1,36 @@
+<!-- htmx/forms/dropdown_radio_select.html -->
+{% spaceless %}
+  <div class="dropdown dropdown-bottom"
+       id="dropdown-{{ widget.attrs.id }}"
+       data-badge-classes='{{ widget.badge_classes_json }}'
+       onchange=" const radio = event.target; if (radio?.type === 'radio') { const label = this.querySelector('.selected-label'); const badgeClasses = JSON.parse(this.dataset.badgeClasses); label.textContent = radio.parentElement.textContent.trim(); label.className = 'selected-label flex items-center gap-1 font-medium ' + (badgeClasses[radio.value] || ''); document.activeElement.blur(); } ">
+    <button type="button"
+            tabindex="0"
+            class="show-selected-box input input-primary h-auto min-h-8 px-2 cursor-pointer flex items-center justify-between gap-1">
+      {% for _, options, _ in widget.optgroups %}
+        {% for option in options %}
+          {% if option.selected %}
+            {% with val=option.value|stringformat:'s' %}
+              <span class="selected-label flex items-center gap-1 font-medium{% for bk, bv in widget.badge_classes.items %}{% if bk == val %} {{ bv }}{% endif %}{% endfor %}">{{ option.label }}</span>
+            {% endwith %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+      <svg class="h-4 w-4 shrink-0 opacity-50 transition-transform duration-200 [:focus-within>&]:rotate-180"
+           xmlns="http://www.w3.org/2000/svg"
+           viewBox="0 0 24 24"
+           fill="none"
+           stroke="currentColor"
+           stroke-width="2"
+           stroke-linecap="round"
+           stroke-linejoin="round">
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+    <div tabindex="0"
+         role="radiogroup"
+         class="dropdown-content bg-base-100 rounded-box z-1 min-w-fit w-full max-h-80 overflow-y-auto p-2 mt-0.5 shadow-sm">
+      {% include "django/forms/widgets/multiple_input.html" %}
+    </div>
+  </div>
+{% endspaceless %}

--- a/src/argus/htmx/templates/htmx/forms/radio_option.html
+++ b/src/argus/htmx/templates/htmx/forms/radio_option.html
@@ -1,0 +1,14 @@
+<!-- htmx/forms/radio_option.html -->
+{% if widget.wrap_label %}
+  <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}
+         class="flex gap-2 items-center py-1.5 px-1 text-sm cursor-pointer">
+  {% endif %}
+  <input type="{{ widget.type }}"
+         name="{{ widget.name }}"
+         autocomplete="off"
+         {% if widget.value != None %} class="radio radio-xs radio-primary" value="{{ widget.value|stringformat:'s' }}"{% endif %}
+         {% include "django/forms/widgets/attrs.html" %}>
+  {% if widget.wrap_label %}
+    <span class="{{ widget.badge_class }}{% if widget.badge_class %} inline-block text-center min-w-12{% endif %}">{{ widget.label }}</span>
+  </label>
+{% endif %}

--- a/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
@@ -20,37 +20,13 @@
       {% for field in filter_form %}
         {% if not field.field.in_header %}
           <li class="form-control">
-            {% if "dropdownmultiselect" in field|widget_type %}
+            {% if "dropdownmultiselect" in field|widget_type or "dropdownradioselect" in field|widget_type %}
               <div class="flex flex-nowrap">
                 <label class="label">
                   <span class="label-text">{{ field.label }}</span>
                 </label>
                 {{ field }}
               </div>
-            {% elif field.name == "open" %}
-              <label class="cursor-pointer label">
-                <span class="label-text">{{ field.label }}</span>
-                <div class="pt-4">
-                  {{ field }}
-                  <div class="flex w-full justify-between gap-2 text-xs">
-                    <span>Open</span>
-                    <span>Both</span>
-                    <span>Closed</span>
-                  </div>
-                </div>
-              </label>
-            {% elif field.name == "acked" %}
-              <label class="cursor-pointer label">
-                <span class="label-text">{{ field.label }}</span>
-                <div class="pt-4">
-                  {{ field }}
-                  <div class="flex w-full justify-between gap-2 text-xs">
-                    <span>Acked</span>
-                    <span>Both</span>
-                    <span>Unacked</span>
-                  </div>
-                </div>
-              </label>
             {% elif field.name == "maxlevel" %}
               <label class="cursor-pointer label">
                 <span class="label-text">{{ field.label }}</span>

--- a/src/argus/htmx/widgets.py
+++ b/src/argus/htmx/widgets.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 
 
@@ -60,3 +62,29 @@ class SearchDropdownMultiSelect(DropdownMultiSelect):
 
 class BadgeDropdownMultiSelect(DropdownMultiSelect):
     template_name = "htmx/forms/badge_dropdown_select_multiple.html"
+
+
+class DropdownRadioSelect(forms.RadioSelect):
+    template_name = "htmx/forms/dropdown_radio_select.html"
+    option_template_name = "htmx/forms/radio_option.html"
+
+    def __init__(self, badge_classes=None, **kwargs):
+        super().__init__(**kwargs)
+        self.badge_classes = badge_classes or {}
+
+    def __deepcopy__(self, memo):
+        obj = super().__deepcopy__(memo)
+        obj.badge_classes = self.badge_classes.copy()
+        memo[id(self)] = obj
+        return obj
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex, attrs)
+        option["badge_class"] = self.badge_classes.get(str(value), "")
+        return option
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context["widget"]["badge_classes"] = self.badge_classes
+        context["widget"]["badge_classes_json"] = json.dumps(self.badge_classes)
+        return context

--- a/tests/htmx/test_widgets.py
+++ b/tests/htmx/test_widgets.py
@@ -1,0 +1,25 @@
+import json
+
+from django.test import SimpleTestCase
+
+from argus.htmx.widgets import DropdownRadioSelect
+
+
+class DropdownRadioSelectTest(SimpleTestCase):
+    def test_given_badge_classes_when_get_context_then_includes_badge_classes(self):
+        badge_classes = {"1": "text-error", "2": "text-success"}
+        widget = DropdownRadioSelect(badge_classes=badge_classes, choices=[("1", "A"), ("2", "B")])
+        context = widget.get_context("test", "1", {})
+        self.assertEqual(context["widget"]["badge_classes"], badge_classes)
+
+    def test_given_badge_classes_when_get_context_then_includes_json_serialized(self):
+        badge_classes = {"1": "text-error", "2": "text-success"}
+        widget = DropdownRadioSelect(badge_classes=badge_classes, choices=[("1", "A"), ("2", "B")])
+        context = widget.get_context("test", "1", {})
+        self.assertEqual(json.loads(context["widget"]["badge_classes_json"]), badge_classes)
+
+    def test_given_no_badge_classes_when_get_context_then_defaults_to_empty(self):
+        widget = DropdownRadioSelect(choices=[("1", "A")])
+        context = widget.get_context("test", "1", {})
+        self.assertEqual(context["widget"]["badge_classes"], {})
+        self.assertEqual(context["widget"]["badge_classes_json"], "{}")


### PR DESCRIPTION
## Scope and purpose

Fixes #1865.

Replace the range sliders for the State (Open/Closed) and Acknowledged filters with styled DaisyUI dropdown selects using radio buttons. Range sliders are a poor fit for discrete categorical choices: ambiguous thumb position, no per-option feedback, and poor accessibility.

### This pull request
* Adds a reusable `DropdownRadioSelect` widget with color-coded badge support
* Renames filter labels: "Open State" to "State", "Acked" to "Acknowledged"
* Uses clearer option labels: "Any", "Open"/"Closed", "Yes"/"No"
* Color-codes selected values to match incident table columns
* Simplifies the filterbox template by removing hardcoded field branches

## Screenshots

<!-- Add screenshots here -->
https://github.com/user-attachments/assets/dc4a64c3-b345-4445-916f-91381cf306f3

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

- [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
- [ ] Added/amended tests for new/changed code
- [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
- [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
- [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
- [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
- [X] If this results in changes in the UI: Added screenshots of the before and after
- [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)