### PR TITLE
Fix test name checker to only flag new tests and support fork PRs

### DIFF
--- a/.claude/hooks/check-test-names.sh
+++ b/.claude/hooks/check-test-names.sh
@@ -21,7 +21,17 @@ fi
 # Make file_path relative to project root for the checker
 REL_PATH="${FILE_PATH#"$PROJECT_DIR"/}"
 
-output=$(python3 "$CHECKER" --files "$REL_PATH" 2>&1)
+# For tracked files, only check the diff (new/modified tests).
+# For untracked files, check the entire file.
+if git -C "$PROJECT_DIR" ls-files --error-unmatch "$REL_PATH" &>/dev/null; then
+  diff=$(git -C "$PROJECT_DIR" diff HEAD --unified=0 -- "$REL_PATH")
+  if [[ -z "$diff" ]]; then
+    exit 0
+  fi
+  output=$(echo "$diff" | python3 "$CHECKER" --stdin 2>&1)
+else
+  output=$(python3 "$CHECKER" --files "$REL_PATH" 2>&1)
+fi
 exit_code=$?
 
 if [[ $exit_code -ne 0 ]]; then

--- a/.github/workflows/check-test-names.yml
+++ b/.github/workflows/check-test-names.yml
@@ -1,7 +1,7 @@
 name: Check test names
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   pull-requests: write
@@ -15,11 +15,16 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Fetch PR head
+      run: git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/head"
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+
     - name: Check new test names
       id: check
       run: |
-        base="origin/${{ github.event.pull_request.base.ref }}"
-        output=$(python3 checks/check_test_names.py --base "$base" --format markdown 2>&1) && has_violations=false || has_violations=true
+        merge_base=$(git merge-base HEAD refs/remotes/pull/head)
+        output=$(git diff "$merge_base" refs/remotes/pull/head --unified=0 | python3 checks/check_test_names.py --stdin --format markdown 2>&1) && has_violations=false || has_violations=true
         echo "$output"
         {
           echo "body<<BODY_EOF"

--- a/checks/check_test_names.py
+++ b/checks/check_test_names.py
@@ -13,6 +13,9 @@ Usage:
 
     # Check specific files
     python checks/check_test_names.py --files tests/test_foo.py tests/test_bar.py
+
+    # Read unified diff from stdin
+    git diff HEAD --unified=0 -- tests/test_foo.py | python checks/check_test_names.py --stdin
 """
 
 import argparse
@@ -156,6 +159,11 @@ def format_markdown(violations, total):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read unified diff from stdin instead of running git.",
+    )
+    parser.add_argument(
         "--base",
         help="Base branch to diff against (e.g. main). If omitted, checks staged changes.",
     )
@@ -173,7 +181,9 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.files:
+    if args.stdin:
+        diff = sys.stdin.read()
+    elif args.files:
         diff = get_diff_files(args.files)
     elif args.base:
         diff = get_diff_base(args.base)


### PR DESCRIPTION
## Scope and purpose



Two fixes for the test name checker:

1. **Claude hook flags every test in a changed file**. The hook used `--files` mode which treats all test definitions as new. Now it uses `git diff HEAD` piped through a new `--stdin` mode, so only new/modified test names are checked. Pre-existing non-conforming names are left alone. Based on https://github.com/Uninett/nav/pull/3930

2. **Workflow fails on fork PRs**. The `pull_request` trigger gives a read-only `GITHUB_TOKEN` for fork PRs, so the comment step fails. Switched to `pull_request_target` which has write permissions. The checkout is the base branch (trusted script), with the PR head fetched for diffing.

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done