### PR TITLE
Add new log level: TRACE (5)

### DIFF
--- a/changelog.d/+add-log-level-trace.added.md
+++ b/changelog.d/+add-log-level-trace.added.md
@@ -1,0 +1,26 @@
+Added a new log level: TRACE, for stuff even less important than DEBUG. In the
+process, moved logging helpers to a dedicated home in anticipation of
+supporting better logging in production.
+
+This new level is really not a good match for use in production, expect a lot
+of noise. See NOTES for configuration.
+
+NOTES:
+
+
+`TRACE` is not an unusal level to have, so if you set the root logger to
+`TRACE` you might get a lot of noise from dependencies. We therefore recommend
+that you never set the root logger to `TRACE` but instead set it on specific
+subloggers when you need higher detail. `TRACE` is currently only used in the
+`argus.htmx` app for now.
+
+If treating argus as a library, you will need to make sure that
+`argus.logging.utils.setup_logging` has been run for this new level to work.
+`argus.settings.base` does this automatically.
+
+If you get the exception
+
+> AttributeError: 'Logger' object has no attribute 'trace'
+
+this is caused by `setup_logging()` never having been run. `setup_logging()`
+with no parameters is idempotent and thus safe to run multiple times.

--- a/src/argus/htmx/incident/columns.py
+++ b/src/argus/htmx/incident/columns.py
@@ -292,7 +292,7 @@ def get_default_column_layout():
     be removed in the future.
     """
     column_setting = getattr(settings, "INCIDENT_TABLE_COLUMNS", [])
-    LOG.debug("Getting INCIDENT_TABLE_COLUMNS: column_setting: %s", column_setting)
+    LOG.trace("Getting INCIDENT_TABLE_COLUMNS: column_setting: %s", column_setting)
     return _DEFAULT_COLUMN_LAYOUT_NAME, column_setting
 
 
@@ -304,7 +304,7 @@ def get_configured_column_layouts():
     argus.htmx.defaults and INCIDENT_TABLE_COLUMNS.
     """
     column_settings = getattr(settings, "INCIDENT_TABLE_COLUMN_LAYOUTS", {})
-    LOG.debug("Getting INCIDENT_TABLE_COLUMN_LAYOUTS: column_setting: %s", column_settings)
+    LOG.trace("Getting INCIDENT_TABLE_COLUMN_LAYOUTS: column_setting: %s", column_settings)
     return column_settings
 
 
@@ -322,7 +322,7 @@ def get_available_column_layouts():
     if configured_layouts:
         layouts.update(configured_layouts)
 
-    LOG.debug("Available column layouts: %s", layouts)
+    LOG.trace("Available column layouts: %s", layouts)
     return layouts
 
 
@@ -339,7 +339,7 @@ def get_incident_table_columns(name: str = BUILTIN_COLUMN_LAYOUT_NAME) -> list[I
 
     Falls back to the built-in layout if the name is unknown."""
 
-    LOG.debug("Getting layouts: get_incident_table_columns")
+    LOG.trace("Getting layouts: get_incident_table_columns")
     layouts = get_available_column_layouts()
     if name not in layouts:
         name = BUILTIN_COLUMN_LAYOUT_NAME
@@ -353,7 +353,7 @@ def get_default_column_layout_name():
     If a layout named "default" is found in the layouts, use that as the
     fallback, otherwise fall back to the built-in layout."""
 
-    LOG.debug("Getting layouts: get_default_column_layout_name")
+    LOG.trace("Getting layouts: get_default_column_layout_name")
     layouts = get_available_column_layouts()
     if _DEFAULT_COLUMN_LAYOUT_NAME in layouts.keys():
         return _DEFAULT_COLUMN_LAYOUT_NAME

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -283,7 +283,7 @@ class FilterListView(ListView):
 
 def incident_list_filter(request, qs, use_empty_filter=False):
     LOG = logging.getLogger(__name__ + ".incident_list_filter")
-    LOG.debug("GET at start: %s", request.GET)
+    LOG.trace("GET at start: %s", request.GET)
     filter_pk, filter_obj = request.session.get("selected_filter", None), None
     if filter_pk:
         try:
@@ -293,41 +293,41 @@ def incident_list_filter(request, qs, use_empty_filter=False):
             filter_pk, filter_obj = None, None
     if filter_obj:
         form = IncidentFilterForm(_convert_filterblob(filter_obj.filter.copy()))
-        LOG.debug("using stored filter: %s", filter_obj.filter)
+        LOG.trace("using stored filter: %s", filter_obj.filter)
     else:
         form_data = _normalize_form_data(request)
         if request.method == "POST":
             form = IncidentFilterForm(form_data)
-            LOG.debug("using POST: %s", form_data)
+            LOG.trace("using POST: %s", form_data)
         else:
             if use_empty_filter:
                 form_data = IncidentFilterForm.DEFAULT_VALUES
                 form = IncidentFilterForm(form_data)
-                LOG.debug("using empty filter: %s", form_data)
+                LOG.trace("using empty filter: %s", form_data)
             elif form_data:
                 # User has explicitly set filter params in URL
                 form = IncidentFilterForm(form_data)
-                LOG.debug("using GET: %s", form_data)
+                LOG.trace("using GET: %s", form_data)
             else:
                 # No filter params - try to load from user preference
                 stored_filter = _get_filter_preference(request)
                 if stored_filter:
                     form = IncidentFilterForm(_convert_filterblob(stored_filter.copy()))
-                    LOG.debug("using stored preference filter: %s", stored_filter)
+                    LOG.trace("using stored preference filter: %s", stored_filter)
                 else:
                     form = IncidentFilterForm(None)
-                    LOG.debug("using empty form (no preference)")
+                    LOG.trace("using empty form (no preference)")
 
     filterblob = {}
     if form.is_valid():
-        LOG.debug("Cleaned data: %s", form.cleaned_data)
+        LOG.trace("Cleaned data: %s", form.cleaned_data)
         filterblob = form.to_filterblob()
         qs = QuerySetFilter.filtered_incidents(filterblob, qs)
     else:
         if not request.GET:
-            LOG.debug("empty form")
+            LOG.trace("empty form")
         else:
-            LOG.debug("Dirty form: %s", form.errors)
+            LOG.trace("Dirty form: %s", form.errors)
             for field, error_messages in form.errors.items():
                 messages.error(request, f"{field}: {','.join(error_messages)}")
 

--- a/src/argus/logging/utils.py
+++ b/src/argus/logging/utils.py
@@ -1,0 +1,63 @@
+import logging
+import logging.config
+
+from django.utils.module_loading import import_string
+
+
+__all__ = [
+    "setup_logging",
+    #     "update_loglevels",
+]
+
+
+def setup_logging(dotted_path=None):
+    """Use the dictionary on the dotted path to set up logging
+
+    Returns the dictionary on success, otherwise None.
+    """
+    _add_logging_level("TRACE", 5)
+
+    if dotted_path:
+        try:
+            class_or_attr = import_string(dotted_path)
+        except AttributeError:
+            return
+
+        logging.config.dictConfig(class_or_attr)
+        return class_or_attr
+
+
+# Removed until needed. Should be changed to be idempotent, but that requires
+# dumping the existing config as a dict first.
+# def update_loglevels(loglevel: str = "INFO", loggers=(), handlers=()) -> None:
+#     """Override specific loglevels in already setup loggers or handlers"""
+#     loglevel = loglevel.upper()
+#     for logger in loggers:
+#         logging.getLogger(logger).setLevel(loglevel)
+#     if handlers:
+#         handlerdict = {}
+#         for handler in handlers:
+#             handlerdict[handler] = {"level": loglevel}
+#         logdict = {
+#             "version": 1,
+#             "disable_existing_loggers": False,
+#             "incremental": True,
+#             "handlers": handlerdict,
+#         }
+#         logging.config.dictConfig(logdict)
+
+
+def _add_logging_level(level_name, level_num):
+    if hasattr(logging, level_name):
+        return
+    logging.addLevelName(level_num, level_name)
+
+    def log_with_custom_level(self, message, *args, **kwargs):
+        if self.isEnabledFor(level_num):
+            self._log(level_num, message, args, **kwargs)
+
+    setattr(logging.Logger, level_name.lower(), log_with_custom_level)
+
+
+# Readthedocs fails the build without this
+_add_logging_level("TRACE", 5)

--- a/src/argus/site/settings/__init__.py
+++ b/src/argus/site/settings/__init__.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import json
-import logging.config
 from os import getenv
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
-from django.utils.module_loading import import_string
-
 from ._serializers import ListAppSetting
+from argus.logging.utils import setup_logging
 
 
 __all__ = [
@@ -128,38 +126,3 @@ def normalize_url(url):
     netloc = "".join(netloc.rsplit(":", 1)[0])
     fixed_url = parsed_url._replace(netloc=netloc)
     return urlunsplit(fixed_url)
-
-
-# logging-helpers, we want the logging-setup separate from the rest
-
-
-def setup_logging(dotted_path=None):
-    """Use the dictionary on the dotted path to set up logging
-
-    Returns the dictionary on success, otherwise None.
-    """
-    if dotted_path:
-        try:
-            class_or_attr = import_string(dotted_path)
-        except AttributeError:
-            return
-        logging.config.dictConfig(class_or_attr)
-        return class_or_attr
-
-
-def update_loglevels(loglevel: str = "INFO", loggers=(), handlers=()) -> None:
-    """Override specific loglevels in already setup loggers or handlers"""
-    loglevel = loglevel.upper()
-    for logger in loggers:
-        logging.getLogger(logger).setLevel(loglevel)
-    if handlers:
-        handlerdict = {}
-        for handler in handlers:
-            handlerdict["handler"] = {"level": loglevel}
-        logdict = {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "incremental": True,
-            "handlers": handlerdict,
-        }
-        logging.config.dictConfig(logdict)

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -21,6 +21,14 @@ from ..utils import update_settings
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
+# Logging
+
+LOGGING_MODULE = get_str_env("DJANGO_LOGGING_MODULE", None)
+if LOGGING_MODULE:
+    LOGGING_CONFIG = None
+    STARTUP_LOGGING = setup_logging(LOGGING_MODULE)
+
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = get_bool_env("DEBUG", False)
 
@@ -193,13 +201,6 @@ EMAIL_PORT = get_int_env("EMAIL_PORT", 25)
 EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=False)
 EMAIL_HOST_PASSWORD = get_str_env("EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = get_str_env("DEFAULT_FROM_EMAIL", "argus@localhost")
-
-# Logging
-
-LOGGING_MODULE = get_str_env("DJANGO_LOGGING_MODULE", None)
-if LOGGING_MODULE:
-    LOGGING_CONFIG = None
-    STARTUP_LOGGING = setup_logging(LOGGING_MODULE)
 
 # For permalinks to incidents in argus dashboard
 FRONTEND_URL = get_str_env("ARGUS_FRONTEND_URL")

--- a/src/argus/site/settings/test_CI.py
+++ b/src/argus/site/settings/test_CI.py
@@ -4,7 +4,10 @@ import logging.config
 
 from argus.htmx.settings import *  # noqa: F403
 
-from . import get_bool_env, get_str_env
+from . import get_bool_env, get_str_env, setup_logging
+
+
+setup_logging()
 
 DEBUG = get_bool_env("DEBUG", True)
 TEMPLATES[0]["OPTIONS"]["debug"] = get_bool_env("TEMPLATE_DEBUG", True)  # noqa: F405

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+from unittest import TestCase
+
+from django.test import tag
+
+
+@tag("unit")
+class TraceLogTests(TestCase):
+    def test_logging_with_level_TRACE_should_not_trigger_any_errors(self):
+        LOG = logging.getLogger(__name__)
+        message = "this is a test"
+        with self.assertLogs(logger=__name__, level="TRACE") as cm:
+            LOG.trace(message)
+            self.assertEqual(cm.output, [f"TRACE:tests.test_logging_utils:{message}"])


### PR DESCRIPTION
## Scope and purpose

In order to be able to filter logs better in production I want to add an additional log level, for debugging at an even higher level of detail.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
