### PR TITLE
Boost severity badge color visibility with OKLCH

### DIFF
--- a/changelog.d/1884.changed.2.md
+++ b/changelog.d/1884.changed.2.md
@@ -1,0 +1,1 @@
+Boost severity badge color visibility using OKLCH for sharper at-a-glance identification

--- a/docs/customization/htmx-frontend.rst
+++ b/docs/customization/htmx-frontend.rst
@@ -180,11 +180,11 @@ The incident severity column uses color-coded badges. The default colors are
 defined in ``argus/htmx/tailwindtheme/snippets/11-extensions.css``::
 
     @theme {
-      --color-severity-primary-1: #FF957A;
-      --color-severity-primary-2: #FFAC70;
-      --color-severity-primary-3: #FBE774;
-      --color-severity-primary-4: #82E3CB;
-      --color-severity-primary-5: #75C7F0;
+      --color-severity-primary-1: oklch(0.74 0.19 28);
+      --color-severity-primary-2: oklch(0.74 0.18 55);
+      --color-severity-primary-3: oklch(0.88 0.17 93);
+      --color-severity-primary-4: oklch(0.74 0.15 170);
+      --color-severity-primary-5: oklch(0.73 0.14 245);
       --color-severity-secondary-1: #1a1a1a;
       --color-severity-secondary-2: #1a1a1a;
       --color-severity-secondary-3: #1a1a1a;

--- a/src/argus/htmx/tailwindtheme/snippets/11-extensions.css
+++ b/src/argus/htmx/tailwindtheme/snippets/11-extensions.css
@@ -1,9 +1,9 @@
 @theme {
-  --color-severity-primary-1: #FF957A;
-  --color-severity-primary-2: #FFAC70;
-  --color-severity-primary-3: #FBE774;
-  --color-severity-primary-4: #82E3CB;
-  --color-severity-primary-5: #75C7F0;
+  --color-severity-primary-1: oklch(0.74 0.19 28);
+  --color-severity-primary-2: oklch(0.74 0.18 55);
+  --color-severity-primary-3: oklch(0.88 0.17 93);
+  --color-severity-primary-4: oklch(0.74 0.15 170);
+  --color-severity-primary-5: oklch(0.73 0.14 245);
   --color-severity-secondary-1: #1a1a1a;
   --color-severity-secondary-2: #1a1a1a;
   --color-severity-secondary-3: #1a1a1a;


### PR DESCRIPTION
## Scope and purpose

Follows up on #1884.

The Sikt data visualization palette colors introduced in #1884 are too pastel for first-line support, who rely on sharp at-a-glance severity identification.

This switches severity badge colors to OKLCH, boosting chroma while staying in the same Sikt hue families. Background lightness is tuned so all levels use consistent dark text.

### This pull request
* changes severity badge colors from hex to OKLCH for higher visibility
* updates documentation to reflect new color values

### Screenshots

| Before | After |
| --- | --- |
| <img width="167" height="396" alt="image" src="https://github.com/user-attachments/assets/48ab0a3c-fbcc-406d-b731-f34b98fadbea" /> | <img width="139" height="367" alt="image" src="https://github.com/user-attachments/assets/10a218de-7fa2-4556-904a-f5d0be886156" />|

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)