### PR TITLE
Add special filters dropdown with compound filters

### DIFF
--- a/changelog.d/1879.added.md
+++ b/changelog.d/1879.added.md
@@ -1,0 +1,1 @@
+Add special filters dropdown with "Hide closed acked" and "Under maintenance" compound filters

--- a/src/argus/filter/filters.py
+++ b/src/argus/filter/filters.py
@@ -55,6 +55,11 @@ _INCIDENT_OPENAPI_CUSTOM_FILTER_PARAMETERS = [
         enum=BooleanStringOAEnum,
     ),
     OpenApiParameter(
+        name="under_maintenance",
+        description="Show only incidents that are currently under planned maintenance (`true`).",
+        enum=BooleanStringOAEnum,
+    ),
+    OpenApiParameter(
         name="tags",
         description="Fetch incidents with specified tags",
         type=str,
@@ -181,6 +186,7 @@ class IncidentFilter(filters.FilterSet):
     duration__gte = filters.NumberFilter(label="Duration", method="incident_filter")
     token_expiry = filters.BooleanFilter(label="Token expiry", method="incident_filter")
     hide_closed_acked = filters.BooleanFilter(label="Hide closed acked", method="incident_filter")
+    under_maintenance = filters.BooleanFilter(label="Under maintenance", method="incident_filter")
     filter_pk = IntegerFilter(label="Filter pk", method="incident_filter")
     notificationprofile_pk = IntegerFilter(label="Notificationprofile pk", method="incident_filter")
 
@@ -250,6 +256,10 @@ class IncidentFilter(filters.FilterSet):
         if name == "hide_closed_acked":
             if value:
                 return queryset.open_or_unacked()
+            return queryset
+        if name == "under_maintenance":
+            if value:
+                return queryset.under_maintenance()
             return queryset
         if name == "filter_pk":
             return QuerySetFilter.incidents_by_filter_pk(queryset, value)

--- a/src/argus/filter/filters.py
+++ b/src/argus/filter/filters.py
@@ -50,6 +50,11 @@ _INCIDENT_OPENAPI_CUSTOM_FILTER_PARAMETERS = [
         enum=BooleanStringOAEnum,
     ),
     OpenApiParameter(
+        name="hide_closed_acked",
+        description="Hide incidents that are both closed and acknowledged (`true`). Shows all open incidents and closed incidents that are still unacked.",
+        enum=BooleanStringOAEnum,
+    ),
+    OpenApiParameter(
         name="tags",
         description="Fetch incidents with specified tags",
         type=str,
@@ -175,6 +180,7 @@ class IncidentFilter(filters.FilterSet):
     tags = TagInFilter(label="Tags", method="incident_filter")
     duration__gte = filters.NumberFilter(label="Duration", method="incident_filter")
     token_expiry = filters.BooleanFilter(label="Token expiry", method="incident_filter")
+    hide_closed_acked = filters.BooleanFilter(label="Hide closed acked", method="incident_filter")
     filter_pk = IntegerFilter(label="Filter pk", method="incident_filter")
     notificationprofile_pk = IntegerFilter(label="Notificationprofile pk", method="incident_filter")
 
@@ -241,6 +247,10 @@ class IncidentFilter(filters.FilterSet):
                 return queryset.is_longer_than_minutes(int(value))
         if name == "token_expiry":
             return queryset.token_expiry()
+        if name == "hide_closed_acked":
+            if value:
+                return queryset.open_or_unacked()
+            return queryset
         if name == "filter_pk":
             return QuerySetFilter.incidents_by_filter_pk(queryset, value)
         if name == "notificationprofile_pk":

--- a/src/argus/filter/filterwrapper.py
+++ b/src/argus/filter/filterwrapper.py
@@ -42,6 +42,7 @@ class FilterKey(StrEnum):
 
 class SpecialFilterKey(StrEnum):
     HIDE_CLOSED_ACKED = "hide_closed_acked"
+    UNDER_MAINTENANCE = "under_maintenance"
 
 
 class FilterWrapper:
@@ -111,6 +112,10 @@ class FilterWrapper:
 
         if self.filter.get(SpecialFilterKey.HIDE_CLOSED_ACKED, False):
             fits = incident.open or not incident.acked
+            results.append(fits)
+
+        if self.filter.get(SpecialFilterKey.UNDER_MAINTENANCE, False):
+            fits = incident.planned_maintenance_tasks.current().exists()
             results.append(fits)
 
         if not results:

--- a/src/argus/filter/filterwrapper.py
+++ b/src/argus/filter/filterwrapper.py
@@ -18,6 +18,7 @@ __all__ = [
     "FilterWrapper",
     "FallbackFilterWrapper",
     "PrecisionFilterWrapper",
+    "SpecialFilterKey",
 ]
 
 
@@ -39,11 +40,16 @@ class FilterKey(StrEnum):
     MAXLEVEL = "maxlevel"
 
 
+class SpecialFilterKey(StrEnum):
+    HIDE_CLOSED_ACKED = "hide_closed_acked"
+
+
 class FilterWrapper:
     TRINARY_FILTERS = (FilterKey.OPEN, FilterKey.ACKED, FilterKey.STATEFUL)
     LIST_FILTERS = (FilterKey.SOURCE_SYSTEM_IDS, FilterKey.SOURCE_SYSTEM_TYPES, FilterKey.TAGS, FilterKey.EVENT_TYPES)
     INT_FILTERS = (FilterKey.MAXLEVEL,)
-    FILTER_KEYS = TRINARY_FILTERS + LIST_FILTERS + INT_FILTERS
+    PRIMARY_FILTER_KEYS = TRINARY_FILTERS + LIST_FILTERS + INT_FILTERS
+    FILTER_KEYS = PRIMARY_FILTER_KEYS + tuple(SpecialFilterKey)
 
     def __init__(self, filterblob: FilterBlobType):
         self.filter = filterblob.copy()
@@ -95,6 +101,22 @@ class FilterWrapper:
         incident_tristate = getattr(incident, tristate, None)
         return incident_tristate is filter_
 
+    def _incident_fits_special_filters(self, incident: Incident) -> TriState:
+        """Check compound/special filters against an incident.
+
+        Returns False if any active special filter excludes this incident,
+        None if no special filters are active.
+        """
+        results = []
+
+        if self.filter.get(SpecialFilterKey.HIDE_CLOSED_ACKED, False):
+            fits = incident.open or not incident.acked
+            results.append(fits)
+
+        if not results:
+            return None
+        return all(results)
+
     # public
 
     def event_fits(self, event) -> bool:
@@ -113,6 +135,7 @@ class FilterWrapper:
         checks["max_level"] = self._incident_fits_maxlevel(incident)
         for tristate in self.TRINARY_FILTERS:
             checks[tristate.value] = self._incident_fits_tristate(incident, tristate)
+        checks["special_filters"] = self._incident_fits_special_filters(incident)
 
         any_failed = False in checks.values()
         if any_failed:

--- a/src/argus/filter/queryset_filters.py
+++ b/src/argus/filter/queryset_filters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from argus.filter.filterwrapper import FilterWrapper, FilterBlobType
+from argus.filter.filterwrapper import FilterWrapper, FilterBlobType, SpecialFilterKey
 from argus.incident.models import Incident
 
 if TYPE_CHECKING:
@@ -55,6 +55,12 @@ def _incidents_fitting_tristates(incident_queryset, filterblob: FilterBlobType):
     return fitting_incidents.distinct()
 
 
+def _incidents_fitting_special_filters(incident_queryset, filterblob: FilterBlobType):
+    if filterblob.get(SpecialFilterKey.HIDE_CLOSED_ACKED, False):
+        incident_queryset = incident_queryset.open_or_unacked()
+    return incident_queryset.distinct()
+
+
 def _incidents_fitting_maxlevel(incident_queryset, filterblob: FilterBlobType):
     maxlevel = filterblob.get("maxlevel", None)
     if not maxlevel:
@@ -85,6 +91,7 @@ class QuerySetFilter:
         filtered_by_tristates = _incidents_fitting_tristates(incident_queryset, filterblob)
         filtered_by_maxlevel = _incidents_fitting_maxlevel(incident_queryset, filterblob)
         filtered_by_event_types = _incidents_fitting_event_types(incident_queryset, filterblob)
+        filtered_by_special = _incidents_fitting_special_filters(incident_queryset, filterblob)
 
         return (
             filtered_by_source_type
@@ -93,6 +100,7 @@ class QuerySetFilter:
             & filtered_by_tristates
             & filtered_by_maxlevel
             & filtered_by_event_types
+            & filtered_by_special
         )
 
     @classmethod

--- a/src/argus/filter/queryset_filters.py
+++ b/src/argus/filter/queryset_filters.py
@@ -58,6 +58,8 @@ def _incidents_fitting_tristates(incident_queryset, filterblob: FilterBlobType):
 def _incidents_fitting_special_filters(incident_queryset, filterblob: FilterBlobType):
     if filterblob.get(SpecialFilterKey.HIDE_CLOSED_ACKED, False):
         incident_queryset = incident_queryset.open_or_unacked()
+    if filterblob.get(SpecialFilterKey.UNDER_MAINTENANCE, False):
+        incident_queryset = incident_queryset.under_maintenance()
     return incident_queryset.distinct()
 
 

--- a/src/argus/filter/swappable/serializers.py
+++ b/src/argus/filter/swappable/serializers.py
@@ -36,3 +36,4 @@ class FilterBlobSerializer(serializers.Serializer):
         choices=Event.Type.choices,
         required=False,
     )
+    hide_closed_acked = serializers.BooleanField(required=False, default=False)

--- a/src/argus/filter/swappable/serializers.py
+++ b/src/argus/filter/swappable/serializers.py
@@ -37,3 +37,4 @@ class FilterBlobSerializer(serializers.Serializer):
         required=False,
     )
     hide_closed_acked = serializers.BooleanField(required=False, default=False)
+    under_maintenance = serializers.BooleanField(required=False, default=False)

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -7,7 +7,13 @@ from django.views.generic import ListView
 
 from argus.auth.utils import get_preference, get_preference_obj
 from argus.filter import get_filter_backend
-from argus.htmx.widgets import BadgeDropdownMultiSelect, DropdownRadioSelect, SearchDropdownMultiSelect
+from argus.filter.filterwrapper import SpecialFilterKey
+from argus.htmx.widgets import (
+    BadgeDropdownMultiSelect,
+    ButtonDropdownMultiSelect,
+    DropdownRadioSelect,
+    SearchDropdownMultiSelect,
+)
 from argus.incident.constants import AckedStatus, Level, OpenStatus
 from argus.incident.models import Event, SourceSystem, SourceSystemType, Tag
 from argus.notificationprofile.models import Filter
@@ -112,6 +118,19 @@ class IncidentFilterForm(forms.Form):
         required=False,
         label="Event Types",
     )
+    special_filters = forms.MultipleChoiceField(
+        widget=ButtonDropdownMultiSelect(
+            attrs={"placeholder": "Special filters"},
+            partial_get=None,
+        ),
+        required=False,
+        label="Special Filters",
+    )
+
+    SPECIAL_FILTER_CHOICES = [
+        (SpecialFilterKey.HIDE_CLOSED_ACKED.value, "Hide Closed & Acked"),
+        (SpecialFilterKey.UNDER_MAINTENANCE.value, "Under Maintenance"),
+    ]
 
     DEFAULT_VALUES = {
         "open": None,
@@ -121,6 +140,7 @@ class IncidentFilterForm(forms.Form):
         "tags": [],
         "maxlevel": max(Level).value,
         "event_types": [],
+        "special_filters": [],
     }
 
     def __init__(self, *args, **kwargs):
@@ -138,6 +158,9 @@ class IncidentFilterForm(forms.Form):
         self.fields["event_types"].widget.partial_get = partial_get
         event_type_choices = Event.Type.choices
         self.fields["event_types"].choices = event_type_choices
+
+        self.fields["special_filters"].widget.partial_get = partial_get
+        self.fields["special_filters"].choices = self.SPECIAL_FILTER_CHOICES
 
     def _init_source_field(self):
         """
@@ -228,6 +251,10 @@ class IncidentFilterForm(forms.Form):
         if event_types:
             filterblob["event_types"] = event_types
 
+        special_filters = self.cleaned_data.get("special_filters", [])
+        for key in special_filters:
+            filterblob[key] = True
+
         return filterblob
 
 
@@ -262,7 +289,7 @@ def incident_list_filter(request, qs, use_empty_filter=False):
             del request.session["selected_filter"]
             filter_pk, filter_obj = None, None
     if filter_obj:
-        form = IncidentFilterForm(_convert_filterblob(filter_obj.filter))
+        form = IncidentFilterForm(_convert_filterblob(filter_obj.filter.copy()))
         LOG.debug("using stored filter: %s", filter_obj.filter)
     else:
         form_data = _normalize_form_data(request)
@@ -347,6 +374,12 @@ def _convert_filterblob(filterblob):
             filterblob["acked"] = AckedStatus.UNACKED
         else:
             filterblob["acked"] = AckedStatus.BOTH
+
+    # Convert individual special filter booleans back to a list for the form
+    special_filter_keys = [key.value for key in SpecialFilterKey]
+    special_filters = [key for key in special_filter_keys if filterblob.pop(key, False)]
+    if special_filters:
+        filterblob["special_filters"] = special_filters
 
     return filterblob
 

--- a/src/argus/htmx/templates/htmx/forms/button_dropdown_select_multiple.html
+++ b/src/argus/htmx/templates/htmx/forms/button_dropdown_select_multiple.html
@@ -1,0 +1,20 @@
+<!-- htmx/forms/button_dropdown_select_multiple.html -->
+<div class="dropdown dropdown-bottom"
+     id="dropdown-{{ widget.attrs.id }}"
+     hx-trigger="change from:(find #{{ widget.attrs.id }})"
+     hx-swap="outerHTML"
+     hx-target="find .btn"
+     hx-select="#dropdown-{{ widget.attrs.id }} .btn"
+     hx-get="{{ widget.partial_get }}"
+     hx-include="find .dropdown-content"
+     hx-on::after-settle="if(typeof checkFilterDirty === 'function') requestAnimationFrame(checkFilterDirty)">
+  <button type="button" class="btn btn-ghost btn-xs">
+    {{ widget.attrs.placeholder }}
+    {% if widget.selected_count %}<span class="badge badge-primary badge-sm">{{ widget.selected_count }}</span>{% endif %}
+  </button>
+  <div tabindex="0"
+       class="dropdown-content bg-base-100 rounded-box z-1 w-max max-h-80 overflow-y-auto p-2 mt-0.5 shadow-sm">
+    <input type="hidden" name="{{ widget.name }}" value="">
+    {% include "django/forms/widgets/multiple_input.html" %}
+  </div>
+</div>

--- a/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_filterbox.html
@@ -20,7 +20,9 @@
       {% for field in filter_form %}
         {% if not field.field.in_header %}
           <li class="form-control">
-            {% if "dropdownmultiselect" in field|widget_type or "dropdownradioselect" in field|widget_type %}
+            {% if field.name == "special_filters" %}
+              {{ field }}
+            {% elif "dropdownmultiselect" in field|widget_type or "dropdownradioselect" in field|widget_type %}
               <div class="flex flex-nowrap">
                 <label class="label">
                   <span class="label-text">{{ field.label }}</span>

--- a/src/argus/htmx/widgets.py
+++ b/src/argus/htmx/widgets.py
@@ -64,6 +64,26 @@ class BadgeDropdownMultiSelect(DropdownMultiSelect):
     template_name = "htmx/forms/badge_dropdown_select_multiple.html"
 
 
+class ButtonDropdownMultiSelect(DropdownMultiSelect):
+    template_name = "htmx/forms/button_dropdown_select_multiple.html"
+
+    def selected_count(self, name, value, attrs):
+        count = 0
+        for _, options, _ in self.optgroups(name, value, attrs):
+            for option in options:
+                if option.get("selected", False):
+                    count += 1
+        return count
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        # Overwrites the parent's has_selected, derived from count
+        count = self.selected_count(name, context["widget"]["value"], context["widget"]["attrs"])
+        context["widget"]["selected_count"] = count
+        context["widget"]["has_selected"] = count > 0
+        return context
+
+
 class DropdownRadioSelect(forms.RadioSelect):
     template_name = "htmx/forms/dropdown_radio_select.html"
     option_template_name = "htmx/forms/radio_option.html"

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -305,6 +305,17 @@ class IncidentQuerySet(models.QuerySet):
     def not_acked(self):
         return self.exclude(id__in=self._get_acked_incident_ids())
 
+    def open_or_unacked(self):
+        """Exclude incidents that are both closed and acked.
+
+        Shows all open incidents regardless of ack status, and all closed
+        incidents that are still unacked.
+        """
+        return self.exclude(
+            end_time__lte=timezone.now(),
+            id__in=self._get_acked_incident_ids(),
+        )
+
     def has_ticket(self):
         return self.exclude(ticket_url="")
 

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -316,6 +316,15 @@ class IncidentQuerySet(models.QuerySet):
             id__in=self._get_acked_incident_ids(),
         )
 
+    def under_maintenance(self):
+        """Return incidents with at least one currently active maintenance task."""
+        from argus.plannedmaintenance.models import PlannedMaintenanceTask
+
+        active_task_incident_ids = (
+            PlannedMaintenanceTask.objects.current().values_list("incidents", flat=True).distinct()
+        )
+        return self.filter(id__in=active_task_incident_ids)
+
     def has_ticket(self):
         return self.exclude(ticket_url="")
 

--- a/src/argus/plannedmaintenance/admin.py
+++ b/src/argus/plannedmaintenance/admin.py
@@ -52,9 +52,11 @@ class PlannedMaintenanceTaskAdmin(admin.ModelAdmin):
         ),
         list_filter_factory(
             "current",
-            lambda qs, yes_filter: qs.current()
-            if yes_filter
-            else qs.filter(Q(start_time__gt=timezone.now()) | Q(end_time__lt=timezone.now())),
+            lambda qs, yes_filter: (
+                qs.current()
+                if yes_filter
+                else qs.filter(Q(start_time__gt=timezone.now()) | Q(end_time__lt=timezone.now()))
+            ),
         ),
     ]
 

--- a/tests/filter/test_filterwrapper_special_filters.py
+++ b/tests/filter/test_filterwrapper_special_filters.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import Mock
+
+from django.test import tag
+
+from argus.filter.filterwrapper import FilterWrapper, SpecialFilterKey
+
+
+@tag("unittest")
+class FilterWrapperIncidentFitsSpecialFiltersTests(unittest.TestCase):
+    def test_when_no_special_filters_are_active_then_returns_None(self):
+        fw = FilterWrapper({"open": True})
+        incident = Mock()
+        result = fw._incident_fits_special_filters(incident)
+        self.assertIsNone(result)
+
+    def test_when_hide_closed_acked_is_true_and_incident_is_open_then_returns_True(self):
+        fw = FilterWrapper({SpecialFilterKey.HIDE_CLOSED_ACKED: True})
+        incident = Mock()
+        incident.open = True
+        incident.acked = True
+        result = fw._incident_fits_special_filters(incident)
+        self.assertTrue(result)
+
+    def test_when_hide_closed_acked_is_true_and_incident_is_closed_and_unacked_then_returns_True(self):
+        fw = FilterWrapper({SpecialFilterKey.HIDE_CLOSED_ACKED: True})
+        incident = Mock()
+        incident.open = False
+        incident.acked = False
+        result = fw._incident_fits_special_filters(incident)
+        self.assertTrue(result)
+
+    def test_when_hide_closed_acked_is_true_and_incident_is_closed_and_acked_then_returns_False(self):
+        fw = FilterWrapper({SpecialFilterKey.HIDE_CLOSED_ACKED: True})
+        incident = Mock()
+        incident.open = False
+        incident.acked = True
+        result = fw._incident_fits_special_filters(incident)
+        self.assertFalse(result)
+
+    def test_when_under_maintenance_is_true_and_incident_has_active_task_then_returns_True(self):
+        fw = FilterWrapper({SpecialFilterKey.UNDER_MAINTENANCE: True})
+        incident = Mock()
+        incident.planned_maintenance_tasks.current.return_value.exists.return_value = True
+        result = fw._incident_fits_special_filters(incident)
+        self.assertTrue(result)
+
+    def test_when_under_maintenance_is_true_and_incident_has_no_active_task_then_returns_False(self):
+        fw = FilterWrapper({SpecialFilterKey.UNDER_MAINTENANCE: True})
+        incident = Mock()
+        incident.planned_maintenance_tasks.current.return_value.exists.return_value = False
+        result = fw._incident_fits_special_filters(incident)
+        self.assertFalse(result)
+
+    def test_when_both_special_filters_active_and_both_pass_then_returns_True(self):
+        fw = FilterWrapper(
+            {
+                SpecialFilterKey.HIDE_CLOSED_ACKED: True,
+                SpecialFilterKey.UNDER_MAINTENANCE: True,
+            }
+        )
+        incident = Mock()
+        incident.open = True
+        incident.acked = False
+        incident.planned_maintenance_tasks.current.return_value.exists.return_value = True
+        result = fw._incident_fits_special_filters(incident)
+        self.assertTrue(result)
+
+    def test_when_both_special_filters_active_and_one_fails_then_returns_False(self):
+        fw = FilterWrapper(
+            {
+                SpecialFilterKey.HIDE_CLOSED_ACKED: True,
+                SpecialFilterKey.UNDER_MAINTENANCE: True,
+            }
+        )
+        incident = Mock()
+        incident.open = False
+        incident.acked = True
+        incident.planned_maintenance_tasks.current.return_value.exists.return_value = True
+        result = fw._incident_fits_special_filters(incident)
+        self.assertFalse(result)
+
+    def test_when_hide_closed_acked_is_false_then_it_should_be_ignored(self):
+        fw = FilterWrapper({SpecialFilterKey.HIDE_CLOSED_ACKED: False})
+        incident = Mock()
+        result = fw._incident_fits_special_filters(incident)
+        self.assertIsNone(result)
+
+    def test_when_under_maintenance_is_false_then_it_should_be_ignored(self):
+        fw = FilterWrapper({SpecialFilterKey.UNDER_MAINTENANCE: False})
+        incident = Mock()
+        result = fw._incident_fits_special_filters(incident)
+        self.assertIsNone(result)

--- a/tests/filter/test_queryset_filters_special.py
+++ b/tests/filter/test_queryset_filters_special.py
@@ -1,0 +1,60 @@
+from datetime import timedelta
+
+from django.test import TestCase, tag
+from django.utils import timezone
+
+from argus.auth.factories import PersonUserFactory, SourceUserFactory
+from argus.filter.filterwrapper import SpecialFilterKey
+from argus.filter.queryset_filters import _incidents_fitting_special_filters
+from argus.incident.factories import (
+    SourceSystemFactory,
+    StatefulIncidentFactory,
+)
+from argus.incident.models import Incident
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
+from argus.util.testing import disconnect_signals, connect_signals
+
+
+@tag("database", "queryset-filter")
+class IncidentsFittingSpecialFiltersTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        source_user = SourceUserFactory()
+        self.source = SourceSystemFactory(user=source_user)
+        self.user = PersonUserFactory()
+        self.now = timezone.now()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_hide_closed_acked_is_true_then_it_should_exclude_closed_acked_incidents(self):
+        closed_acked = StatefulIncidentFactory(source=self.source, end_time=self.now)
+        closed_acked.create_ack(self.user)
+        open_incident = StatefulIncidentFactory(source=self.source)
+
+        qs = Incident.objects.all()
+        result = _incidents_fitting_special_filters(qs, {SpecialFilterKey.HIDE_CLOSED_ACKED: True})
+        self.assertNotIn(closed_acked, result)
+        self.assertIn(open_incident, result)
+
+    def test_when_under_maintenance_is_true_then_it_should_return_only_maintained_incidents(self):
+        maintained = StatefulIncidentFactory(source=self.source)
+        not_maintained = StatefulIncidentFactory(source=self.source)
+        pm_task = PlannedMaintenanceFactory(
+            start_time=self.now - timedelta(hours=1),
+            end_time=self.now + timedelta(hours=1),
+        )
+        pm_task.incidents.add(maintained)
+
+        qs = Incident.objects.all()
+        result = _incidents_fitting_special_filters(qs, {SpecialFilterKey.UNDER_MAINTENANCE: True})
+        self.assertIn(maintained, result)
+        self.assertNotIn(not_maintained, result)
+
+    def test_when_no_special_filters_then_it_should_return_all_incidents(self):
+        StatefulIncidentFactory(source=self.source)
+        StatefulIncidentFactory(source=self.source)
+
+        qs = Incident.objects.all()
+        result = _incidents_fitting_special_filters(qs, {})
+        self.assertEqual(set(result), set(qs))

--- a/tests/htmx/incident/test_filter_special.py
+++ b/tests/htmx/incident/test_filter_special.py
@@ -1,0 +1,56 @@
+from django.test import TestCase
+
+from argus.filter.filterwrapper import SpecialFilterKey
+from argus.htmx.incident.filter import IncidentFilterForm, _convert_filterblob
+from argus.incident.factories import SourceSystemFactory
+from argus.util.testing import disconnect_signals, connect_signals
+
+
+class TestToFilterblobSpecialFilters(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        SourceSystemFactory(name="testsource")
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_special_filters_are_selected_then_filterblob_it_should_contain_them_as_booleans(self):
+        form = IncidentFilterForm(
+            {
+                "special_filters": [SpecialFilterKey.HIDE_CLOSED_ACKED.value, SpecialFilterKey.UNDER_MAINTENANCE.value],
+            }
+        )
+        filterblob = form.to_filterblob()
+        self.assertTrue(filterblob.get(SpecialFilterKey.HIDE_CLOSED_ACKED.value))
+        self.assertTrue(filterblob.get(SpecialFilterKey.UNDER_MAINTENANCE.value))
+
+    def test_when_no_special_filters_selected_then_filterblob_it_should_not_contain_special_keys(self):
+        form = IncidentFilterForm({})
+        filterblob = form.to_filterblob()
+        self.assertNotIn(SpecialFilterKey.HIDE_CLOSED_ACKED.value, filterblob)
+        self.assertNotIn(SpecialFilterKey.UNDER_MAINTENANCE.value, filterblob)
+
+
+class TestConvertFilterblobSpecialFilters(TestCase):
+    def test_when_filterblob_has_special_filter_booleans_then_it_should_convert_to_list(self):
+        filterblob = {
+            SpecialFilterKey.HIDE_CLOSED_ACKED.value: True,
+            SpecialFilterKey.UNDER_MAINTENANCE.value: True,
+        }
+        result = _convert_filterblob(filterblob)
+        self.assertIn("special_filters", result)
+        self.assertIn(SpecialFilterKey.HIDE_CLOSED_ACKED.value, result["special_filters"])
+        self.assertIn(SpecialFilterKey.UNDER_MAINTENANCE.value, result["special_filters"])
+        # The individual keys should be removed
+        self.assertNotIn(SpecialFilterKey.HIDE_CLOSED_ACKED.value, result)
+        self.assertNotIn(SpecialFilterKey.UNDER_MAINTENANCE.value, result)
+
+    def test_when_filterblob_has_no_special_filters_then_it_should_not_add_special_filters_key(self):
+        filterblob = {"open": True}
+        result = _convert_filterblob(filterblob)
+        self.assertNotIn("special_filters", result)
+
+    def test_when_filterblob_has_only_one_special_filter_then_it_should_convert_correctly(self):
+        filterblob = {SpecialFilterKey.HIDE_CLOSED_ACKED.value: True}
+        result = _convert_filterblob(filterblob)
+        self.assertEqual(result["special_filters"], [SpecialFilterKey.HIDE_CLOSED_ACKED.value])

--- a/tests/htmx/test_widgets.py
+++ b/tests/htmx/test_widgets.py
@@ -1,8 +1,9 @@
 import json
+import unittest
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, tag
 
-from argus.htmx.widgets import DropdownRadioSelect
+from argus.htmx.widgets import ButtonDropdownMultiSelect, DropdownRadioSelect
 
 
 class DropdownRadioSelectTest(SimpleTestCase):
@@ -23,3 +24,81 @@ class DropdownRadioSelectTest(SimpleTestCase):
         context = widget.get_context("test", "1", {})
         self.assertEqual(context["widget"]["badge_classes"], {})
         self.assertEqual(context["widget"]["badge_classes_json"], "{}")
+
+
+class StubButtonDropdownMultiSelect(ButtonDropdownMultiSelect):
+    """Subclass that stubs optgroups to avoid needing real form field choices."""
+
+    def __init__(self, options, **kwargs):
+        super().__init__(partial_get="/fake-url/", **kwargs)
+        self._stub_options = options
+
+    def optgroups(self, name, value, attrs=None):
+        """Return a single group with the stubbed options."""
+        return [("", self._stub_options, 0)]
+
+
+@tag("unittest")
+class ButtonDropdownMultiSelectSelectedCountTests(unittest.TestCase):
+    def test_selected_count_returns_zero_when_no_options_are_selected(self):
+        options = [
+            {"value": "a", "selected": False},
+            {"value": "b", "selected": False},
+        ]
+        widget = StubButtonDropdownMultiSelect(options)
+        count = widget.selected_count("test", ["a", "b"], {})
+        self.assertEqual(count, 0)
+
+    def test_selected_count_returns_correct_count_when_some_options_are_selected(self):
+        options = [
+            {"value": "a", "selected": True},
+            {"value": "b", "selected": False},
+            {"value": "c", "selected": True},
+        ]
+        widget = StubButtonDropdownMultiSelect(options)
+        count = widget.selected_count("test", ["a", "b", "c"], {})
+        self.assertEqual(count, 2)
+
+    def test_selected_count_returns_correct_count_when_all_options_are_selected(self):
+        options = [
+            {"value": "a", "selected": True},
+            {"value": "b", "selected": True},
+        ]
+        widget = StubButtonDropdownMultiSelect(options)
+        count = widget.selected_count("test", ["a", "b"], {})
+        self.assertEqual(count, 2)
+
+    def test_selected_count_returns_zero_when_no_options(self):
+        widget = StubButtonDropdownMultiSelect([])
+        count = widget.selected_count("test", [], {})
+        self.assertEqual(count, 0)
+
+
+@tag("unittest")
+class ButtonDropdownMultiSelectGetContextTests(unittest.TestCase):
+    def test_get_context_it_should_include_selected_count(self):
+        options = [
+            {"value": "a", "selected": True},
+            {"value": "b", "selected": False},
+        ]
+        widget = StubButtonDropdownMultiSelect(options, choices=[("a", "A"), ("b", "B")])
+        context = widget.get_context("test", ["a"], {})
+        self.assertIn("selected_count", context["widget"])
+        self.assertEqual(context["widget"]["selected_count"], 1)
+
+    def test_get_context_has_selected_is_true_when_count_is_positive(self):
+        options = [
+            {"value": "a", "selected": True},
+        ]
+        widget = StubButtonDropdownMultiSelect(options, choices=[("a", "A")])
+        context = widget.get_context("test", ["a"], {})
+        self.assertTrue(context["widget"]["has_selected"])
+
+    def test_get_context_has_selected_is_false_when_count_is_zero(self):
+        options = [
+            {"value": "a", "selected": False},
+        ]
+        widget = StubButtonDropdownMultiSelect(options, choices=[("a", "A")])
+        context = widget.get_context("test", [], {})
+        self.assertFalse(context["widget"]["has_selected"])
+        self.assertEqual(context["widget"]["selected_count"], 0)

--- a/tests/incident/test_filters_special.py
+++ b/tests/incident/test_filters_special.py
@@ -1,0 +1,79 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from argus.auth.factories import PersonUserFactory, SourceUserFactory
+from argus.incident.factories import (
+    SourceSystemFactory,
+    SourceSystemTypeFactory,
+    StatefulIncidentFactory,
+)
+from argus.incident.models import Incident
+from argus.incident.views import IncidentFilter
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
+from argus.util.testing import disconnect_signals, connect_signals
+
+
+class IncidentFilterHideClosedAckedTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        source_type = SourceSystemTypeFactory(name="nav")
+        source_user = SourceUserFactory(username="nav1")
+        self.source = SourceSystemFactory(name="NAV 1", type=source_type, user=source_user)
+        self.user = PersonUserFactory()
+        self.now = timezone.now()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_hide_closed_acked_is_true_then_it_should_exclude_closed_and_acked(self):
+        closed_acked = StatefulIncidentFactory(source=self.source, end_time=self.now)
+        closed_acked.create_ack(self.user)
+        open_incident = StatefulIncidentFactory(source=self.source)
+
+        qs = Incident.objects.order_by("pk")
+        result = IncidentFilter.incident_filter(qs, "hide_closed_acked", True)
+        self.assertNotIn(closed_acked, result)
+        self.assertIn(open_incident, result)
+
+    def test_when_hide_closed_acked_is_false_then_it_should_return_full_queryset(self):
+        closed_acked = StatefulIncidentFactory(source=self.source, end_time=self.now)
+        closed_acked.create_ack(self.user)
+
+        qs = Incident.objects.order_by("pk")
+        result = IncidentFilter.incident_filter(qs, "hide_closed_acked", False)
+        self.assertIn(closed_acked, result)
+
+
+class IncidentFilterUnderMaintenanceTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        source_type = SourceSystemTypeFactory(name="nav")
+        source_user = SourceUserFactory(username="nav1")
+        self.source = SourceSystemFactory(name="NAV 1", type=source_type, user=source_user)
+        self.now = timezone.now()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_under_maintenance_is_true_then_it_should_return_only_maintained_incidents(self):
+        maintained = StatefulIncidentFactory(source=self.source)
+        not_maintained = StatefulIncidentFactory(source=self.source)
+        pm_task = PlannedMaintenanceFactory(
+            start_time=self.now - timedelta(hours=1),
+            end_time=self.now + timedelta(hours=1),
+        )
+        pm_task.incidents.add(maintained)
+
+        qs = Incident.objects.order_by("pk")
+        result = IncidentFilter.incident_filter(qs, "under_maintenance", True)
+        self.assertIn(maintained, result)
+        self.assertNotIn(not_maintained, result)
+
+    def test_when_under_maintenance_is_false_then_it_should_return_full_queryset(self):
+        incident = StatefulIncidentFactory(source=self.source)
+
+        qs = Incident.objects.order_by("pk")
+        result = IncidentFilter.incident_filter(qs, "under_maintenance", False)
+        self.assertIn(incident, result)

--- a/tests/incident/test_queryset_special_filters.py
+++ b/tests/incident/test_queryset_special_filters.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from argus.auth.factories import PersonUserFactory
+from argus.incident.factories import (
+    SourceSystemFactory,
+    SourceUserFactory,
+    StatefulIncidentFactory,
+)
+from argus.incident.models import Incident
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
+from argus.util.testing import disconnect_signals, connect_signals
+
+
+class OpenOrUnackedQuerySetTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        source_user = SourceUserFactory()
+        self.source = SourceSystemFactory(user=source_user)
+        self.user = PersonUserFactory()
+        self.timestamp = timezone.now()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_incident_is_open_and_acked_then_it_should_be_included(self):
+        incident = StatefulIncidentFactory(source=self.source)
+        incident.create_ack(self.user)
+        result = Incident.objects.open_or_unacked()
+        self.assertIn(incident, result)
+
+    def test_when_incident_is_open_and_unacked_then_it_should_be_included(self):
+        incident = StatefulIncidentFactory(source=self.source)
+        result = Incident.objects.open_or_unacked()
+        self.assertIn(incident, result)
+
+    def test_when_incident_is_closed_and_unacked_then_it_should_be_included(self):
+        incident = StatefulIncidentFactory(
+            source=self.source,
+            end_time=self.timestamp,
+        )
+        result = Incident.objects.open_or_unacked()
+        self.assertIn(incident, result)
+
+    def test_when_incident_is_closed_and_acked_then_it_should_be_excluded(self):
+        incident = StatefulIncidentFactory(
+            source=self.source,
+            end_time=self.timestamp,
+        )
+        incident.create_ack(self.user)
+        result = Incident.objects.open_or_unacked()
+        self.assertNotIn(incident, result)
+
+
+class UnderMaintenanceQuerySetTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        source_user = SourceUserFactory()
+        self.source = SourceSystemFactory(user=source_user)
+        self.now = timezone.now()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_incident_has_active_maintenance_task_then_it_should_be_included(self):
+        incident = StatefulIncidentFactory(source=self.source)
+        pm_task = PlannedMaintenanceFactory(
+            start_time=self.now - timedelta(hours=1),
+            end_time=self.now + timedelta(hours=1),
+        )
+        pm_task.incidents.add(incident)
+        result = Incident.objects.under_maintenance()
+        self.assertIn(incident, result)
+
+    def test_when_incident_has_no_maintenance_task_then_it_should_be_excluded(self):
+        incident = StatefulIncidentFactory(source=self.source)
+        result = Incident.objects.under_maintenance()
+        self.assertNotIn(incident, result)
+
+    def test_when_incident_has_only_past_maintenance_task_then_it_should_be_excluded(self):
+        incident = StatefulIncidentFactory(source=self.source)
+        pm_task = PlannedMaintenanceFactory(
+            start_time=self.now - timedelta(hours=2),
+            end_time=self.now - timedelta(hours=1),
+        )
+        pm_task.incidents.add(incident)
+        result = Incident.objects.under_maintenance()
+        self.assertNotIn(incident, result)


### PR DESCRIPTION
## Scope and purpose

Background: NOC users requested a "Hide all incidents that are closed and acked" filter. This PR adds a suggested approach that supports additional "special filters", which is why there is also a second "Under maintenace" filter for demonstration (or inclusion, if we decide so).

Add a "Special filters" dropdown button to the incident filter bar with two compound filters requested by NOC power users:

- **Hide closed acked**: Shows all open incidents regardless of ack status, plus closed incidents that are still unacked. Hides only incidents that are both closed AND acknowledged.
- **Under maintenance**: Shows only incidents currently under active planned maintenance.

## Details

- Introduces `SpecialFilterKey` enum separate from `FilterKey` to keep compound filters as second-class citizens in the filter architecture
- Adds `ButtonDropdownMultiSelect` widget, a ghost-styled button with a count badge that opens a checkbox dropdown
- Adds `open_or_unacked()` and `under_maintenance()` queryset methods on `IncidentQuerySet`
- Supports both HTMX frontend and REST API (`?hide_closed_acked=true`, `?under_maintenance=true`)
- Adds fields to `FilterBlobSerializer` so named filters can include special filters

### Screen recordings
https://github.com/user-attachments/assets/dfd61a06-3d31-47e6-8059-f191335940ef

https://github.com/user-attachments/assets/4cfae865-ec55-4773-a603-a897ecea9010

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after