### PR TITLE
Add staff access control to PM search and filter views

### DIFF
--- a/changelog.d/1784.fixed.md
+++ b/changelog.d/1784.fixed.md
@@ -1,0 +1,1 @@
+Add missing staff access control to planned maintenance filter search and preview views

--- a/src/argus/htmx/plannedmaintenance/urls.py
+++ b/src/argus/htmx/plannedmaintenance/urls.py
@@ -6,8 +6,8 @@ from . import views
 app_name = "htmx"
 urlpatterns = [
     path("create/", views.PlannedMaintenanceCreateView.as_view(), name="plannedmaintenance-create"),
-    path("search-filters/", views.search_filters, name="search-filters"),
-    path("filter-preview/", views.filter_preview, name="plannedmaintenance-filter-preview"),
+    path("search-filters/", views.SearchFiltersView.as_view(), name="search-filters"),
+    path("filter-preview/", views.FilterPreviewView.as_view(), name="plannedmaintenance-filter-preview"),
     re_path(r"^(?P<tab>upcoming|past)?/$", views.PlannedMaintenanceListView.as_view(), name="plannedmaintenance-list"),
     path("<pk>/cancel/", views.PlannedMaintenanceCancelView.as_view(), name="plannedmaintenance-cancel"),
     path("<pk>/delete/", views.PlannedMaintenanceDeleteView.as_view(), name="plannedmaintenance-delete"),

--- a/src/argus/htmx/plannedmaintenance/views.py
+++ b/src/argus/htmx/plannedmaintenance/views.py
@@ -7,8 +7,7 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.http import require_GET
-from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
+from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView, View
 
 from argus.filter.queryset_filters import QuerySetFilter
 from argus.htmx.incident.columns import get_incident_table_columns, MAINTENANCE_COLUMN_LAYOUT_NAME
@@ -186,64 +185,69 @@ class PlannedMaintenanceUpdateView(
         return super().form_valid(form)
 
 
-@require_GET
-def search_filters(request):
-    query = request.GET.get("q", "")
+class SearchFiltersView(UserIsStaffMixin, View):
+    http_method_names = ["get"]
 
-    filters = Filter.objects.select_related("user")
-    if query:
-        filters = filters.filter(
-            Q(name__icontains=query)
-            | Q(user__username__icontains=query)
-            | Q(user__first_name__icontains=query)
-            | Q(user__last_name__icontains=query)
-        )
-    filters = sorted(filters, key=lambda f: (f.user != request.user, f.name))[:20]
+    def get(self, request):
+        query = request.GET.get("q", "")
 
-    options = [{"id": f.pk, "text": f"{f.name} ({f.user.username})"} for f in filters]
+        filters = Filter.objects.select_related("user")
+        if query:
+            filters = filters.filter(
+                Q(name__icontains=query)
+                | Q(user__username__icontains=query)
+                | Q(user__first_name__icontains=query)
+                | Q(user__last_name__icontains=query)
+            )
+        filters = sorted(filters, key=lambda f: (f.user != request.user, f.name))[:20]
 
-    return JsonResponse({"results": options})
+        options = [{"id": f.pk, "text": f"{f.name} ({f.user.username})"} for f in filters]
+
+        return JsonResponse({"results": options})
 
 
-@require_GET
-def filter_preview(request):
+class FilterPreviewView(UserIsStaffMixin, View):
     """Return a preview of open incidents that match the selected filters."""
-    filter_ids = [id for id in request.GET.getlist("filters") if id.isdigit()]
 
-    if not filter_ids:
-        return render(request, FILTER_PREVIEW_TEMPLATE, {"no_filters": True})
+    http_method_names = ["get"]
 
-    open_incidents = Incident.objects.open()
-    total_open = open_incidents.count()
+    def get(self, request):
+        filter_ids = [fid for fid in request.GET.getlist("filters") if fid.isdigit()]
 
-    if not total_open:
-        return render(request, "htmx/plannedmaintenance/_filter_preview.html", {"no_open_incidents": True})
+        if not filter_ids:
+            return render(request, FILTER_PREVIEW_TEMPLATE, {"no_filters": True})
 
-    # All filters must match (AND logic), same as actual PM coverage in utils.py
-    filters = Filter.objects.filter(pk__in=filter_ids)
-    matching_qs = open_incidents
-    for filter_obj in filters:
-        matching_qs = QuerySetFilter.filtered_incidents(filter_obj.filter, matching_qs)
+        open_incidents = Incident.objects.open()
+        total_open = open_incidents.count()
 
-    matching_count = matching_qs.count()
-    matching_percent = round(100 * matching_count / total_open) if total_open else 0
-    incident_list = (
-        matching_qs.select_related("source")
-        .prefetch_related("incident_tag_relations", "incident_tag_relations__tag")
-        .order_by("-start_time")[:FILTER_PREVIEW_LIMIT]
-    )
-    columns = get_incident_table_columns(MAINTENANCE_COLUMN_LAYOUT_NAME)
+        if not total_open:
+            return render(request, "htmx/plannedmaintenance/_filter_preview.html", {"no_open_incidents": True})
 
-    return render(
-        request,
-        FILTER_PREVIEW_TEMPLATE,
-        {
-            "matching_count": matching_count,
-            "matching_percent": matching_percent,
-            "total_open": total_open,
-            "incident_list": incident_list,
-            "columns": columns,
-            "compact": True,
-            "dummy_column": True,
-        },
-    )
+        # All filters must match (AND logic), same as actual PM coverage in utils.py
+        filters = Filter.objects.filter(pk__in=filter_ids)
+        matching_qs = open_incidents
+        for filter_obj in filters:
+            matching_qs = QuerySetFilter.filtered_incidents(filter_obj.filter, matching_qs)
+
+        matching_count = matching_qs.count()
+        matching_percent = round(100 * matching_count / total_open) if total_open else 0
+        incident_list = (
+            matching_qs.select_related("source")
+            .prefetch_related("incident_tag_relations", "incident_tag_relations__tag")
+            .order_by("-start_time")[:FILTER_PREVIEW_LIMIT]
+        )
+        columns = get_incident_table_columns(MAINTENANCE_COLUMN_LAYOUT_NAME)
+
+        return render(
+            request,
+            FILTER_PREVIEW_TEMPLATE,
+            {
+                "matching_count": matching_count,
+                "matching_percent": matching_percent,
+                "total_open": total_open,
+                "incident_list": incident_list,
+                "columns": columns,
+                "compact": True,
+                "dummy_column": True,
+            },
+        )

--- a/tests/htmx/plannedmaintenance/test_views.py
+++ b/tests/htmx/plannedmaintenance/test_views.py
@@ -263,71 +263,83 @@ class PlannedMaintenanceCancelViewTests(TestCase):
 @tag("integration")
 class SearchFiltersViewTests(TestCase):
     def setUp(self):
-        self.user = PersonUserFactory(username="felaali", first_name="Ferrari", last_name="Testarossa")
-        self.other_user = PersonUserFactory(username="lambo", first_name="Lamborghini", last_name="Countach")
+        self.user = PersonUserFactory()
+        self.staff_user = AdminUserFactory(username="felaali", first_name="Ferrari", last_name="Testarossa")
+        self.other_staff_user = AdminUserFactory(username="lambo", first_name="Lamborghini", last_name="Countach")
 
-        self.user_filter = FilterFactory(user=self.user, name="My Filter")
-        self.other_filter = FilterFactory(user=self.other_user, name="Other Filter")
+        self.staff_filter = FilterFactory(user=self.staff_user, name="My Filter")
+        self.other_staff_filter = FilterFactory(user=self.other_staff_user, name="Other Filter")
 
     def test_search_filters_requires_login(self):
         response = self.client.get(reverse("htmx:search-filters"))
         self.assertEqual(response.status_code, 302)
 
-    def test_search_filters_returns_json(self):
+    def test_search_filters_when_not_staff_then_forbidden(self):
         self.client.force_login(self.user)
+        response = self.client.get(reverse("htmx:search-filters"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_search_filters_it_should_return_json(self):
+        self.client.force_login(self.staff_user)
         response = self.client.get(reverse("htmx:search-filters"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/json")
 
     def test_search_filters_returns_all_filters_without_query(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         response = self.client.get(reverse("htmx:search-filters"))
         data = response.json()
         self.assertEqual(len(data["results"]), 2)
 
     def test_search_filters_filters_by_name(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         response = self.client.get(reverse("htmx:search-filters"), {"q": "My"})
         data = response.json()
         self.assertEqual(len(data["results"]), 1)
-        self.assertEqual(data["results"][0]["id"], self.user_filter.pk)
+        self.assertEqual(data["results"][0]["id"], self.staff_filter.pk)
 
     def test_search_filters_filters_by_username(self):
-        self.client.force_login(self.user)
-        response = self.client.get(reverse("htmx:search-filters"), {"q": self.other_user.username})
+        self.client.force_login(self.staff_user)
+        response = self.client.get(reverse("htmx:search-filters"), {"q": self.other_staff_user.username})
         data = response.json()
         self.assertEqual(len(data["results"]), 1)
-        self.assertEqual(data["results"][0]["id"], self.other_filter.pk)
+        self.assertEqual(data["results"][0]["id"], self.other_staff_filter.pk)
 
     def test_search_filters_sorts_current_user_filters_first(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         response = self.client.get(reverse("htmx:search-filters"))
         data = response.json()
-        self.assertEqual(data["results"][0]["id"], self.user_filter.pk)
+        self.assertEqual(data["results"][0]["id"], self.staff_filter.pk)
 
 
 @tag("integration")
 class FilterPreviewViewTests(TestCase):
     def setUp(self):
         self.user = PersonUserFactory()
+        self.staff_user = AdminUserFactory()
 
     def test_filter_preview_requires_login(self):
         response = self.client.get(reverse("htmx:plannedmaintenance-filter-preview"))
         self.assertEqual(response.status_code, 302)
 
-    def test_filter_preview_without_filters_shows_no_filters(self):
+    def test_filter_preview_when_not_staff_then_forbidden(self):
         self.client.force_login(self.user)
+        response = self.client.get(reverse("htmx:plannedmaintenance-filter-preview"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_filter_preview_when_no_filters_then_shows_no_filters(self):
+        self.client.force_login(self.staff_user)
         response = self.client.get(reverse("htmx:plannedmaintenance-filter-preview"))
         self.assertTrue(response.context["no_filters"])
 
     def test_filter_preview_with_filters_shows_counts(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         # Create an open incident
         incident = StatefulIncidentFactory()
 
         # Create a filter that matches by source
         filter_with_match = FilterFactory(
-            user=self.user,
+            user=self.staff_user,
             filter={"sourceSystemIds": [incident.source.pk]},
         )
 
@@ -342,13 +354,13 @@ class FilterPreviewViewTests(TestCase):
         self.assertEqual(response.context["matching_count"], 1)
 
     def test_filter_preview_with_no_matching_incidents(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         # Create an open incident
         StatefulIncidentFactory()
 
         # Create a filter that matches nothing (non-existent source ID)
         filter_no_match = FilterFactory(
-            user=self.user,
+            user=self.staff_user,
             filter={"sourceSystemIds": [99999]},
         )
 
@@ -360,9 +372,9 @@ class FilterPreviewViewTests(TestCase):
         self.assertEqual(response.context["matching_count"], 0)
 
     def test_filter_preview_with_no_open_incidents(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         # Don't create any incidents - should return early
-        filter_obj = FilterFactory(user=self.user)
+        filter_obj = FilterFactory(user=self.staff_user)
 
         response = self.client.get(
             reverse("htmx:plannedmaintenance-filter-preview"),
@@ -372,18 +384,18 @@ class FilterPreviewViewTests(TestCase):
         self.assertTrue(response.context["no_open_incidents"])
 
     def test_filter_preview_intersects_multiple_filters(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         # Create two incidents with different sources
         incident1 = StatefulIncidentFactory()
         StatefulIncidentFactory()
 
         # Create two filters: one matching incident1's source, one matching a non-existent source
         filter1 = FilterFactory(
-            user=self.user,
+            user=self.staff_user,
             filter={"sourceSystemIds": [incident1.source.pk]},
         )
         filter2 = FilterFactory(
-            user=self.user,
+            user=self.staff_user,
             filter={"sourceSystemIds": [99999]},
         )
 
@@ -396,14 +408,14 @@ class FilterPreviewViewTests(TestCase):
         self.assertEqual(response.context["matching_count"], 0)
 
     def test_filter_preview_limits_incident_list(self):
-        self.client.force_login(self.user)
+        self.client.force_login(self.staff_user)
         source = SourceSystemFactory()
         # Create more incidents than the limit
         for _ in range(FILTER_PREVIEW_LIMIT + 1):
             StatefulIncidentFactory(source=source)
 
         filter_obj = FilterFactory(
-            user=self.user,
+            user=self.staff_user,
             filter={"sourceSystemIds": [source.pk]},
         )
 


### PR DESCRIPTION
## Scope and purpose

Fixes #1784.

The `search_filters` and `filter_preview` views in planned maintenance lacked staff access control. This converts them from function-based views to class-based views with `UserIsStaffMixin`, consistent with the other PM views.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)