### PR TITLE
Preserve QueryDict in _normalize_form_data

### DIFF
--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -2,6 +2,7 @@ import logging
 
 from django import forms
 from django.contrib import messages
+from django.http import QueryDict
 from django.urls import reverse
 from django.views.generic import ListView
 
@@ -31,12 +32,12 @@ class TagFieldMixin:
         Initializes the 'tags' field widget and choices as key=value strings, and dynamically adds submitted tags.
         """
         self.fields["tags"].widget.partial_get = reverse("htmx:search-tags")
-        query_dict = args[0] if args else None
-        if not query_dict:
+        data = args[0] if args else None
+        if not data:
             self.fields["tags"].choices = []
             return
 
-        tags = query_dict.get("tags", [])
+        tags = data.getlist("tags") if isinstance(data, QueryDict) else data.get("tags", [])
 
         choices = [(tag, tag) for tag in tags]
         self.fields["tags"].choices = choices
@@ -315,17 +316,13 @@ def _convert_filterblob(filterblob):
 
 
 def _normalize_form_data(request):
-    """Normalizes form data from request, especially the 'tags' parameter."""
+    """Normalizes form data from request, preserving the QueryDict."""
 
     raw_data = request.POST if request.method == "POST" else request.GET
-    data = dict(raw_data.items())
-    for key in raw_data:
-        value = raw_data.getlist(key, [])
-        if key == "tags":
-            value = _normalize_tags_param(value)
-        elif key not in ["source_types", "sourceSystemIds", "event_types"]:
-            value = value[0]
-        data[key] = value
+    data = raw_data.copy()
+    if "tags" in data:
+        tags = _normalize_tags_param(data.getlist("tags"))
+        data.setlist("tags", tags)
     return data
 
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1863.

`_normalize_form_data` converted the `QueryDict` to a plain `dict`, losing multi-value key support and requiring manual list extraction for each field. This replaces that with a `QueryDict.copy()` that only normalizes comma-separated tags, letting Django's form machinery handle multi-value fields natively.

Also fixes `TagFieldMixin._init_tag_field` to use `getlist` when receiving a `QueryDict`, since `QueryDict.get()` only returns the last value.

`DEFAULT_VALUES` is kept as a native dict as converting it to a `QueryDict` adds nothing but complexity. The value is only used once anyways.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->