### PR TITLE
Add setup-tailwind-standalone Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean testclean distclean coverageclean cacheclean nuke setup-tailwind tailwind-config tailwind-build-config tailwind docclean upgrade-tailwind tailwind-watch check-test-names sync
+.PHONY: clean testclean distclean coverageclean cacheclean nuke setup-tailwind setup-tailwind-standalone tailwind-config tailwind-build-config tailwind docclean upgrade-tailwind tailwind-watch check-test-names sync
 
 TAILWINDDIR=src/argus/htmx/tailwindtheme
 STATICDIR=src/argus/htmx/static
@@ -32,6 +32,8 @@ testclean: coverageclean clean
 nuke: clean docclean distclean testclean cacheclean
 
 setup-tailwind: upgrade-tailwind tailwind-config tailwind
+
+setup-tailwind-standalone: upgrade-tailwind tailwind-build-config tailwind
 
 tailwind-config:
 	PYTHONPATH=$(PYTHONPATH) python3 manage.py tailwind_config


### PR DESCRIPTION
## Scope and purpose

Add `make setup-tailwind-standalone`. It is a Django-free alternative to `make setup-tailwind` for use when building releases.

It chains the existing targets `upgrade-tailwind`, `tailwind-build-config`, and `tailwind`, which all work without Django.

## Contributor Checklist

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)