### PR TITLE
Replace native multiselect with checkboxes for level column filter

### DIFF
--- a/changelog.d/1890.changed.md
+++ b/changelog.d/1890.changed.md
@@ -1,0 +1,1 @@
+Make severity level column filter more accessible

--- a/src/argus/htmx/incident/forms/base.py
+++ b/src/argus/htmx/incident/forms/base.py
@@ -12,6 +12,7 @@ class IncidentListForm(forms.Form):
     field_initial: Any
     widget_classes: str = ""
     widget_template_name: Optional[str] = None
+    widget_option_template_name: Optional[str] = None
     lookup: Optional[str] = None  # used by filter method
     placeholder: str = ""
 
@@ -19,6 +20,8 @@ class IncidentListForm(forms.Form):
         super().__init__(*args, **kwargs)
         if self.widget_template_name:
             self.fields[self.fieldname].widget.template_name = self.widget_template_name
+        if self.widget_option_template_name:
+            self.fields[self.fieldname].widget.option_template_name = self.widget_option_template_name
         self.fields[self.fieldname].widget.attrs["class"] = self.widget_classes
         self.fields[self.fieldname].widget.attrs["placeholder"] = self.placeholder
 

--- a/src/argus/htmx/incident/forms/incident_filters.py
+++ b/src/argus/htmx/incident/forms/incident_filters.py
@@ -63,6 +63,8 @@ class LevelForm(SearchMixin, IncidentListForm):
     fieldname = "level"
     field_initial = ""
     widget_classes = "incident-list-param"
+    widget_template_name = "htmx/forms/menu_checkbox_select.html"
+    widget_option_template_name = "htmx/forms/menu_checkbox_option.html"
     lookup = f"{fieldname}__in"
 
     level = forms.TypedMultipleChoiceField(
@@ -70,6 +72,7 @@ class LevelForm(SearchMixin, IncidentListForm):
         choices=Level,
         coerce=int,
         empty_value="",
+        widget=forms.CheckboxSelectMultiple,
     )
 
 

--- a/src/argus/htmx/templates/htmx/forms/menu_checkbox_option.html
+++ b/src/argus/htmx/templates/htmx/forms/menu_checkbox_option.html
@@ -1,0 +1,10 @@
+<!-- htmx/forms/menu_checkbox_option.html -->
+<label class="flex items-center gap-2 cursor-pointer text-sm"
+       {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+  <input type="checkbox"
+         name="{{ widget.name }}"
+         class="checkbox checkbox-sm checkbox-primary"
+         {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
+         {% include "django/forms/widgets/classless_attrs.html" %}>
+  <span class="font-normal">{{ widget.label }}</span>
+</label>

--- a/src/argus/htmx/templates/htmx/forms/menu_checkbox_select.html
+++ b/src/argus/htmx/templates/htmx/forms/menu_checkbox_select.html
@@ -1,0 +1,11 @@
+<!-- htmx/forms/menu_checkbox_select.html -->
+{% with id=widget.attrs.id %}
+  <div {% if id %}id="{{ id }}"{% endif %} class="flex flex-col gap-1">
+    {% for group, options, index in widget.optgroups %}
+      {% if group %}<span class="text-xs font-semibold opacity-60">{{ group }}</span>{% endif %}
+      {% for option in options %}
+        {% include option.template_name with widget=option %}
+      {% endfor %}
+    {% endfor %}
+  </div>
+{% endwith %}

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_compact_severity_filter.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_compact_severity_filter.html
@@ -1,5 +1,5 @@
 <!-- htmx/incident/cells/_incident_compact_severity_filter.html -->
-{% load argus_htmx widget_tweaks %}
+{% load argus_htmx %}
 <div id="{{ column.name }}-dropdown" class="dropdown dropdown-end">
   <button type="button"
           tabindex="0"
@@ -8,48 +8,6 @@
           class="filter-btn btn btn-xs {% if field.value %} btn-primary {% else %} btn-ghost text-primary {% endif %} min-h-4 h-4">
     <i class="fa-solid fa-magnifying-glass text-xs"></i>
   </button>
-  <div id="{{ column.name }}-dropdown-content"
-       class="dropdown-content bg-base-100 p-2 mt-1 rounded-box shadow border-2 border-primary z-10 w-max h-max"
-       tabindex="-1">
-    <form class="incident-list-param">
-      <div aria-labelledby="{{ field.name }}-label">
-        {# djlint:off #}
-        {% if not dummy_column %}
-          {% url 'htmx:incident-list' as incident_list_url %}
-          {% render_field field hx-get=incident_list_url hx-include=".incident-list-param" hx-target="#table-body" hx-select="#table-body" hx-select-oob="#table-footer" hx-swap="outerHTML" hx-push-url="true" hx-indicator="#incident-list .htmx-indicator" hx-trigger="change delay:500ms" %}
-        {% else %}
-          {{ field }}
-        {% endif %}
-        {# djlint:on #}
-      </div>
-    </form>
-  </div>
+  {% include "htmx/incident/cells/_incident_filter_dropdown_body.html" %}
 </div>
-<script>
-(function() {
-  const dropdown = document.querySelector('#{{ column.name }}-dropdown');
-  const filterBtn = dropdown.querySelector('.filter-btn');
-
-  filterBtn.addEventListener('focus', function() {
-    const content = dropdown.querySelector('.dropdown-content');
-    const rect = content.getBoundingClientRect();
-
-    if (rect.right > window.innerWidth) {
-      dropdown.classList.add('dropdown-end');
-    } else if (rect.left < 0) {
-      dropdown.classList.remove('dropdown-end');
-    }
-  });
-
-  dropdown.addEventListener('htmx:afterRequest', function() {
-    const field = dropdown.querySelector('input:not([type="hidden"]), select');
-    if (field?.value) {
-      filterBtn.classList.add('btn-primary');
-      filterBtn.classList.remove('btn-ghost', 'text-primary');
-    } else {
-      filterBtn.classList.remove('btn-primary');
-      filterBtn.classList.add('btn-ghost', 'text-primary');
-    }
-  });
-})();
-</script>
+{% include "htmx/incident/cells/_incident_filter_dropdown_script.html" %}

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filter_dropdown_body.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filter_dropdown_body.html
@@ -1,0 +1,15 @@
+<!-- htmx/incident/cells/_incident_filter_dropdown_body.html -->
+<div id="{{ column.name }}-dropdown-content"
+     class="dropdown-content bg-base-100 p-2 mt-1 rounded-box shadow border-2 border-primary z-10 w-max h-max"
+     tabindex="-1">
+  <form class="incident-list-param">
+    {% if not dummy_column %}
+      {% url 'htmx:incident-list' as incident_list_url %}
+    {% endif %}
+    {# djlint:off #}
+    <div aria-labelledby="{{ field.name }}-label" {% if not dummy_column %}hx-get="{{ incident_list_url }}" hx-include=".incident-list-param" hx-target="#table-body" hx-select="#table-body" hx-select-oob="#table-footer" hx-swap="outerHTML" hx-push-url="true" hx-indicator="#incident-list .htmx-indicator" hx-trigger="change delay:500ms"{% endif %}>
+      {{ field }}
+    </div>
+    {# djlint:on #}
+  </form>
+</div>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filter_dropdown_script.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filter_dropdown_script.html
@@ -1,0 +1,33 @@
+<!-- htmx/incident/cells/_incident_filter_dropdown_script.html -->
+<script>
+(function() {
+  const dropdown = document.querySelector('#{{ column.name }}-dropdown');
+  const filterBtn = dropdown.querySelector('.filter-btn');
+
+  filterBtn.addEventListener('focus', function() {
+    const content = dropdown.querySelector('.dropdown-content');
+    const rect = content.getBoundingClientRect();
+
+    if (rect.right > window.innerWidth) {
+      dropdown.classList.add('dropdown-end');
+    } else if (rect.left < 0) {
+      dropdown.classList.remove('dropdown-end');
+    }
+  });
+
+  dropdown.addEventListener('htmx:afterRequest', function() {
+    const select = dropdown.querySelector('select');
+    const hasValue = select
+      ? !!select.value
+      : !!dropdown.querySelector('input[type="checkbox"]:checked')
+        || !!dropdown.querySelector('input:not([type="hidden"]):not([type="checkbox"])')?.value;
+    if (hasValue) {
+      filterBtn.classList.add('btn-primary');
+      filterBtn.classList.remove('btn-ghost', 'text-primary');
+    } else {
+      filterBtn.classList.remove('btn-primary');
+      filterBtn.classList.add('btn-ghost', 'text-primary');
+    }
+  });
+})();
+</script>

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_filterable_column_header_content.html
@@ -1,5 +1,5 @@
 <!-- htmx/incident/cells/_incident_filterable_column_header_content.html -->
-{% load argus_htmx widget_tweaks %}
+{% load argus_htmx %}
 {% with field=form|get_form_field:fieldname %}
   <div class="flex items-center gap-1">
     <span id="{{ field.name }}-label">{{ column.label }}</span>
@@ -14,50 +14,8 @@
               {% if dummy_column %}disabled{% endif %}>
         <i class="fa-solid fa-magnifying-glass"></i>
       </button>
-      <div id="{{ column.name }}-dropdown-content"
-           class="dropdown-content bg-base-100 p-2 mt-1 rounded-box shadow border-2 border-primary z-10 w-max h-max"
-           tabindex="-1">
-        <form class="incident-list-param">
-          <div aria-labelledby="{{ field.name }}-label">
-            {# djlint:off #}
-            {% if not dummy_column %}
-              {% url 'htmx:incident-list' as incident_list_url %}
-              {% render_field field hx-get=incident_list_url hx-include=".incident-list-param" hx-target="#table-body" hx-select="#table-body" hx-select-oob="#table-footer" hx-swap="outerHTML" hx-push-url="true" hx-indicator="#incident-list .htmx-indicator" hx-trigger="change delay:500ms" %}
-            {% else %}
-              {{ field }}
-            {% endif %}
-            {# djlint:on #}
-          </div>
-        </form>
-      </div>
+      {% include "htmx/incident/cells/_incident_filter_dropdown_body.html" %}
     </div>
   </div>
 {% endwith %}
-<script>
-(function() {
-  const dropdown = document.querySelector('#{{ column.name }}-dropdown');
-  const filterBtn = dropdown.querySelector('.filter-btn');
-
-  filterBtn.addEventListener('focus', function() {
-    const content = dropdown.querySelector('.dropdown-content');
-    const rect = content.getBoundingClientRect();
-
-    if (rect.right > window.innerWidth) {
-      dropdown.classList.add('dropdown-end');
-    } else if (rect.left < 0) {
-      dropdown.classList.remove('dropdown-end');
-    }
-  });
-
-  dropdown.addEventListener('htmx:afterRequest', function() {
-    const field = dropdown.querySelector('input:not([type="hidden"]), select');
-    if (field?.value) {
-      filterBtn.classList.add('btn-primary');
-      filterBtn.classList.remove('btn-ghost', 'text-primary');
-    } else {
-      filterBtn.classList.remove('btn-primary');
-      filterBtn.classList.add('btn-ghost', 'text-primary');
-    }
-  });
-})();
-</script>
+{% include "htmx/incident/cells/_incident_filter_dropdown_script.html" %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1890.

The severity level column filter (`select_levels` / `compact_select_levels`) uses a native `<select multiple>` element, which requires Ctrl/Cmd+click to toggle options and gives no visual feedback of selected state. This replaces it with a checkbox list that makes multi-selection intuitive.

### This pull request
* Switches `LevelForm` widget from `SelectMultiple` to `CheckboxSelectMultiple` with custom templates
* Moves HTMX attributes from `render_field` to a wrapper `<div>` to prevent attribute propagation to individual checkboxes
* Adds `widget_option_template_name` support to `IncidentListForm` base class
* Updates filter button state detection JS to handle checkboxes

### Screenshots

| Before | After |
| --- | --- |
| <img width="218" height="180" alt="image" src="https://github.com/user-attachments/assets/25506692-0ee7-4941-b6b9-17d8c57005f2" /> | <img width="170" height="218" alt="image" src="https://github.com/user-attachments/assets/7e1e2a0e-5ac9-447e-b5e1-782926d6f138" /> |

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)