### PR TITLE
Consolidate theme colors around Sikt design system

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -3,6 +3,27 @@
 This file documents changes to Argus that are relevant for operations,
 customizers and end-users.
 
+## Unreleased
+
+### Theme consolidation
+
+The ``sikt`` and ``sikt-dark`` themes have been renamed to ``light`` and
+``dark``. This means the built-in DaisyUI themes with those names are no longer
+directly accessible — the custom Sikt themes take their place. The bundled
+themes are now ``light``, ``dark``, and ``argus``.
+
+The old names still work at runtime (mapped automatically with a deprecation
+warning), but ``DAISYUI_THEMES`` and ``THEME_DEFAULT`` should be updated.
+
+To get the original DaisyUI light/dark themes back, add them as custom themes
+under a different name (e.g. ``daisy-light``) via ``DAISYUI_THEMES``. See
+`DaisyUI 5 theme generator <https://daisyui.com/theme-generator/>`_ and the
+:ref:`themes and styling <themes-and-styling>` docs for how to install custom
+themes.
+
+Severity badge colors and support colors (info, success, warning, error) have
+been aligned with the Sikt data visualization palette across all themes.
+
 ## [2.8.0] - 2026-03-06
 
 This release adds an important new dependency, django-tasks-db, which brings

--- a/changelog.d/1884.changed.md
+++ b/changelog.d/1884.changed.md
@@ -1,0 +1,1 @@
+Consolidate theme colors: replace built-in DaisyUI light/dark with Sikt themes, align support and severity colors across all themes, and add runtime fallback for deprecated theme names

--- a/docs/customization/htmx-frontend.rst
+++ b/docs/customization/htmx-frontend.rst
@@ -180,16 +180,16 @@ The incident severity column uses color-coded badges. The default colors are
 defined in ``argus/htmx/tailwindtheme/snippets/11-extensions.css``::
 
     @theme {
-      --color-severity-primary-1: red;
-      --color-severity-primary-2: orange;
-      --color-severity-primary-3: yellow;
-      --color-severity-primary-4: green;
-      --color-severity-primary-5: blue;
-      --color-severity-secondary-1: white;
-      --color-severity-secondary-2: black;
-      --color-severity-secondary-3: black;
-      --color-severity-secondary-4: white;
-      --color-severity-secondary-5: white;
+      --color-severity-primary-1: #FF957A;
+      --color-severity-primary-2: #FFAC70;
+      --color-severity-primary-3: #FBE774;
+      --color-severity-primary-4: #82E3CB;
+      --color-severity-primary-5: #75C7F0;
+      --color-severity-secondary-1: #1a1a1a;
+      --color-severity-secondary-2: #1a1a1a;
+      --color-severity-secondary-3: #1a1a1a;
+      --color-severity-secondary-4: #1a1a1a;
+      --color-severity-secondary-5: #1a1a1a;
     }
 
 The ``severity-primary`` colors are used for background and border, while

--- a/src/argus/htmx/tailwindtheme/config.py
+++ b/src/argus/htmx/tailwindtheme/config.py
@@ -2,11 +2,9 @@ from pathlib import Path
 
 
 DEFAULT_THEMES = [
-    "dark",
     "light",
+    "dark",
     "argus",
-    "sikt",
-    "sikt-dark",
 ]
 
 VERSION = "2.1.37"

--- a/src/argus/htmx/tailwindtheme/snippets/11-extensions.css
+++ b/src/argus/htmx/tailwindtheme/snippets/11-extensions.css
@@ -1,14 +1,14 @@
 @theme {
-  --color-severity-primary-1: red;
-  --color-severity-primary-2: orange;
-  --color-severity-primary-3: yellow;
-  --color-severity-primary-4: green;
-  --color-severity-primary-5: blue;
-  --color-severity-secondary-1: white;
-  --color-severity-secondary-2: black;
-  --color-severity-secondary-3: black;
-  --color-severity-secondary-4: white;
-  --color-severity-secondary-5: white;
+  --color-severity-primary-1: #FF957A;
+  --color-severity-primary-2: #FFAC70;
+  --color-severity-primary-3: #FBE774;
+  --color-severity-primary-4: #82E3CB;
+  --color-severity-primary-5: #75C7F0;
+  --color-severity-secondary-1: #1a1a1a;
+  --color-severity-secondary-2: #1a1a1a;
+  --color-severity-secondary-3: #1a1a1a;
+  --color-severity-secondary-4: #1a1a1a;
+  --color-severity-secondary-5: #1a1a1a;
 }
 
 /*

--- a/src/argus/htmx/tailwindtheme/snippets/12-daisy-compat.css
+++ b/src/argus/htmx/tailwindtheme/snippets/12-daisy-compat.css
@@ -1,14 +1,3 @@
-/*
- * Override DaisyUI v5 built-in theme colors to match v4 values.
- * These must be outside @layer to have higher specificity than DaisyUI's definitions.
- */
-[data-theme=dark] {
-  --color-neutral: oklch(0.314 0.021 254.139);
-}
-[data-theme=light] {
-  --color-neutral: oklch(0.321785 0.02476 255.702);
-}
-
 /* DaisyUI v4 compatibility classes */
 @layer components {
   /* Restore label-text styling from DaisyUI v4 */

--- a/src/argus/htmx/tailwindtheme/themes/argus.css
+++ b/src/argus/htmx/tailwindtheme/themes/argus.css
@@ -13,12 +13,12 @@
   --color-base-200: #ced9de;
   --color-base-300: #b0babd;
   --color-base-content: #141516;
-  --color-info: #006ad4;
-  --color-info-content: #ffffff;
-  --color-success: #008700;
-  --color-success-content: #ffffff;
-  --color-warning: #ee4900;
-  --color-warning-content: #140200;
-  --color-error: #e5545a;
-  --color-error-content: #2c0608;
+  --color-info: #004FCF;
+  --color-info-content: #FFFFFF;
+  --color-success: #138849;
+  --color-success-content: #FFFFFF;
+  --color-warning: #FFB700;
+  --color-warning-content: #141516;
+  --color-error: #D74033;
+  --color-error-content: #FFFFFF;
 }

--- a/src/argus/htmx/tailwindtheme/themes/dark.css
+++ b/src/argus/htmx/tailwindtheme/themes/dark.css
@@ -22,17 +22,3 @@
   --color-error: #D74033; /* support.critical.strong: red.52-100 */
   --color-error-content: #FFFFFF; /* neutral.100-100 */
 }
-
-/* Severity colors from Sikt datavisualization category tokens */
-[data-theme="dark"] {
-  --color-severity-primary-1: #FF957A;
-  --color-severity-primary-2: #FFAC70;
-  --color-severity-primary-3: #FBE774;
-  --color-severity-primary-4: #82E3CB;
-  --color-severity-primary-5: #75C7F0;
-  --color-severity-secondary-1: #0A0132;
-  --color-severity-secondary-2: #0A0132;
-  --color-severity-secondary-3: #0A0132;
-  --color-severity-secondary-4: #0A0132;
-  --color-severity-secondary-5: #0A0132;
-}

--- a/src/argus/htmx/tailwindtheme/themes/dark.css
+++ b/src/argus/htmx/tailwindtheme/themes/dark.css
@@ -1,5 +1,5 @@
 @plugin "daisyui/theme" {
-  name: "sikt-dark";
+  name: "dark";
   color-scheme: "dark";
   --color-primary: #7351FB; /* interaction.primary: purple.65-100 */
   --color-primary-content: #FFFFFF; /* neutral.100-100 */
@@ -24,7 +24,7 @@
 }
 
 /* Severity colors from Sikt datavisualization category tokens */
-[data-theme="sikt-dark"] {
+[data-theme="dark"] {
   --color-severity-primary-1: #FF957A;
   --color-severity-primary-2: #FFAC70;
   --color-severity-primary-3: #FBE774;

--- a/src/argus/htmx/tailwindtheme/themes/dark.css
+++ b/src/argus/htmx/tailwindtheme/themes/dark.css
@@ -7,7 +7,7 @@
   --color-secondary-content: #FFFFFF; /* neutral.100-100 */
   --color-accent: #4324C8; /* purple.46-100 */
   --color-accent-content: #FFFFFF; /* neutral.100-100 */
-  --color-neutral: #595959; /* neutral.35-100 */
+  --color-neutral: #2a323b; /* override: Sikt neutral.35-100 is too light for navbar */
   --color-neutral-content: #FFFFFF; /* neutral.100-100 */
   --color-base-100: #262626; /* neutral.15-100 */
   --color-base-200: #1A1A1A; /* neutral.10-100 */

--- a/src/argus/htmx/tailwindtheme/themes/light.css
+++ b/src/argus/htmx/tailwindtheme/themes/light.css
@@ -22,17 +22,3 @@
   --color-error: #D74033; /* support.critical.strong: red.52-100 */
   --color-error-content: #FFFFFF; /* neutral.100-100 */
 }
-
-/* Severity colors from Sikt datavisualization category tokens */
-[data-theme="light"] {
-  --color-severity-primary-1: #FF957A;
-  --color-severity-primary-2: #FFAC70;
-  --color-severity-primary-3: #FBE774;
-  --color-severity-primary-4: #82E3CB;
-  --color-severity-primary-5: #75C7F0;
-  --color-severity-secondary-1: #0A0132;
-  --color-severity-secondary-2: #0A0132;
-  --color-severity-secondary-3: #0A0132;
-  --color-severity-secondary-4: #0A0132;
-  --color-severity-secondary-5: #0A0132;
-}

--- a/src/argus/htmx/tailwindtheme/themes/light.css
+++ b/src/argus/htmx/tailwindtheme/themes/light.css
@@ -1,5 +1,5 @@
 @plugin "daisyui/theme" {
-  name: "sikt";
+  name: "light";
   color-scheme: "light";
   --color-primary: #7351FB; /* interaction.primary: purple.65-100 */
   --color-primary-content: #FFFFFF; /* neutral.100-100 */
@@ -24,7 +24,7 @@
 }
 
 /* Severity colors from Sikt datavisualization category tokens */
-[data-theme="sikt"] {
+[data-theme="light"] {
   --color-severity-primary-1: #FF957A;
   --color-severity-primary-2: #FFAC70;
   --color-severity-primary-3: #FBE774;

--- a/src/argus/htmx/tailwindtheme/themes/light.css
+++ b/src/argus/htmx/tailwindtheme/themes/light.css
@@ -7,7 +7,7 @@
   --color-secondary-content: #FFFFFF; /* neutral.100-100 */
   --color-accent: #D1CDFF; /* purple.90-100 */
   --color-accent-content: #0A0132; /* purple.10-100 */
-  --color-neutral: #595959; /* neutral.35-100 */
+  --color-neutral: #2b3440; /* override: Sikt neutral.35-100 is too light for navbar */
   --color-neutral-content: #FFFFFF; /* neutral.100-100 */
   --color-base-100: #FFFFFF; /* neutral.100-100 */
   --color-base-200: #F1F1F1; /* neutral.95-100 */

--- a/src/argus/htmx/themes/utils.py
+++ b/src/argus/htmx/themes/utils.py
@@ -16,11 +16,27 @@ __all__ = [
     "get_theme_names",
     "get_theme_names_from_setting",
     "get_theme_default",
+    "resolve_theme_name",
 ]
 
 ThemesList = list[str | dict[str, dict]]
 
 LOG = logging.getLogger(__name__)
+
+# Themes renamed in Argus 2.x; old names still work at runtime.
+DEPRECATED_THEME_NAMES = {
+    "sikt": "light",
+    "sikt-dark": "dark",
+}
+
+
+def resolve_theme_name(name: str) -> str:
+    """Map a deprecated theme name to its replacement, if applicable."""
+    new_name = DEPRECATED_THEME_NAMES.get(name)
+    if new_name is not None:
+        LOG.warning("Theme %r has been renamed to %r; please update your configuration", name, new_name)
+        return new_name
+    return name
 
 
 def get_raw_themes_setting():
@@ -41,7 +57,7 @@ def clean_themes(themes: Sequence[str | dict]) -> ThemesList:
             if not entry:
                 LOG.warning("Skipping empty string theme entry")
                 continue
-            cleaned.append(entry)
+            cleaned.append(resolve_theme_name(entry))
         elif isinstance(entry, dict):
             if not entry:
                 LOG.warning("Skipping empty dict theme entry")
@@ -110,4 +126,4 @@ def get_theme_names(quiet=True):
 
 
 def get_theme_default():
-    return getattr(settings, "THEME_DEFAULT", fallbacks.THEME_DEFAULT)
+    return resolve_theme_name(getattr(settings, "THEME_DEFAULT", fallbacks.THEME_DEFAULT))

--- a/src/argus/htmx/user/preferences/models.py
+++ b/src/argus/htmx/user/preferences/models.py
@@ -5,6 +5,7 @@ from argus.htmx.constants import (
     UPDATE_INTERVAL_DEFAULT,
 )
 from argus.htmx.incident.utils import update_interval_string
+from argus.htmx.themes.utils import resolve_theme_name
 from .forms import (
     DateTimeFormatForm,
     IncidentFilterPreferenceForm,
@@ -29,6 +30,11 @@ class ArgusHtmxPreferences:
     }
 
     def update_context(self, context):
+        # Resolve deprecated theme names (e.g. "sikt" → "light")
+        theme = context.get("theme")
+        if theme:
+            context["theme"] = resolve_theme_name(theme)
+
         datetime_format_name = context.get("datetime_format_name", self.FIELDS["datetime_format_name"].default)
         datetime_format = DATETIME_FORMATS[datetime_format_name]
         incidents_table_layout = context.get("incidents_table_layout", INCIDENTS_TABLE_LAYOUT_DEFAULT)

--- a/tests/htmx/themes/test_utils.py
+++ b/tests/htmx/themes/test_utils.py
@@ -1,7 +1,13 @@
 from django import test
 from django.test import override_settings
 
-from argus.htmx.themes.utils import clean_themes, get_theme_names_from_setting
+from argus.htmx.themes.utils import (
+    DEPRECATED_THEME_NAMES,
+    clean_themes,
+    get_theme_default,
+    get_theme_names_from_setting,
+    resolve_theme_name,
+)
 from argus.htmx import defaults as fallbacks
 
 
@@ -57,3 +63,46 @@ class TestGetThemesFromSetting(test.SimpleTestCase):
     @override_settings(DAISYUI_THEMES=["dark", None, "", 42, "light"])
     def test_given_invalid_entries_then_filters_them_out(self):
         self.assertEqual(get_theme_names_from_setting(), ["dark", "light"])
+
+
+class TestResolveThemeName(test.SimpleTestCase):
+    def test_given_current_name_then_passes_through(self):
+        self.assertEqual(resolve_theme_name("light"), "light")
+        self.assertEqual(resolve_theme_name("dark"), "dark")
+        self.assertEqual(resolve_theme_name("argus"), "argus")
+
+    def test_given_deprecated_name_then_returns_new_name(self):
+        for old_name, new_name in DEPRECATED_THEME_NAMES.items():
+            with self.assertLogs("argus.htmx.themes.utils", level="WARNING"):
+                self.assertEqual(resolve_theme_name(old_name), new_name)
+
+    def test_given_unknown_name_then_passes_through(self):
+        self.assertEqual(resolve_theme_name("custom"), "custom")
+
+
+class TestCleanThemesDeprecatedNames(test.SimpleTestCase):
+    def test_given_deprecated_string_entries_then_resolves_them(self):
+        with self.assertLogs("argus.htmx.themes.utils", level="WARNING"):
+            result = clean_themes(["sikt", "argus", "sikt-dark"])
+        self.assertEqual(result, ["light", "argus", "dark"])
+
+    def test_given_both_old_and_new_name_then_keeps_both(self):
+        with self.assertLogs("argus.htmx.themes.utils", level="WARNING"):
+            result = clean_themes(["light", "sikt"])
+        self.assertEqual(result, ["light", "light"])
+
+
+class TestGetThemeDefaultDeprecated(test.SimpleTestCase):
+    @override_settings(THEME_DEFAULT="sikt")
+    def test_given_deprecated_default_then_resolves_to_light(self):
+        with self.assertLogs("argus.htmx.themes.utils", level="WARNING"):
+            self.assertEqual(get_theme_default(), "light")
+
+    @override_settings(THEME_DEFAULT="sikt-dark")
+    def test_given_deprecated_dark_default_then_resolves_to_dark(self):
+        with self.assertLogs("argus.htmx.themes.utils", level="WARNING"):
+            self.assertEqual(get_theme_default(), "dark")
+
+    @override_settings(THEME_DEFAULT="argus")
+    def test_given_current_default_then_passes_through(self):
+        self.assertEqual(get_theme_default(), "argus")

--- a/tests/htmx/user/test_preferences.py
+++ b/tests/htmx/user/test_preferences.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from argus.htmx.user.factories import ArgusHtmxPreferencesFactory
+
+
+class TestArgusHtmxPreferencesUpdateContext(TestCase):
+    def test_given_deprecated_theme_in_preferences_then_resolves_to_new_name(self):
+        prefs = ArgusHtmxPreferencesFactory(preferences={"theme": "sikt"})
+        context = prefs.get_context()
+        self.assertEqual(context["theme"], "light")
+
+    def test_given_deprecated_dark_theme_in_preferences_then_resolves_to_dark(self):
+        prefs = ArgusHtmxPreferencesFactory(preferences={"theme": "sikt-dark"})
+        context = prefs.get_context()
+        self.assertEqual(context["theme"], "dark")
+
+    def test_given_current_theme_in_preferences_then_passes_through(self):
+        prefs = ArgusHtmxPreferencesFactory(preferences={"theme": "argus"})
+        context = prefs.get_context()
+        self.assertEqual(context["theme"], "argus")


### PR DESCRIPTION
## Scope and purpose

Fixes #1884.

Replaces the built-in DaisyUI light/dark themes with the Sikt design system themes, aligns support and severity colors across all themes, and adds runtime fallback for deprecated theme names (`sikt` -> `light`, `sikt-dark` -> `dark`).

Colors that are not part of the Argus brand identity (like success, warning, error etc.) are switched to use the same values as the Sikt themes. This is to avoid maintaining color design tokens which add no real value. The following colors are kept intact in Argus.css: 
* primary (teal)
* secondary (gold)
* accent (burnt orange)
* neutral (teal)
* base 100-300 (blue tint)

### Screenshots

#### The Argus theme is now using the same status colors as Sikt light, and proper severity colors
<img width="687" height="488" alt="image" src="https://github.com/user-attachments/assets/bab0d7a2-c22c-40c9-9bac-60fab1bff7ae" />

#### Light and Dark themes have been replaced with colors from the Sikt Design System. Fallbacks are in place for handling those who used sikt-light or sikt-dark explicitly.
<img width="710" height="166" alt="image" src="https://github.com/user-attachments/assets/f82044a3-5744-4247-a55a-d53d078ef571" />

#### The neutral color in the sikt themes was adjusted to match the color from the DaisyUI Light/Dark themes. The Sikt themes don't have sufficient contrast, and this darker gray pops better.
<img width="965" height="151" alt="image" src="https://github.com/user-attachments/assets/e1d524a8-da1a-49ff-8f30-2a6d1f78db35" />

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after