### PR TITLE
Fix incidents page UX: URL duplication and checkbox accessibility

### DIFF
--- a/changelog.d/1906.fixed.md
+++ b/changelog.d/1906.fixed.md
@@ -1,0 +1,1 @@
+Fix duplicate URL parameters and improve checkbox accessibility on incidents page

--- a/src/argus/htmx/templates/htmx/incident/_filter_controls_script.html
+++ b/src/argus/htmx/templates/htmx/incident/_filter_controls_script.html
@@ -97,6 +97,19 @@
     btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
   }
 
+  // Deduplicate single-valued HTMX request parameters caused by hx-vals
+  // and hx-include overlap (e.g. sort button provides sort via hx-vals while
+  // hx-include also picks up the hidden sort inputs from the filter form).
+  // For array params, keep the last value which comes from hx-vals.
+  document.body.addEventListener('htmx:configRequest', (e) => {
+    const params = e.detail.parameters;
+    for (const key of ['sort', 'sort_order', 'page']) {
+      if (Array.isArray(params[key])) {
+        params[key] = params[key][params[key].length - 1];
+      }
+    }
+  });
+
   document.addEventListener('DOMContentLoaded', () => {
     if (localStorage.getItem('argus_show_filters') === 'false') {
       document.getElementById('filter-controls-box')?.classList.add('filters-collapsed');

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_autorefresh.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_autorefresh.html
@@ -1,7 +1,8 @@
 {# djlint:off #}
 {% with preferences.argus_htmx.update_interval as update_interval %}
   {% if update_interval != 'never' %}
-    hx-get="{% querystring page=page.number %}"
+    hx-get="{% url 'htmx:incident-list' %}"
+    hx-vals='{"page": "{{ page.number }}"}'
     hx-target="this"
     hx-swap="outerHTML"
     hx-trigger="every {{ update_interval }}s"

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -5,7 +5,8 @@ page works without JavaScript, and to ensure the link is
 displayed as clickable.
 -->
 <li>
-  <a hx-get="{% querystring page=page_number %}"
+  <a hx-get="{% url 'htmx:incident-list' %}"
+     hx-vals='{"page": "{{ page_number }}"}'
      href="{% querystring page=page_number %}"
      hx-indicator="#incident-list .htmx-indicator"
      hx-include=".incident-list-param"

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_checkbox.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_checkbox.html
@@ -1,5 +1,5 @@
 <!-- htmx/incident/cells/_incident_checkbox.html -->
-<label for="select-incident-{{ incident.pk }}" class="sr-only">Select all visible</label>
+<label for="select-incident-{{ incident.pk }}" class="sr-only">Select incident {{ incident.pk }}</label>
 <input id="select-incident-{{ incident.pk }}"
        hx-preserve
        type="checkbox"


### PR DESCRIPTION
## Scope and purpose

Fix two UX issues on the incidents page.

**URL parameter duplication:** `sort`, `sort_order`, and `page` appeared multiple times in the URL bar due to overlap between `hx-vals` and `hx-include`. The paginator and auto-refresh also doubled up params by combining `{% querystring %}` with `hx-include`.

**Checkbox accessibility:** Row checkboxes all had the label "Select all visible" instead of referencing the specific incident.

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after