### PR TITLE
 Add `is under maintenance` column with filtering 

### DIFF
--- a/changelog.d/1879.added.md
+++ b/changelog.d/1879.added.md
@@ -1,1 +1,1 @@
-Add special filters dropdown with "Hide closed acked" and "Under maintenance" compound filters
+Add special filters dropdown with "Hide closed acked" compound filter

--- a/changelog.d/1894.added.md
+++ b/changelog.d/1894.added.md
@@ -1,0 +1,1 @@
+Add is under maintenance column with filtering

--- a/docs/reference/htmx-frontend.rst
+++ b/docs/reference/htmx-frontend.rst
@@ -354,6 +354,20 @@ under_maintenance
     :Description: An icon indicating if there exists a planned maintenance task that
                   covers the incident, meaning no notifications are being sent for that
                   incident.
+    :Redundant with: is_under_maintenance
+
+    .. image:: img/columns/under_maintenance.png
+           :width: 200
+
+is_under_maintenance
+    :From: planned_maintenance_tasks
+    :Name: is_under_maintenance
+    :Description: An icon indicating if there exists a planned maintenance task that
+                  covers the incident, meaning no notifications are being sent for that
+                  incident.
+                  Can toggle showing only incidents that are or are not covered by
+                  maintenance.
+    :Redundant with: under_maintenance
 
     .. image:: img/columns/under_maintenance.png
            :width: 200

--- a/src/argus/filter/filters.py
+++ b/src/argus/filter/filters.py
@@ -55,11 +55,6 @@ _INCIDENT_OPENAPI_CUSTOM_FILTER_PARAMETERS = [
         enum=BooleanStringOAEnum,
     ),
     OpenApiParameter(
-        name="under_maintenance",
-        description="Show only incidents that are currently under planned maintenance (`true`).",
-        enum=BooleanStringOAEnum,
-    ),
-    OpenApiParameter(
         name="tags",
         description="Fetch incidents with specified tags",
         type=str,
@@ -186,7 +181,6 @@ class IncidentFilter(filters.FilterSet):
     duration__gte = filters.NumberFilter(label="Duration", method="incident_filter")
     token_expiry = filters.BooleanFilter(label="Token expiry", method="incident_filter")
     hide_closed_acked = filters.BooleanFilter(label="Hide closed acked", method="incident_filter")
-    under_maintenance = filters.BooleanFilter(label="Under maintenance", method="incident_filter")
     filter_pk = IntegerFilter(label="Filter pk", method="incident_filter")
     notificationprofile_pk = IntegerFilter(label="Notificationprofile pk", method="incident_filter")
 
@@ -256,10 +250,6 @@ class IncidentFilter(filters.FilterSet):
         if name == "hide_closed_acked":
             if value:
                 return queryset.open_or_unacked()
-            return queryset
-        if name == "under_maintenance":
-            if value:
-                return queryset.under_maintenance()
             return queryset
         if name == "filter_pk":
             return QuerySetFilter.incidents_by_filter_pk(queryset, value)

--- a/src/argus/filter/filterwrapper.py
+++ b/src/argus/filter/filterwrapper.py
@@ -42,7 +42,6 @@ class FilterKey(StrEnum):
 
 class SpecialFilterKey(StrEnum):
     HIDE_CLOSED_ACKED = "hide_closed_acked"
-    UNDER_MAINTENANCE = "under_maintenance"
 
 
 class FilterWrapper:
@@ -112,10 +111,6 @@ class FilterWrapper:
 
         if self.filter.get(SpecialFilterKey.HIDE_CLOSED_ACKED, False):
             fits = incident.open or not incident.acked
-            results.append(fits)
-
-        if self.filter.get(SpecialFilterKey.UNDER_MAINTENANCE, False):
-            fits = incident.planned_maintenance_tasks.current().exists()
             results.append(fits)
 
         if not results:

--- a/src/argus/filter/queryset_filters.py
+++ b/src/argus/filter/queryset_filters.py
@@ -58,8 +58,6 @@ def _incidents_fitting_tristates(incident_queryset, filterblob: FilterBlobType):
 def _incidents_fitting_special_filters(incident_queryset, filterblob: FilterBlobType):
     if filterblob.get(SpecialFilterKey.HIDE_CLOSED_ACKED, False):
         incident_queryset = incident_queryset.open_or_unacked()
-    if filterblob.get(SpecialFilterKey.UNDER_MAINTENANCE, False):
-        incident_queryset = incident_queryset.under_maintenance()
     return incident_queryset.distinct()
 
 

--- a/src/argus/filter/swappable/serializers.py
+++ b/src/argus/filter/swappable/serializers.py
@@ -37,4 +37,3 @@ class FilterBlobSerializer(serializers.Serializer):
         required=False,
     )
     hide_closed_acked = serializers.BooleanField(required=False, default=False)
-    under_maintenance = serializers.BooleanField(required=False, default=False)

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -275,6 +275,12 @@ _BUILTIN_COLUMN_LIST = [
         "Maintenance",
         "htmx/incident/cells/_incident_maintenance.html",
     ),
+    IncidentTableColumn(
+        "is_under_maintenance",
+        "Maintenance",
+        "htmx/incident/cells/_incident_maintenance.html",
+        filter_field="is_under_maintenance",
+    ),
 ]
 BUILTIN_COLUMNS = {col.name: col for col in _BUILTIN_COLUMN_LIST}
 

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -129,7 +129,6 @@ class IncidentFilterForm(forms.Form):
 
     SPECIAL_FILTER_CHOICES = [
         (SpecialFilterKey.HIDE_CLOSED_ACKED.value, "Hide Closed & Acked"),
-        (SpecialFilterKey.UNDER_MAINTENANCE.value, "Under Maintenance"),
     ]
 
     DEFAULT_VALUES = {

--- a/src/argus/htmx/incident/forms/base.py
+++ b/src/argus/htmx/incident/forms/base.py
@@ -102,3 +102,13 @@ class HasTextSearchMixin:
         elif _input == "no":
             queryset = queryset.filter(**{self.lookup: ""})
         return queryset
+
+
+class HasAttributeSearchMixin:
+    def filter(self, queryset, request):
+        _input = self.get_clean_value(request)
+        if _input == "yes":
+            queryset = queryset.exclude(**{self.lookup: None})
+        elif _input == "no":
+            queryset = queryset.filter(**{self.lookup: None})
+        return queryset

--- a/src/argus/htmx/incident/forms/incident_filters.py
+++ b/src/argus/htmx/incident/forms/incident_filters.py
@@ -9,7 +9,7 @@ from argus.htmx.constants import (
     TIMEFRAME_CHOICES,
     TIMEFRAME_DEFAULT,
 )
-from argus.htmx.incident.forms.base import IncidentListForm, SearchMixin, HasTextSearchMixin
+from argus.htmx.incident.forms.base import HasAttributeSearchMixin, HasTextSearchMixin, IncidentListForm, SearchMixin
 from argus.incident.constants import Level
 
 
@@ -84,7 +84,7 @@ class HasTicketForm(HasTextSearchMixin, IncidentListForm):
 
     has_ticket = forms.ChoiceField(
         required=False,
-        choices=[("yes", "Yes"), ("no", "No"), ("", "N/A")],
+        choices=[("yes", "Yes"), ("no", "No"), ("", "Any")],
         widget=forms.RadioSelect,
     )
 
@@ -97,6 +97,19 @@ class FindTicketForm(SearchMixin, IncidentListForm):
     placeholder = "part of ticket url"
 
     ticket_url = forms.CharField(required=False)
+
+
+class IsUnderMaintenanceForm(HasAttributeSearchMixin, IncidentListForm):
+    widget_classes = "incident-list-param"
+    fieldname = "is_under_maintenance"
+    field_initial = ""
+    lookup = "planned_maintenance_tasks"
+
+    is_under_maintenance = forms.ChoiceField(
+        required=False,
+        choices=[("yes", "Yes"), ("no", "No"), ("", "Any")],
+        widget=forms.RadioSelect,
+    )
 
 
 # Stored in preference

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -316,15 +316,6 @@ class IncidentQuerySet(models.QuerySet):
             id__in=self._get_acked_incident_ids(),
         )
 
-    def under_maintenance(self):
-        """Return incidents with at least one currently active maintenance task."""
-        from argus.plannedmaintenance.models import PlannedMaintenanceTask
-
-        active_task_incident_ids = (
-            PlannedMaintenanceTask.objects.current().values_list("incidents", flat=True).distinct()
-        )
-        return self.filter(id__in=active_task_incident_ids)
-
     def has_ticket(self):
         return self.exclude(ticket_url="")
 

--- a/tests/filter/test_filterwrapper_special_filters.py
+++ b/tests/filter/test_filterwrapper_special_filters.py
@@ -38,56 +38,8 @@ class FilterWrapperIncidentFitsSpecialFiltersTests(unittest.TestCase):
         result = fw._incident_fits_special_filters(incident)
         self.assertFalse(result)
 
-    def test_when_under_maintenance_is_true_and_incident_has_active_task_then_returns_True(self):
-        fw = FilterWrapper({SpecialFilterKey.UNDER_MAINTENANCE: True})
-        incident = Mock()
-        incident.planned_maintenance_tasks.current.return_value.exists.return_value = True
-        result = fw._incident_fits_special_filters(incident)
-        self.assertTrue(result)
-
-    def test_when_under_maintenance_is_true_and_incident_has_no_active_task_then_returns_False(self):
-        fw = FilterWrapper({SpecialFilterKey.UNDER_MAINTENANCE: True})
-        incident = Mock()
-        incident.planned_maintenance_tasks.current.return_value.exists.return_value = False
-        result = fw._incident_fits_special_filters(incident)
-        self.assertFalse(result)
-
-    def test_when_both_special_filters_active_and_both_pass_then_returns_True(self):
-        fw = FilterWrapper(
-            {
-                SpecialFilterKey.HIDE_CLOSED_ACKED: True,
-                SpecialFilterKey.UNDER_MAINTENANCE: True,
-            }
-        )
-        incident = Mock()
-        incident.open = True
-        incident.acked = False
-        incident.planned_maintenance_tasks.current.return_value.exists.return_value = True
-        result = fw._incident_fits_special_filters(incident)
-        self.assertTrue(result)
-
-    def test_when_both_special_filters_active_and_one_fails_then_returns_False(self):
-        fw = FilterWrapper(
-            {
-                SpecialFilterKey.HIDE_CLOSED_ACKED: True,
-                SpecialFilterKey.UNDER_MAINTENANCE: True,
-            }
-        )
-        incident = Mock()
-        incident.open = False
-        incident.acked = True
-        incident.planned_maintenance_tasks.current.return_value.exists.return_value = True
-        result = fw._incident_fits_special_filters(incident)
-        self.assertFalse(result)
-
     def test_when_hide_closed_acked_is_false_then_it_should_be_ignored(self):
         fw = FilterWrapper({SpecialFilterKey.HIDE_CLOSED_ACKED: False})
-        incident = Mock()
-        result = fw._incident_fits_special_filters(incident)
-        self.assertIsNone(result)
-
-    def test_when_under_maintenance_is_false_then_it_should_be_ignored(self):
-        fw = FilterWrapper({SpecialFilterKey.UNDER_MAINTENANCE: False})
         incident = Mock()
         result = fw._incident_fits_special_filters(incident)
         self.assertIsNone(result)

--- a/tests/filter/test_queryset_filters_special.py
+++ b/tests/filter/test_queryset_filters_special.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.test import TestCase, tag
 from django.utils import timezone
 
@@ -11,7 +9,6 @@ from argus.incident.factories import (
     StatefulIncidentFactory,
 )
 from argus.incident.models import Incident
-from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
 from argus.util.testing import disconnect_signals, connect_signals
 
 
@@ -36,20 +33,6 @@ class IncidentsFittingSpecialFiltersTests(TestCase):
         result = _incidents_fitting_special_filters(qs, {SpecialFilterKey.HIDE_CLOSED_ACKED: True})
         self.assertNotIn(closed_acked, result)
         self.assertIn(open_incident, result)
-
-    def test_when_under_maintenance_is_true_then_it_should_return_only_maintained_incidents(self):
-        maintained = StatefulIncidentFactory(source=self.source)
-        not_maintained = StatefulIncidentFactory(source=self.source)
-        pm_task = PlannedMaintenanceFactory(
-            start_time=self.now - timedelta(hours=1),
-            end_time=self.now + timedelta(hours=1),
-        )
-        pm_task.incidents.add(maintained)
-
-        qs = Incident.objects.all()
-        result = _incidents_fitting_special_filters(qs, {SpecialFilterKey.UNDER_MAINTENANCE: True})
-        self.assertIn(maintained, result)
-        self.assertNotIn(not_maintained, result)
 
     def test_when_no_special_filters_then_it_should_return_all_incidents(self):
         StatefulIncidentFactory(source=self.source)

--- a/tests/htmx/incident/test_filter_special.py
+++ b/tests/htmx/incident/test_filter_special.py
@@ -15,35 +15,24 @@ class TestToFilterblobSpecialFilters(TestCase):
         connect_signals()
 
     def test_when_special_filters_are_selected_then_filterblob_it_should_contain_them_as_booleans(self):
-        form = IncidentFilterForm(
-            {
-                "special_filters": [SpecialFilterKey.HIDE_CLOSED_ACKED.value, SpecialFilterKey.UNDER_MAINTENANCE.value],
-            }
-        )
+        form = IncidentFilterForm({"special_filters": [SpecialFilterKey.HIDE_CLOSED_ACKED.value]})
         filterblob = form.to_filterblob()
         self.assertTrue(filterblob.get(SpecialFilterKey.HIDE_CLOSED_ACKED.value))
-        self.assertTrue(filterblob.get(SpecialFilterKey.UNDER_MAINTENANCE.value))
 
     def test_when_no_special_filters_selected_then_filterblob_it_should_not_contain_special_keys(self):
         form = IncidentFilterForm({})
         filterblob = form.to_filterblob()
         self.assertNotIn(SpecialFilterKey.HIDE_CLOSED_ACKED.value, filterblob)
-        self.assertNotIn(SpecialFilterKey.UNDER_MAINTENANCE.value, filterblob)
 
 
 class TestConvertFilterblobSpecialFilters(TestCase):
     def test_when_filterblob_has_special_filter_booleans_then_it_should_convert_to_list(self):
-        filterblob = {
-            SpecialFilterKey.HIDE_CLOSED_ACKED.value: True,
-            SpecialFilterKey.UNDER_MAINTENANCE.value: True,
-        }
+        filterblob = {SpecialFilterKey.HIDE_CLOSED_ACKED.value: True}
         result = _convert_filterblob(filterblob)
         self.assertIn("special_filters", result)
         self.assertIn(SpecialFilterKey.HIDE_CLOSED_ACKED.value, result["special_filters"])
-        self.assertIn(SpecialFilterKey.UNDER_MAINTENANCE.value, result["special_filters"])
         # The individual keys should be removed
         self.assertNotIn(SpecialFilterKey.HIDE_CLOSED_ACKED.value, result)
-        self.assertNotIn(SpecialFilterKey.UNDER_MAINTENANCE.value, result)
 
     def test_when_filterblob_has_no_special_filters_then_it_should_not_add_special_filters_key(self):
         filterblob = {"open": True}

--- a/tests/htmx/incident/test_forms_incident_filters.py
+++ b/tests/htmx/incident/test_forms_incident_filters.py
@@ -1,9 +1,13 @@
+from datetime import timedelta
+
 from django.http.request import QueryDict
 from django.test import TestCase
+from django.utils import timezone
 
 from argus.incident.models import Incident
 from argus.incident.factories import IncidentFactory
-from argus.htmx.incident.forms.incident_filters import DescriptionForm, HasTicketForm, IdForm
+from argus.htmx.incident.forms.incident_filters import DescriptionForm, HasTicketForm, IdForm, IsUnderMaintenanceForm
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
 
 
 class IdFormTest(TestCase):
@@ -158,3 +162,70 @@ class HasTicketFormTest(TestCase):
         result_qs = form.filter(qs, request)
         self.assertEqual(result_qs.count(), 1)
         self.assertEqual(result_qs[0], self.incident2)
+
+
+class IsUnderMaintenanceFormTest(TestCase):
+    class obj:
+        pass
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        now = timezone.now()
+        cls.under_maintenance_incident = IncidentFactory()
+        cls.not_under_maintenance_incident = IncidentFactory()
+
+        cls.maintenance = PlannedMaintenanceFactory(
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1),
+        )
+
+        cls.maintenance.incidents.add(cls.under_maintenance_incident)
+
+    def test_form_without_input_returns_every_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="")
+        form = IsUnderMaintenanceForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertEqual(qs, result_qs)
+
+    def test_form_with_unfound_input_returns_every_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="is_under_maintenance=blbl")
+        form = IsUnderMaintenanceForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertEqual(qs, result_qs)
+
+    def test_form_with_irrelevant_input_returns_every_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="otherkey=1234")
+        form = IsUnderMaintenanceForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertEqual(qs, result_qs)
+
+    def test_form_with_input_yes_returns_specific_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="is_under_maintenance=yes")
+        form = IsUnderMaintenanceForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertIn(self.under_maintenance_incident, result_qs)
+        self.assertNotIn(self.not_under_maintenance_incident, result_qs)
+
+    def test_form_with_input_no_returns_specific_incident(self):
+        qs = Incident.objects.all()
+        request = self.obj()
+
+        request.GET = QueryDict(query_string="is_under_maintenance=no")
+        form = IsUnderMaintenanceForm(data=request.GET)
+        result_qs = form.filter(qs, request)
+        self.assertIn(self.not_under_maintenance_incident, result_qs)
+        self.assertNotIn(self.under_maintenance_incident, result_qs)

--- a/tests/incident/test_filters_special.py
+++ b/tests/incident/test_filters_special.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.test import TestCase
 from django.utils import timezone
 
@@ -11,7 +9,6 @@ from argus.incident.factories import (
 )
 from argus.incident.models import Incident
 from argus.incident.views import IncidentFilter
-from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
 from argus.util.testing import disconnect_signals, connect_signals
 
 
@@ -44,36 +41,3 @@ class IncidentFilterHideClosedAckedTests(TestCase):
         qs = Incident.objects.order_by("pk")
         result = IncidentFilter.incident_filter(qs, "hide_closed_acked", False)
         self.assertIn(closed_acked, result)
-
-
-class IncidentFilterUnderMaintenanceTests(TestCase):
-    def setUp(self):
-        disconnect_signals()
-        source_type = SourceSystemTypeFactory(name="nav")
-        source_user = SourceUserFactory(username="nav1")
-        self.source = SourceSystemFactory(name="NAV 1", type=source_type, user=source_user)
-        self.now = timezone.now()
-
-    def tearDown(self):
-        connect_signals()
-
-    def test_when_under_maintenance_is_true_then_it_should_return_only_maintained_incidents(self):
-        maintained = StatefulIncidentFactory(source=self.source)
-        not_maintained = StatefulIncidentFactory(source=self.source)
-        pm_task = PlannedMaintenanceFactory(
-            start_time=self.now - timedelta(hours=1),
-            end_time=self.now + timedelta(hours=1),
-        )
-        pm_task.incidents.add(maintained)
-
-        qs = Incident.objects.order_by("pk")
-        result = IncidentFilter.incident_filter(qs, "under_maintenance", True)
-        self.assertIn(maintained, result)
-        self.assertNotIn(not_maintained, result)
-
-    def test_when_under_maintenance_is_false_then_it_should_return_full_queryset(self):
-        incident = StatefulIncidentFactory(source=self.source)
-
-        qs = Incident.objects.order_by("pk")
-        result = IncidentFilter.incident_filter(qs, "under_maintenance", False)
-        self.assertIn(incident, result)

--- a/tests/incident/test_queryset_special_filters.py
+++ b/tests/incident/test_queryset_special_filters.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.test import TestCase
 from django.utils import timezone
 
@@ -10,7 +8,6 @@ from argus.incident.factories import (
     StatefulIncidentFactory,
 )
 from argus.incident.models import Incident
-from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
 from argus.util.testing import disconnect_signals, connect_signals
 
 
@@ -51,40 +48,4 @@ class OpenOrUnackedQuerySetTests(TestCase):
         )
         incident.create_ack(self.user)
         result = Incident.objects.open_or_unacked()
-        self.assertNotIn(incident, result)
-
-
-class UnderMaintenanceQuerySetTests(TestCase):
-    def setUp(self):
-        disconnect_signals()
-        source_user = SourceUserFactory()
-        self.source = SourceSystemFactory(user=source_user)
-        self.now = timezone.now()
-
-    def tearDown(self):
-        connect_signals()
-
-    def test_when_incident_has_active_maintenance_task_then_it_should_be_included(self):
-        incident = StatefulIncidentFactory(source=self.source)
-        pm_task = PlannedMaintenanceFactory(
-            start_time=self.now - timedelta(hours=1),
-            end_time=self.now + timedelta(hours=1),
-        )
-        pm_task.incidents.add(incident)
-        result = Incident.objects.under_maintenance()
-        self.assertIn(incident, result)
-
-    def test_when_incident_has_no_maintenance_task_then_it_should_be_excluded(self):
-        incident = StatefulIncidentFactory(source=self.source)
-        result = Incident.objects.under_maintenance()
-        self.assertNotIn(incident, result)
-
-    def test_when_incident_has_only_past_maintenance_task_then_it_should_be_excluded(self):
-        incident = StatefulIncidentFactory(source=self.source)
-        pm_task = PlannedMaintenanceFactory(
-            start_time=self.now - timedelta(hours=2),
-            end_time=self.now - timedelta(hours=1),
-        )
-        pm_task.incidents.add(incident)
-        result = Incident.objects.under_maintenance()
         self.assertNotIn(incident, result)


### PR DESCRIPTION
## Scope and purpose

As a follow up to #1589 and making changes to a filter added in #1879. Instead of having a separate filter for filtering incidents that are marked under maintenance I decided to add it as a column instead, similar to `has_ticket` and `select_levels`.

Screenshot:

<img width="168" height="563" alt="image" src="https://github.com/user-attachments/assets/511729a3-7752-447b-b38f-310b2e57b177" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
