### PR TITLE
Automatically update last_seen if a source uses the API

### DIFF
--- a/changelog.d/+automatic-heartbeat-api.added.md
+++ b/changelog.d/+automatic-heartbeat-api.added.md
@@ -1,0 +1,2 @@
+Record when a source last did something. This makes it easy to spot which
+sources are actually in use, and serves as the start of heartbeat support.

--- a/src/argus/incident/models.py
+++ b/src/argus/incident/models.py
@@ -5,6 +5,7 @@ import logging
 from operator import and_
 from random import randint, choice
 from urllib.parse import urljoin
+from typing import Optional
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -172,6 +173,10 @@ class SourceSystem(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.type})"
+
+    def update_last_seen(self, timestamp: Optional[datetime] = None):
+        self.last_seen = timestamp if timestamp else timezone.now()
+        self.save()
 
 
 class TagQuerySet(models.QuerySet):

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -83,14 +83,29 @@ class EventPagination(CursorPagination):
     page_size_query_param = "page_size"
 
 
+class HeartBeatMixin:
+    def initial(self, request, *args, **kwargs):
+        # ensure we are logged in
+        super().initial(request, *args, **kwargs)
+
+        if request.user.is_authenticated and request.user.is_source_system:
+            LOG.info("Heartbeat: %s", request.user.source_system.name)
+            request.user.source_system.update_last_seen()
+
+
 class SourceSystemTypeViewSet(
-    mixins.CreateModelMixin, mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+    HeartBeatMixin,
+    mixins.CreateModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
 ):
     serializer_class = SourceSystemTypeSerializer
     queryset = SourceSystemType.objects.all()
 
 
 class SourceSystemViewSet(
+    HeartBeatMixin,
     mixins.CreateModelMixin,
     mixins.UpdateModelMixin,
     mixins.RetrieveModelMixin,
@@ -127,6 +142,7 @@ class SourceSystemViewSet(
 
 
 class BaseIncidentViewSet(
+    HeartBeatMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
@@ -279,7 +295,7 @@ class SourceLockedIncidentViewSet(BaseIncidentViewSet):
         request=EmptySerializer,
     ),
 )
-class TicketPluginViewSet(viewsets.ViewSet):
+class TicketPluginViewSet(HeartBeatMixin, viewsets.ViewSet):
     """This endpoint will automatically create a pre-filled ticket in a ticket
     system that is configured in the settings and return its URL or return the
     URL of an existing linked ticket.
@@ -336,6 +352,7 @@ class TicketPluginViewSet(viewsets.ViewSet):
 
 
 class IncidentTagViewSet(
+    HeartBeatMixin,
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.CreateModelMixin,
@@ -403,7 +420,7 @@ class IncidentTagViewSet(
         ],
     )
 )
-class AllEventsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+class AllEventsViewSet(HeartBeatMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     pagination_class = EventPagination
     queryset = Event.objects.none()
     serializer_class = EventSerializer
@@ -420,7 +437,9 @@ class AllEventsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         ],
     )
 )
-class EventViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class EventViewSet(
+    HeartBeatMixin, mixins.ListModelMixin, mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+):
     queryset = Incident.objects.none()  # For OpenAPI
     serializer_class = EventSerializer
 
@@ -512,7 +531,7 @@ class EventViewSet(mixins.ListModelMixin, mixins.CreateModelMixin, mixins.Retrie
         responses={"200": ResponseAcknowledgementSerializer},
     ),
 )
-class AcknowledgementViewSet(rw_viewsets.ModelViewSet):
+class AcknowledgementViewSet(HeartBeatMixin, rw_viewsets.ModelViewSet):
     queryset = Incident.objects.none()  # For OpenAPI
     serializer_class = ResponseAcknowledgementSerializer
     read_serializer_class = ResponseAcknowledgementSerializer
@@ -569,7 +588,7 @@ class BulkHelper:
         responses=ResponseBulkSerializer,
     )
 )
-class BulkAcknowledgementViewSet(BulkHelper, viewsets.ViewSet):
+class BulkAcknowledgementViewSet(HeartBeatMixin, BulkHelper, viewsets.ViewSet):
     serializer_class = ResponseBulkSerializer
     write_serializer_class = RequestBulkAcknowledgementSerializer
     queryset = Incident.objects.all()
@@ -614,7 +633,7 @@ class BulkAcknowledgementViewSet(BulkHelper, viewsets.ViewSet):
         responses=ResponseBulkSerializer,
     )
 )
-class BulkEventViewSet(BulkHelper, viewsets.ViewSet):
+class BulkEventViewSet(HeartBeatMixin, BulkHelper, viewsets.ViewSet):
     serializer_class = ResponseBulkSerializer
     write_serializer_class = RequestBulkEventSerializer
     queryset = Incident.objects.all()
@@ -664,7 +683,7 @@ class BulkEventViewSet(BulkHelper, viewsets.ViewSet):
         responses=ResponseBulkSerializer,
     )
 )
-class BulkTicketUrlViewSet(BulkHelper, viewsets.ViewSet):
+class BulkTicketUrlViewSet(HeartBeatMixin, BulkHelper, viewsets.ViewSet):
     serializer_class = ResponseBulkSerializer
     write_serializer_class = RequestBulkTicketUrlSerializer
     queryset = Incident.objects.all()

--- a/tests/incident/test_source_system.py
+++ b/tests/incident/test_source_system.py
@@ -1,16 +1,37 @@
+from datetime import datetime
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
-from django.test import Client, tag
+from django.test import Client, tag, TestCase
 from django.urls import reverse
 
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient, APITestCase
 
 from argus.auth.factories import AdminUserFactory
-from argus.incident.factories import SourceSystemTypeFactory
+from argus.incident.factories import SourceSystemFactory, SourceSystemTypeFactory
 from argus.incident.models import SourceSystem
 
 
 User = get_user_model()
+
+
+@tag("db")
+class SourceSystemUpdateLastSeenTests(TestCase):
+    def test_updates_last_seen_field_to_given_timestamp(self):
+        source = SourceSystemFactory()
+        self.assertIsNone(source.last_seen)
+        testtime = datetime(1970, 1, 1)
+        source.update_last_seen(testtime)
+        self.assertEqual(source.last_seen, testtime)
+
+    def test_updates_last_seen_field_to_current_timestamp(self):
+        source = SourceSystemFactory()
+        self.assertIsNone(source.last_seen)
+        testtime = datetime(1970, 1, 1)
+        with patch("argus.incident.models.timezone.now", return_value=testtime):
+            source.update_last_seen()
+            self.assertEqual(source.last_seen, testtime)
 
 
 @tag("api", "integration")


### PR DESCRIPTION
## Scope and purpose

For #1160. Depends on #1820.

This is an implicitly updated heartbeat, that holds for all glue services without changing anything for them, or adding config.

Together with #1820 this should go together in a release.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
