### PR TITLE
Show generated token inline in sources table

### DIFF
--- a/src/argus/htmx/sourcesystem/views.py
+++ b/src/argus/htmx/sourcesystem/views.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.db.models import Count, ProtectedError
 from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
@@ -98,9 +99,24 @@ class SourceSystemTokenView(UserIsStaffMixin, View):
     http_method_names = ["post"]
 
     def post(self, request, pk):
-        source = get_object_or_404(SourceSystem, pk=pk)
+        source = get_object_or_404(
+            SourceSystem.objects.select_related("type", "user", "user__auth_token").annotate(
+                incident_count=Count("incidents")
+            ),
+            pk=pk,
+        )
         Token.objects.filter(user=source.user).delete()
         token = Token.objects.create(user=source.user)
+
+        if request.headers.get("HX-Request"):
+            source.token_status = "valid"
+            messages.success(request, f'New token generated for "{source}".')
+            return TemplateResponse(
+                request,
+                "htmx/sourcesystem/_sourcesystem_row.html",
+                {"source": source, "generated_token": token.key},
+            )
+
         messages.success(
             request,
             f'New token for "{source}": {token.key}',

--- a/src/argus/htmx/templates/htmx/sourcesystem/_sourcesystem_row.html
+++ b/src/argus/htmx/templates/htmx/sourcesystem/_sourcesystem_row.html
@@ -1,0 +1,102 @@
+<tbody id="source-{{ source.pk }}"
+       class="[&:last-child_tr:last-child_td]:border-b-0">
+  <tr>
+    <td class="{% if not generated_token %}border-b border-base-300{% endif %}">{{ source.name }}</td>
+    <td class="{% if not generated_token %}border-b border-base-300{% endif %}">
+      <span class="badge badge-primary text-xs">{{ source.type }}</span>
+    </td>
+    <td class="{% if not generated_token %}border-b border-base-300{% endif %} max-w-xs truncate">
+      {{ source.base_url|default:"-" }}
+    </td>
+    <td class="{% if not generated_token %}border-b border-base-300{% endif %}">
+      {% if source.token_status == "valid" %}
+        <span class="badge badge-outline badge-success text-xs gap-1">
+          <i class="fa-solid fa-check" aria-hidden="true"></i> Valid
+        </span>
+      {% elif source.token_status == "expired" %}
+        <span class="badge badge-outline badge-error text-xs gap-1">
+          <i class="fa-solid fa-exclamation" aria-hidden="true"></i> Expired
+        </span>
+      {% else %}
+        <span class="badge badge-outline text-xs gap-1">
+          <i class="fa-solid fa-minus" aria-hidden="true"></i> Missing
+        </span>
+      {% endif %}
+    </td>
+    <td class="{% if not generated_token %}border-b border-base-300{% endif %} text-right">{{ source.incident_count }}</td>
+    <td class="{% if not generated_token %}border-b border-base-300{% endif %} text-right overflow-visible">
+      {% if request.user.is_staff %}
+        <div class="flex gap-1 justify-end">
+          <a href="{% url 'htmx:sourcesystem-update' pk=source.pk %}"
+             class="btn btn-sm btn-ghost">Edit</a>
+          <div class="dropdown dropdown-end">
+            <button tabindex="0" class="btn btn-sm btn-ghost btn-square">
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   class="h-4 w-4"
+                   viewBox="0 0 20 20"
+                   fill="currentColor">
+                <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+              </svg>
+            </button>
+            <ul class="dropdown-content z-[50] menu menu-sm p-2 shadow bg-base-100 rounded-box w-max border border-base-300">
+              <li>
+                <button type="button"
+                        hx-post="{% url 'htmx:sourcesystem-token' pk=source.pk %}"
+                        hx-target="#source-{{ source.pk }}"
+                        hx-swap="outerHTML"
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+                  <i class="fa-solid fa-key" aria-hidden="true"></i>
+                  {% if source.token_status == "missing" %}
+                    Generate token
+                  {% else %}
+                    Regenerate token
+                  {% endif %}
+                </button>
+              </li>
+              {% if source.incident_count %}
+                <li class="disabled">
+                  <span class="tooltip tooltip-left tooltip-warning"
+                        data-tip="Cannot delete: has {{ source.incident_count }} incident{{ source.incident_count|pluralize }}">
+                    <i class="fa-regular fa-trash-can" aria-hidden="true"></i> Delete
+                  </span>
+                </li>
+              {% else %}
+                <li>
+                  <button type="button"
+                          class="text-error"
+                          onclick="document.getElementById('delete-dialog-{{ source.pk }}').showModal()">
+                    <i class="fa-regular fa-trash-can" aria-hidden="true"></i> Delete
+                  </button>
+                </li>
+              {% endif %}
+            </ul>
+          </div>
+        </div>
+      {% endif %}
+    </td>
+  </tr>
+  {% if generated_token %}
+    <tr>
+      <td colspan="6" class="border-b border-base-300 py-2">
+        <div class="flex items-center gap-2">
+          <span class="text-xs text-success font-medium">
+            <i class="fa-solid fa-check" aria-hidden="true"></i>
+            Token generated for "{{ source.name }}"
+          </span>
+          <input type="text"
+                 value="{{ generated_token }}"
+                 readonly
+                 size="40"
+                 class="input input-xs input-bordered font-mono w-auto select-all"
+                 onclick="this.select()" />
+          <button type="button"
+                  class="btn btn-xs btn-ghost"
+                  onclick="navigator.clipboard.writeText('{{ generated_token }}'); this.querySelector('i').className = 'fa-solid fa-check'; setTimeout(() => this.querySelector('i').className = 'fa-regular fa-clipboard', 2000)"
+                  title="Copy to clipboard">
+            <i class="fa-regular fa-clipboard"></i>
+          </button>
+        </div>
+      </td>
+    </tr>
+  {% endif %}
+</tbody>

--- a/src/argus/htmx/templates/htmx/sourcesystem/sourcesystem_list.html
+++ b/src/argus/htmx/templates/htmx/sourcesystem/sourcesystem_list.html
@@ -18,95 +18,18 @@
           <th class="border-b border-primary text-right">Actions</th>
         </tr>
       </thead>
-      <tbody>
-        {% for source in object_list %}
-          <tr class="group">
-            <td class="border-b border-neutral-content group-last:border-b-0">{{ source.name }}</td>
-            <td class="border-b border-neutral-content group-last:border-b-0">
-              <span class="badge badge-primary text-xs">{{ source.type }}</span>
-            </td>
-            <td class="border-b border-neutral-content group-last:border-b-0 max-w-xs truncate">
-              {{ source.base_url|default:"-" }}
-            </td>
-            <td class="border-b border-neutral-content group-last:border-b-0">
-              {% if source.token_status == "valid" %}
-                <span class="badge badge-outline badge-success text-xs gap-1">
-                  <i class="fa-solid fa-check" aria-hidden="true"></i> Valid
-                </span>
-              {% elif source.token_status == "expired" %}
-                <span class="badge badge-outline badge-error text-xs gap-1">
-                  <i class="fa-solid fa-exclamation" aria-hidden="true"></i> Expired
-                </span>
-              {% else %}
-                <span class="badge badge-outline text-xs gap-1">
-                  <i class="fa-solid fa-minus" aria-hidden="true"></i> Missing
-                </span>
-              {% endif %}
-            </td>
-            <td class="border-b border-neutral-content group-last:border-b-0 text-right">{{ source.incident_count }}</td>
-            <td class="border-b border-neutral-content group-last:border-b-0 text-right overflow-visible">
-              {% if request.user.is_staff %}
-                <div class="flex gap-1 justify-end">
-                  <a href="{% url 'htmx:sourcesystem-update' pk=source.pk %}"
-                     class="btn btn-sm btn-ghost">Edit</a>
-                  <div class="dropdown dropdown-end">
-                    <button tabindex="0" class="btn btn-sm btn-ghost btn-square">
-                      <svg xmlns="http://www.w3.org/2000/svg"
-                           class="h-4 w-4"
-                           viewBox="0 0 20 20"
-                           fill="currentColor">
-                        <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-                      </svg>
-                    </button>
-                    <ul class="dropdown-content z-[50] menu menu-sm p-2 shadow bg-base-100 rounded-box w-max border border-base-300">
-                      <li>
-                        <button type="button"
-                                onclick="document.getElementById('token-form-{{ source.pk }}').submit()">
-                          <i class="fa-solid fa-key" aria-hidden="true"></i>
-                          {% if source.token_status == "missing" %}
-                            Generate token
-                          {% else %}
-                            Regenerate token
-                          {% endif %}
-                        </button>
-                      </li>
-                      {% if source.incident_count %}
-                        <li class="disabled">
-                          <span class="tooltip tooltip-left tooltip-warning"
-                                data-tip="Cannot delete: has {{ source.incident_count }} incident{{ source.incident_count|pluralize }}">
-                            <i class="fa-regular fa-trash-can" aria-hidden="true"></i> Delete
-                          </span>
-                        </li>
-                      {% else %}
-                        <li>
-                          <button type="button"
-                                  class="text-error"
-                                  onclick="document.getElementById('delete-dialog-{{ source.pk }}').showModal()">
-                            <i class="fa-regular fa-trash-can" aria-hidden="true"></i> Delete
-                          </button>
-                        </li>
-                      {% endif %}
-                    </ul>
-                  </div>
-                </div>
-              {% endif %}
-            </td>
-          </tr>
-        {% empty %}
+      {% for source in object_list %}
+        {% include "./_sourcesystem_row.html" %}
+      {% empty %}
+        <tbody>
           <tr>
             <td colspan="6" class="text-center text-base-content/60 py-4">No source systems configured</td>
           </tr>
-        {% endfor %}
-      </tbody>
+        </tbody>
+      {% endfor %}
     </table>
     {% if request.user.is_staff %}
       {% for source in object_list %}
-        <form id="token-form-{{ source.pk }}"
-              method="post"
-              action="{% url 'htmx:sourcesystem-token' pk=source.pk %}"
-              class="hidden">
-          {% csrf_token %}
-        </form>
         {% if not source.incident_count %}
           {% include "./_delete_confirm_dialog.html" with obj=source delete_url_name="htmx:sourcesystem-delete" obj_type="source" %}
         {% endif %}

--- a/tests/htmx/sourcesystem/test_views.py
+++ b/tests/htmx/sourcesystem/test_views.py
@@ -227,6 +227,27 @@ class SourceSystemTokenViewTests(TestCase):
         self.assertEqual(len(msgs), 1)
         self.assertIn(token.key, str(msgs[0]))
 
+    def test_given_htmx_request_when_generating_it_should_return_partial(self):
+        self.client.force_login(self.staff_user)
+        response = self.client.post(
+            reverse("htmx:sourcesystem-token", kwargs={"pk": self.source.pk}),
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        token = Token.objects.get(user=self.source.user)
+        self.assertContains(response, token.key)
+
+    def test_given_htmx_request_when_generating_it_should_not_include_token_in_message(self):
+        self.client.force_login(self.staff_user)
+        response = self.client.post(
+            reverse("htmx:sourcesystem-token", kwargs={"pk": self.source.pk}),
+            HTTP_HX_REQUEST="true",
+        )
+        token = Token.objects.get(user=self.source.user)
+        msgs = list(response.context["messages"])
+        self.assertEqual(len(msgs), 1)
+        self.assertNotIn(token.key, str(msgs[0]))
+
 
 @tag("integration")
 class SourceSystemTypeListViewTests(TestCase):


### PR DESCRIPTION
## Scope and purpose

Fixes #1911.

After generating a token, show it inline in the sources table with a copyable text field instead of only in a transient toast notification.

### Demo
https://github.com/user-attachments/assets/79b4bbcf-9d03-4f6c-9e61-52ed66d5a202

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html) — covered by #1901's changelog entry
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after — see demo above