### PR TITLE
Add task for finding latest version

### DIFF
--- a/docs/reference/site-specific-settings.rst
+++ b/docs/reference/site-specific-settings.rst
@@ -429,3 +429,13 @@ Debugging settings
 
 * :setting:`TEMPLATE_DEBUG` (optional) provides a convenient way to turn debugging on and off
   for templates. If undefined it will default to the value of :setting:`DEBUG`.
+
+
+PyPI settings
+-------------
+.. setting:: PYPI_URL
+
+* :setting:`PYPI_URL` is the URL used to check for the latest version of Argus. The default is
+  a proxy server called ``https://pypi-proxy.sokrates.edupaas.no``.
+  The proxy is used so we can get a sense of how many people use Argus and what versions they are running.
+  If you do not wish to use the Proxy, simply change the URL to ``https://pypi.org``.

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -335,3 +335,6 @@ del _extra_apps_env
 update_settings(globals(), EXTRA_APPS)
 
 BANNER_MESSAGE = get_str_env("ARGUS_BANNER_MESSAGE", default=None)
+
+# Used for looking up the latest version of Argus on PyPI
+PYPI_URL = get_str_env("ARGUS_PYPI_URL", "https://pypi-proxy.sokrates.edupaas.no")

--- a/src/argus/versioncheck/tasks.py
+++ b/src/argus/versioncheck/tasks.py
@@ -1,0 +1,33 @@
+import logging
+import requests
+from urllib.parse import urljoin
+
+from django_tasks import task
+from django.conf import settings
+
+from argus.versioncheck.models import LastSeenVersion
+from argus.site.views import get_version
+
+LOG = logging.getLogger(__name__)
+
+
+@task
+def task_register_latest_version():
+    try:
+        latest_version = get_latest_version()
+        LastSeenVersion.objects.get_or_create(version=latest_version)
+    except requests.RequestException as e:
+        LOG.error("Error getting latest version: %s", e)
+
+
+def get_latest_version():
+    # Custom user agent so we can see in logs if it's an argus instance or just a crawler that's checking the page
+    version = get_version()
+    response = requests.get(
+        urljoin(settings.PYPI_URL, "/pypi/argus-server/json"),
+        timeout=5,
+        headers={"User-Agent": f"Argus-server-{version}"},
+    )
+    response.raise_for_status()
+    data = response.json()
+    return data["info"]["version"]

--- a/tests/versioncheck/test_tasks.py
+++ b/tests/versioncheck/test_tasks.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+from django.test import TestCase, tag
+from requests import RequestException
+
+from argus.versioncheck.models import LastSeenVersion
+from argus.versioncheck.tasks import task_register_latest_version, get_latest_version
+from argus.util.testing import connect_signals, disconnect_signals
+
+
+@tag("database")
+class TestTaskRegisterLatestVersion(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+    def tearDown(self):
+        connect_signals()
+
+    @patch("argus.versioncheck.tasks.get_latest_version")
+    def test_when_new_version_is_not_already_registered_then_register_new_version(self, get_latest_version):
+        get_latest_version.return_value = "1.2.3"
+        assert not LastSeenVersion.objects.filter(version="1.2.3").exists()
+        task_register_latest_version.func()
+        assert LastSeenVersion.objects.filter(version="1.2.3").exists()
+
+    @patch("argus.versioncheck.tasks.get_latest_version")
+    def test_when_new_version_is_already_registered_then_do_not_register_it_again(self, get_latest_version):
+        get_latest_version.return_value = "1.2.3"
+        LastSeenVersion.objects.create(version="1.2.3")
+        assert LastSeenVersion.objects.filter(version="1.2.3").count() == 1
+        task_register_latest_version.func()
+        # Still only one instance of this version in the database
+        assert LastSeenVersion.objects.filter(version="1.2.3").count() == 1
+
+    @patch("argus.versioncheck.tasks.get_latest_version")
+    def test_when_a_request_exception_occurs_then_do_not_raise_exception(self, get_latest_version):
+        get_latest_version.side_effect = RequestException
+        try:
+            task_register_latest_version.func()
+        except RequestException:
+            self.fail("task_register_latest_version raised RequestException unexpectedly!")
+
+
+@tag("unittest")
+class TestGetLatestVersion(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+    def tearDown(self):
+        connect_signals()
+
+    @patch("argus.versioncheck.tasks.requests.get")
+    def test_it_should_return_correct_version(self, mock_get):
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"info": {"version": "1.2.3"}}
+        version = get_latest_version()
+        self.assertEqual(version, "1.2.3")


### PR DESCRIPTION
## Scope and purpose

Partially fixes #1881 by adding the task itself, but the task is never run.

The plan was to run this with `django-crontask`, but that requires 3.12 while Argus support 3.10 and 3,11, so we currently dont know how to run this

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
