### PR TITLE
Add dedicated health check endpoint to prove that argus is up

### DIFF
--- a/changelog.d/+dedicated-healthcheck-endpoint.added.md
+++ b/changelog.d/+dedicated-healthcheck-endpoint.added.md
@@ -1,0 +1,2 @@
+A new endpoint dedicated to health checks was added, on "/.still-alive/". This
+is to make it easier to filter out in access logs.

--- a/docs/production.rst
+++ b/docs/production.rst
@@ -2,8 +2,8 @@
 Running in production
 =====================
 
-
 .. toctree::
 
    production/task-queue
    production/logging
+   production/health-check

--- a/docs/production/health-check.rst
+++ b/docs/production/health-check.rst
@@ -1,0 +1,13 @@
+===================================================
+Checking that Argus is up and running and reachable
+===================================================
+
+It is useful to be able to easily, cheaply and automatically verify that the
+server is up and running. This is called doing a "health check" or "pinging".
+
+Argus has a specific endpoint for this: ``/.still-alive/``. It will always
+return HTTP status code 204, and an empty body. It is idempotent, needs no
+authentication and can safely be accessed with any HTTP method.
+
+You might want to exclude log lines for visiting ``/.still-alive/`` as they can
+add a lot of noise to an access log.

--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -26,7 +26,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from argus.constants import API_STABLE_VERSION, API_STABLE_SCHEMA_VIEWNAME
 from argus.notificationprofile.v2.views import SchemaView
 from argus.site.utils import get_urlpatterns
-from argus.site.views import index, MetadataView, api_gone, error
+from argus.site.views import index, MetadataView, api_gone, error, health_check
 
 api_v1_gone = partial(api_gone, message="API v1 has been removed")
 
@@ -34,6 +34,7 @@ api_v1_gone = partial(api_gone, message="API v1 has been removed")
 urlpatterns = [
     path("favicon.ico", RedirectView.as_view(url="/static/favicon.svg", permanent=True)),
     path(".error/", error, name="error"),
+    path(".still-alive/", health_check),  # doesn't need a name
     path("admin/", admin.site.urls),
     path(
         "api/schema/",

--- a/src/argus/site/views.py
+++ b/src/argus/site/views.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from argus.constants import API_STABLE_VERSION, API_STABLE_SCHEMA_VIEWNAME
+from argus.util.http import HttpResponseNoContent
 from .serializers import MetadataSerializer
 
 LOG = logging.getLogger(__name__)
@@ -31,6 +32,13 @@ def index(request):
     }
     return render(request, "index.html", context=context)
 index.login_required = False
+# fmt: on
+
+
+# fmt: off
+def health_check(request):
+    return HttpResponseNoContent()
+health_check.login_required = False
 # fmt: on
 
 

--- a/src/argus/util/http.py
+++ b/src/argus/util/http.py
@@ -1,0 +1,6 @@
+from http import HTTPStatus
+from django.http import HttpResponse
+
+
+class HttpResponseNoContent(HttpResponse):
+    status_code = HTTPStatus.NO_CONTENT

--- a/tests/site/test_views.py
+++ b/tests/site/test_views.py
@@ -15,6 +15,12 @@ class TestAPIV1GoneView(TestCase):
             self.assertEqual(response.status_code, status.HTTP_410_GONE)
 
 
+class TestHealthCheckView(TestCase):
+    def test_it_should_always_return_204(self):
+        response = self.client.get("/.still-alive/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+
 class TestErrorView(TestCase):
     def setUp(self):
         self.user = PersonUserFactory()


### PR DESCRIPTION
## Scope and purpose

Add an endpoint just for checking if Argus is up and running, returns status 204 and no content. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
