### PR TITLE
Add API endpoints for planned maintenance tasks

### DIFF
--- a/changelog.d/1774.added.md
+++ b/changelog.d/1774.added.md
@@ -1,0 +1,1 @@
+Add maintenance API endpoints

--- a/docs/reference/api/v2.rst
+++ b/docs/reference/api/v2.rst
@@ -1003,3 +1003,78 @@ Notification profile endpoints
        {
            "sourceSystemIds": [<SourceSystem.pk>, ...]
        }
+
+Planned maintenance endpoints
+-----------------------------
+
+-  ``/api/v2/plannedmaintenance/``:
+
+   -  ``GET``: returns all planned maintenance tasks
+
+      .. code-block:: json
+        :caption: Example response body
+
+          [
+            {
+              "pk": 0,
+              "created_by": {
+                "pk": 1,
+                "username": "admin"
+              },
+              "created": "2026-05-08T14:03:12.590Z",
+              "start_time": "2026-05-08T14:03:12.590Z",
+              "end_time": "2026-05-09T14:03:12.590Z",
+              "description": "Moving the server room",
+              "filters": [
+                {
+                  "pk": 7,
+                  "name": "test",
+                  "filter": {
+                    "sourceSystemIds": [
+                      2
+                    ],
+                    "source_types": [
+                      "argus"
+                    ],
+                    "open": null,
+                    "acked": null,
+                    "stateful": null,
+                    "maxlevel": null,
+                    "event_type": null
+                  }
+                }
+              ]
+            }
+          ]
+
+
+   -  ``POST``: creates and returns a planned maintenance task, which is then
+      connected to the logged in user, omit the end time to set it to infinite, only
+      possible for admins
+
+      .. code-block:: json
+        :caption: Example request body
+
+          {
+            "start_time": "2026-05-08T08:28:51.204Z",
+            "end_time": "2026-05-09T08:28:51.204Z",
+            "description": "Moving the server room",
+            "filters": [
+              1
+            ]
+          }
+
+
+-  ``/api/v2/plannedmaintenance/<int:pk>/``:
+
+   -  ``GET``: returns a planned maintenance task by primary key
+
+   -  ``PATCH``: updates and returns a planned maintenance task by primary key, only
+      possible if the task has not ended more than 12 hours ago, only possible for
+      admins
+
+      -  Example request body: same or a subset of ``POST`` to
+         ``/api/v2/plannedmaintenance/``
+
+   -  ``DELETE``: deletes a planned maintenance task by primary key, only possible if
+      the task is in the future and for admins

--- a/src/argus/drf/permissions.py
+++ b/src/argus/drf/permissions.py
@@ -14,6 +14,14 @@ class IsSuperuserOrReadOnly(permissions.BasePermission):
         return request.user.is_superuser
 
 
+class IsAdminOrReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return request.user.is_staff
+
+
 class IsOwnerOrReadOnly(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:

--- a/src/argus/plannedmaintenance/serializers.py
+++ b/src/argus/plannedmaintenance/serializers.py
@@ -1,0 +1,41 @@
+from rest_framework import serializers
+
+from argus.auth.serializers import UsernameSerializer
+from argus.filter.serializers import FilterSerializer
+from argus.plannedmaintenance.models import PlannedMaintenanceTask
+from argus.util.datetime_utils import LOCAL_INFINITY
+
+
+class RequestPlannedMaintenanceTaskSerializer(serializers.ModelSerializer):
+    end_time = serializers.DateTimeField(default=LOCAL_INFINITY, required=False, allow_null=True)
+
+    class Meta:
+        model = PlannedMaintenanceTask
+        fields = [
+            "start_time",
+            "end_time",
+            "description",
+            "filters",
+        ]
+
+    def validate_end_time(self, value):
+        if value is None:
+            return LOCAL_INFINITY
+        return value
+
+
+class ResponsePlannedMaintenanceTaskSerializer(serializers.ModelSerializer):
+    created_by = UsernameSerializer()
+    filters = FilterSerializer(many=True)
+
+    class Meta:
+        model = PlannedMaintenanceTask
+        fields = [
+            "pk",
+            "created_by",
+            "created",
+            "start_time",
+            "end_time",
+            "description",
+            "filters",
+        ]

--- a/src/argus/plannedmaintenance/urls.py
+++ b/src/argus/plannedmaintenance/urls.py
@@ -1,0 +1,9 @@
+from rest_framework import routers
+
+from . import views
+
+router = routers.SimpleRouter()
+router.register(r"", views.PlannedMaintenanceTaskViewSet)
+
+app_name = "plannedmaintenance"
+urlpatterns = router.urls

--- a/src/argus/plannedmaintenance/views.py
+++ b/src/argus/plannedmaintenance/views.py
@@ -1,0 +1,45 @@
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_rw_serializers import viewsets as rw_viewsets
+from rest_framework import serializers, viewsets
+
+from argus.drf.permissions import IsAdminOrReadOnly
+from argus.filter import get_filter_backend
+from argus.plannedmaintenance.models import PlannedMaintenanceTask
+from argus.plannedmaintenance.serializers import (
+    RequestPlannedMaintenanceTaskSerializer,
+    ResponsePlannedMaintenanceTaskSerializer,
+)
+
+
+filter_backend = get_filter_backend()
+QuerySetFilter = filter_backend.QuerySetFilter
+FilterBlobSerializer = filter_backend.FilterBlobSerializer
+
+
+@extend_schema_view(
+    create=extend_schema(
+        request=RequestPlannedMaintenanceTaskSerializer,
+        responses={201: ResponsePlannedMaintenanceTaskSerializer},
+    ),
+    update=extend_schema(
+        request=RequestPlannedMaintenanceTaskSerializer,
+    ),
+    partial_update=extend_schema(
+        request=RequestPlannedMaintenanceTaskSerializer,
+    ),
+)
+class PlannedMaintenanceTaskViewSet(rw_viewsets.ModelViewSet):
+    permission_classes = [*viewsets.GenericViewSet.permission_classes, IsAdminOrReadOnly]
+    serializer_class = ResponsePlannedMaintenanceTaskSerializer
+    read_serializer_class = ResponsePlannedMaintenanceTaskSerializer
+    write_serializer_class = RequestPlannedMaintenanceTaskSerializer
+    queryset = PlannedMaintenanceTask.objects.all()
+    http_method_names = ["get", "head", "post", "patch", "put", "delete"]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user)
+
+    def perform_destroy(self, instance):
+        if not instance.future:
+            raise serializers.ValidationError("It is not possible to delete past or ongoing planned maintenance tasks.")
+        instance.delete()

--- a/src/argus/site/api_v2_urls.py
+++ b/src/argus/site/api_v2_urls.py
@@ -19,5 +19,6 @@ urlpatterns = [
     path("auth/", include("argus.auth.urls")),
     path("incidents/", include("argus.incident.urls")),
     path("notificationprofiles/", include("argus.notificationprofile.v2.urls")),
+    path("plannedmaintenance/", include("argus.plannedmaintenance.urls")),
     path("token-auth/", include((tokenauth_urls, "auth"))),
 ]

--- a/tests/plannedmaintenance/test_serializers.py
+++ b/tests/plannedmaintenance/test_serializers.py
@@ -1,0 +1,110 @@
+from datetime import timedelta
+
+from django.test import TestCase, tag
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory
+
+from argus.auth.factories import AdminUserFactory
+from argus.filter.factories import FilterFactory
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
+from argus.plannedmaintenance.serializers import RequestPlannedMaintenanceTaskSerializer
+from argus.util.datetime_utils import LOCAL_INFINITY
+
+
+@tag("integration")
+class PlannedMaintenanceTaskSerializerTests(TestCase):
+    def setUp(self):
+        self.user = AdminUserFactory()
+
+        now = timezone.now()
+        self.future_pm = PlannedMaintenanceFactory(
+            start_time=now + timedelta(days=1),
+            end_time=LOCAL_INFINITY,
+        )
+        self.current_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(hours=1),
+            end_time=LOCAL_INFINITY,
+        )
+        self.past_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(days=2),
+            end_time=now - timedelta(days=1),
+        )
+        self.recently_ended_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(minutes=60),
+            end_time=now - timedelta(minutes=15),
+        )
+
+        self.open_filter = FilterFactory(filter={"open": True})
+        self.request_factory = APIRequestFactory()
+
+    def test_given_correct_input_then_planned_maintenance_serializer_is_valid(self):
+        request = self.request_factory.post("/")
+        request.user = self.user
+        now = timezone.now()
+        data = {
+            "start_time": now,
+            "end_time": now + timedelta(hours=5),
+            "description": "ABC",
+            "filters": [self.open_filter.pk],
+        }
+        serializer = RequestPlannedMaintenanceTaskSerializer(
+            data=data,
+            context={"request": request},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_given_minimal_input_then_planned_maintenance_serializer_is_valid(self):
+        request = self.request_factory.post("/")
+        request.user = self.user
+        data = {
+            "start_time": timezone.now(),
+            "filters": [self.open_filter.pk],
+        }
+        serializer = RequestPlannedMaintenanceTaskSerializer(
+            data=data,
+            context={"request": request},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_given_end_time_none_then_set_end_time_to_infinity(self):
+        request = self.request_factory.post("/")
+        request.user = self.user
+        data = {
+            "start_time": timezone.now(),
+            "end_time": None,
+            "description": "ABC",
+            "filters": [self.open_filter.pk],
+        }
+        serializer = RequestPlannedMaintenanceTaskSerializer(
+            data=data,
+            context={"request": request},
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["end_time"], LOCAL_INFINITY)
+
+    def test_given_valid_input_then_create_task(self):
+        request = self.request_factory.post("/")
+        request.user = self.user
+        validated_data = {
+            "start_time": timezone.now(),
+            "end_time": LOCAL_INFINITY,
+            "description": "abc",
+            "filters": [self.open_filter.pk],
+            "created_by": self.user,
+        }
+        serializer = RequestPlannedMaintenanceTaskSerializer(
+            context={"request": request},
+        )
+        obj = serializer.create(validated_data)
+        self.assertEqual(obj.description, "abc")
+
+    def test_given_valid_input_then_update_task(self):
+        task = PlannedMaintenanceFactory(description="ABC", created_by=self.user)
+        request = self.request_factory.post("/")
+        request.user = self.user
+        validated_data = {"description": "new description"}
+        serializer = RequestPlannedMaintenanceTaskSerializer(
+            context={"request": request},
+        )
+        obj = serializer.update(task, validated_data)
+        self.assertEqual(obj.description, "new description")

--- a/tests/plannedmaintenance/test_views.py
+++ b/tests/plannedmaintenance/test_views.py
@@ -1,0 +1,298 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from django.test import tag
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from argus.auth.factories import AdminUserFactory, PersonUserFactory
+from argus.filter.factories import FilterFactory
+from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
+from argus.plannedmaintenance.models import PlannedMaintenanceTask
+from argus.util.datetime_utils import LOCAL_INFINITY
+from argus.util.testing import connect_signals, disconnect_signals
+
+
+@tag("API", "integration")
+class PlannedMaintenanceTaskViewTests(APITestCase):
+    ENDPOINT = "/api/v2/plannedmaintenance/"
+
+    def setUp(self):
+        disconnect_signals()
+        self.user = PersonUserFactory()
+        self.staff_user = AdminUserFactory()
+
+        self.user_rest_client = APIClient()
+        self.user_rest_client.force_authenticate(user=self.user)
+
+        self.admin_user_rest_client = APIClient()
+        self.admin_user_rest_client.force_authenticate(user=self.staff_user)
+
+        now = timezone.now()
+        self.future_pm = PlannedMaintenanceFactory(
+            start_time=now + timedelta(days=1),
+            end_time=LOCAL_INFINITY,
+        )
+        self.current_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(hours=1),
+            end_time=LOCAL_INFINITY,
+        )
+        self.past_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(days=2),
+            end_time=now - timedelta(days=1),
+        )
+        self.recently_ended_pm = PlannedMaintenanceFactory(
+            start_time=now - timedelta(minutes=60),
+            end_time=now - timedelta(minutes=15),
+        )
+
+        self.open_filter = FilterFactory(filter={"open": True})
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_getting_list_as_non_admin_then_return_200_ok(self):
+        response = self.user_rest_client.get(path=self.ENDPOINT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    def test_when_getting_list__as_admin_then_return_200_ok(self):
+        response = self.admin_user_rest_client.get(path=self.ENDPOINT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    def test_when_getting_list_then_return_all_planned_maintenance_tasks(self):
+        response = self.admin_user_rest_client.get(path=self.ENDPOINT)
+        all_response_pks = {task["pk"] for task in response.data}
+        self.assertIn(self.future_pm.pk, all_response_pks)
+        self.assertIn(self.current_pm.pk, all_response_pks)
+        self.assertIn(self.recently_ended_pm.pk, all_response_pks)
+        self.assertIn(self.past_pm.pk, all_response_pks)
+
+    def test_when_getting_specific_task_as_non_admin_then_return_200(self):
+        pm_path = f"{self.ENDPOINT}{self.current_pm.pk}/"
+        response = self.user_rest_client.get(path=pm_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    def test_when_getting_specific_task_as_admin_then_return_200_ok(self):
+        pm_path = f"{self.ENDPOINT}{self.current_pm.pk}/"
+        response = self.admin_user_rest_client.get(path=pm_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    def test_when_getting_specific_task_then_return_task(self):
+        pm_path = f"{self.ENDPOINT}{self.current_pm.pk}/"
+        response = self.admin_user_rest_client.get(path=pm_path)
+        self.assertEqual(response.data["pk"], self.current_pm.pk)
+
+    def test_when_posting_as_non_admin_then_return_403_forbidden(self):
+        data = {
+            "start_time": "2025-05-14T11:14:41.391Z",
+            "end_time": "2025-05-16T11:14:41.391Z",
+            "description": "ABC",
+            "filters": [self.open_filter.pk],
+        }
+        response = self.user_rest_client.post(path=self.ENDPOINT, data=data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(PlannedMaintenanceTask.objects.filter(description=data["description"]).exists())
+
+    def test_given_valid_values_then_should_create_task(self):
+        response = self.admin_user_rest_client.post(
+            path=self.ENDPOINT,
+            data={
+                "start_time": "2025-05-14T11:14:41.391Z",
+                "end_time": "2025-05-16T11:14:41.391Z",
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(PlannedMaintenanceTask.objects.filter(pk=response.data["pk"]).exists())
+
+    def test_given_no_end_time_then_set_end_time_to_infinite(self):
+        response = self.admin_user_rest_client.post(
+            path=self.ENDPOINT,
+            data={
+                "start_time": "2025-05-14T11:14:41.391Z",
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        pm = PlannedMaintenanceTask.objects.filter(pk=response.data["pk"]).first()
+        self.assertTrue(pm)
+        self.assertEqual(pm.end_time, LOCAL_INFINITY)
+
+    def test_given_end_time_none_then_set_end_time_to_infinite(self):
+        response = self.admin_user_rest_client.post(
+            path=self.ENDPOINT,
+            data={
+                "start_time": "2025-05-14T11:14:41.391Z",
+                "end_time": None,
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        pm = PlannedMaintenanceTask.objects.filter(pk=response.data["pk"]).first()
+        self.assertTrue(pm)
+        self.assertEqual(pm.end_time, LOCAL_INFINITY)
+
+    def test_given_end_time_before_start_time_then_should_return_400_bad_request(self):
+        data = {
+            "start_time": "2025-05-14T11:14:41.391Z",
+            "end_time": "2025-05-12T11:14:41.391Z",
+            "description": "ABC",
+            "filters": [self.open_filter.pk],
+        }
+        response = self.admin_user_rest_client.post(
+            path=self.ENDPOINT,
+            data=data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(PlannedMaintenanceTask.objects.filter(description=data["description"]).exists())
+
+    def test_when_patching_pm_as_non_admin_then_return_403_forbidden(self):
+        description = "ABC"
+        response = self.user_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.future_pm.pk}/", data={"description": description}
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.future_pm.refresh_from_db()
+        self.assertNotEqual(self.future_pm.description, description)
+
+    def test_given_valid_values_when_patching_future_pm_then_change_values(self):
+        response = self.admin_user_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.future_pm.pk}/",
+            data={
+                "start_time": timezone.now().isoformat(),
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.future_pm.refresh_from_db()
+        self.assertEqual(self.future_pm.description, "ABC")
+
+    def test_when_patching_old_pm_then_return_400_bad_request(self):
+        description = "ABC"
+        response = self.admin_user_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.past_pm.pk}/", data={"description": description}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.past_pm.refresh_from_db()
+        self.assertNotEqual(self.past_pm.description, description)
+
+    def test_when_patching_start_time_of_current_pm_then_return_400_bad_request(self):
+        start_time = self.current_pm.start_time
+        response = self.admin_user_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.current_pm.pk}/", data={"start_time": timezone.now().isoformat()}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.current_pm.refresh_from_db()
+        self.assertEqual(self.current_pm.start_time, start_time)
+
+    def test_when_patching_start_time_of_recently_ended_pm_then_return_400_bad_request(self):
+        start_time = self.recently_ended_pm.start_time
+        response = self.admin_user_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.recently_ended_pm.pk}/", data={"start_time": timezone.now().isoformat()}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.recently_ended_pm.refresh_from_db()
+        self.assertEqual(self.recently_ended_pm.start_time, start_time)
+
+    def test_when_putting_pm_as_non_admin_then_return_403_forbidden(self):
+        description = "ABC"
+        response = self.user_rest_client.put(
+            path=f"{self.ENDPOINT}{self.future_pm.pk}/",
+            data={
+                "start_time": timezone.now().isoformat(),
+                "description": "ABC",
+                "filters": [],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.future_pm.refresh_from_db()
+        self.assertNotEqual(self.future_pm.description, description)
+
+    def test_given_valid_values_when_putting_future_pm_then_change_values(self):
+        now = timezone.now()
+        response = self.admin_user_rest_client.put(
+            path=f"{self.ENDPOINT}{self.future_pm.pk}/",
+            data={
+                "start_time": now.isoformat(),
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.future_pm.refresh_from_db()
+        self.assertEqual(self.future_pm.description, "ABC")
+        self.assertEqual(self.future_pm.start_time, now)
+        self.assertEqual([self.open_filter.pk], [filter.pk for filter in self.future_pm.filters.all()])
+
+    def test_when_putting_old_pm_then_return_400_bad_request(self):
+        now = timezone.now()
+        response = self.admin_user_rest_client.put(
+            path=f"{self.ENDPOINT}{self.past_pm.pk}/",
+            data={
+                "start_time": now.isoformat(),
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("This planned maintenance task is no longer modifiable", response.content.decode())
+        self.past_pm.refresh_from_db()
+        self.assertNotEqual(self.past_pm.description, "ABC")
+
+    def test_when_putting_current_pm_then_return_400_bad_request(self):
+        start_time = self.current_pm.start_time
+        response = self.admin_user_rest_client.put(
+            path=f"{self.ENDPOINT}{self.current_pm.pk}/",
+            data={
+                "start_time": timezone.now().isoformat(),
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("The start time cannot be modified after the task has already started", response.content.decode())
+        self.current_pm.refresh_from_db()
+        self.assertEqual(self.current_pm.start_time, start_time)
+
+    def test_when_putting_recently_ended_pm_then_return_400_bad_request(self):
+        start_time = self.recently_ended_pm.start_time
+        response = self.admin_user_rest_client.put(
+            path=f"{self.ENDPOINT}{self.recently_ended_pm.pk}/",
+            data={
+                "start_time": timezone.now().isoformat(),
+                "description": "ABC",
+                "filters": [self.open_filter.pk],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("The start time cannot be modified after the task has already started", response.content.decode())
+        self.recently_ended_pm.refresh_from_db()
+        self.assertEqual(self.recently_ended_pm.start_time, start_time)
+
+    def test_when_deleting_future_task_as_admin_then_should_delete_task(self):
+        pm_path = f"{self.ENDPOINT}{self.future_pm.pk}/"
+        response = self.admin_user_rest_client.delete(path=pm_path)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(PlannedMaintenanceTask.objects.filter(pk=self.future_pm.pk).exists())
+
+    def test_when_deleting_current_task_then_should_return_400_bad_request(self):
+        pm_path = f"{self.ENDPOINT}{self.current_pm.pk}/"
+        response = self.admin_user_rest_client.delete(path=pm_path)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(PlannedMaintenanceTask.objects.filter(pk=self.current_pm.pk).exists())
+
+    def test_when_deleting_past_task_then_should_return_400_bad_request(self):
+        pm_path = f"{self.ENDPOINT}{self.past_pm.pk}/"
+        response = self.admin_user_rest_client.delete(path=pm_path)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(PlannedMaintenanceTask.objects.filter(pk=self.past_pm.pk).exists())
+
+    def test_when_deleting_task_as_non_admin_then_should_return_403_forbidden(self):
+        pm_path = f"{self.ENDPOINT}{self.future_pm.pk}/"
+        response = self.user_rest_client.delete(path=pm_path)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(PlannedMaintenanceTask.objects.filter(pk=self.future_pm.pk).exists())


### PR DESCRIPTION
## Scope and purpose

Fixes #1774.

Potential follow up issue: Make it possible to filter on the GET endpoint.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
