### PR TITLE
Remove linked incidents for longer ended PM tasks

### DIFF
--- a/changelog.d/1885.fixed.md
+++ b/changelog.d/1885.fixed.md
@@ -1,0 +1,1 @@
+Remove linked incidents for all ended planned maintenance tasks

--- a/src/argus/dev/management/commands/check_ended_maintenance.py
+++ b/src/argus/dev/management/commands/check_ended_maintenance.py
@@ -1,26 +1,13 @@
-from datetime import timedelta
-
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
 from argus.plannedmaintenance.models import PlannedMaintenanceTask
 
 
 class Command(BaseCommand):
-    help = "Find all planned maintenance tasks that have ended recently and remove the incidents connection"
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "-m",
-            "--minutes",
-            default=5,
-            type=int,
-            help="Only remove the incidents from the planned maintenance tasks that have ended within the last <number> minutes",
-        )
+    help = "Removes incidents from ended planned maintenance tasks"
 
     def handle(self, *args, **options):
-        end_time = timezone.now() - timedelta(minutes=options.get("minutes"))
-        ended_pm_tasks = PlannedMaintenanceTask.objects.ended_after_time(end_time)
+        ended_pm_tasks_with_linked_incidents = PlannedMaintenanceTask.objects.past().exclude(incidents=None)
 
-        for pm_task in ended_pm_tasks:
+        for pm_task in ended_pm_tasks_with_linked_incidents:
             pm_task.incidents.clear()

--- a/tests/dev/test_check_ended_maintenance.py
+++ b/tests/dev/test_check_ended_maintenance.py
@@ -1,0 +1,86 @@
+from datetime import timedelta
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from argus.filter.factories import FilterFactory
+from argus.incident.factories import StatefulIncidentFactory
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
+from argus.util.datetime_utils import LOCAL_INFINITY
+from argus.util.testing import connect_signals, disconnect_signals
+
+
+class CheckEndedMaintenanceTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+        now = timezone.now()
+
+        self.open_filter = FilterFactory(filter={"open": True})
+        self.incident = self.incident = StatefulIncidentFactory(start_time=now - timedelta(days=1))
+
+        self.future_pm = PlannedMaintenanceFactory(
+            start_time=now + timedelta(days=1),
+            end_time=LOCAL_INFINITY,
+        )
+        self.current_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(hours=1),
+            end_time=LOCAL_INFINITY,
+        )
+        self.recently_ended_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(days=2),
+            end_time=now,
+        )
+        self.past_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(days=2),
+            end_time=now - timedelta(days=1),
+        )
+
+        self.future_pm.filters.add(self.open_filter)
+        self.current_pm.filters.add(self.open_filter)
+        self.past_pm.filters.add(self.open_filter)
+
+        self.future_pm.incidents.add(self.incident)
+        self.current_pm.incidents.add(self.incident)
+        self.recently_ended_pm.incidents.add(self.incident)
+        self.past_pm.incidents.add(self.incident)
+
+    def tearDown(self):
+        connect_signals()
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "check_ended_maintenance",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def test_given_recently_ended_pm_then_remove_linked_incidents(self):
+        out = self.call_command()
+
+        self.assertFalse(out)
+        self.assertFalse(self.recently_ended_pm.incidents.exists())
+
+    def test_given_long_ended_pm_with_linked_incidents_then_remove_linked_incidents(self):
+        out = self.call_command()
+
+        self.assertFalse(out)
+        self.assertFalse(self.past_pm.incidents.exists())
+
+    def test_given_ongoing_pm_then_do_not_remove_linked_incidents(self):
+        out = self.call_command()
+
+        self.assertFalse(out)
+        self.assertTrue(self.current_pm.incidents.exists())
+
+    def test_given_future_pm_then_do_not_remove_linked_incidents(self):
+        out = self.call_command()
+
+        self.assertFalse(out)
+        self.assertTrue(self.future_pm.incidents.exists())


### PR DESCRIPTION
## Scope and purpose

Fixes #1885. Also adds some more test coverage for the management command.

How to test: Create a maintenance task that covers some incidents that starts an hour ago. Run the management command `check_started_maintenance` with `--minutes 60`. See that the incidents are linked to it. Then end the task, but set the end time to more than 5 minutes ago. Run the management command `check_ended_maintenance`. See that the incidents are no longer linked to it.  

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
