### PR TITLE
Add API endpoint for recording a source's heartbeat to indicate that a glue service has not stopped

### DIFF
--- a/changelog.d/1939.added.md
+++ b/changelog.d/1939.added.md
@@ -1,0 +1,1 @@
+Added new API endpoint to explicitly update the last_seen field for a source system.

--- a/src/argus/incident/urls.py
+++ b/src/argus/incident/urls.py
@@ -41,4 +41,5 @@ urlpatterns = [
     path("<int:incident_pk>/tags/", tag_list, name="incident-tags"),
     path("<int:incident_pk>/tags/<str:tag>/", tag_detail, name="incident-tag"),
     path("<int:incident_pk>/automatic-ticket/", ticket_plugin_detail, name="incident-ticket-plugin"),
+    path("sources/heartbeat/", views.UpdateLastSeenView.as_view(), name="source-heartbeat"),
 ] + router.urls

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -291,12 +291,12 @@ class SourceLockedIncidentViewSet(BaseIncidentViewSet):
 
 
 class UpdateLastSeenView(views.APIView):
-    "Explicitly update `last_seen` field on source system"
+    "Set `SourceSystem.last_seen` to access time for the requesting source user"
 
-    http_method_names = ["post", "put", "patch", "head", "options", "trace"]
+    http_method_names = ["post", "head", "options", "trace"]
 
     @extend_schema(
-        summary="Update `last_seen` field on source system",
+        summary="Update `last_seen` field on inquiring source system",
         responses={
             "204": inline_serializer("no content", {}),
             "403": inline_serializer("forbidden", {}),
@@ -310,9 +310,6 @@ class UpdateLastSeenView(views.APIView):
         except Exception:
             pass
         return Response(status=status.HTTP_403_FORBIDDEN)
-
-    patch = post
-    put = post
 
 
 @extend_schema_view(

--- a/src/argus/incident/views.py
+++ b/src/argus/incident/views.py
@@ -7,11 +7,11 @@ from django.db import IntegrityError
 from django.utils import timezone
 
 from django_filters import rest_framework as filters
-from rest_framework.filters import SearchFilter
 from drf_rw_serializers import viewsets as rw_viewsets
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse
-from rest_framework import mixins, serializers, status, viewsets
+from rest_framework.filters import SearchFilter
+from rest_framework import mixins, serializers, status, viewsets, views
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError, PermissionDenied, MethodNotAllowed
 from rest_framework.generics import get_object_or_404
@@ -288,6 +288,31 @@ class SourceLockedIncidentViewSet(BaseIncidentViewSet):
 
     def get_queryset(self):
         return Incident.objects.filter(source__user=self.request.user).prefetch_default_related()
+
+
+class UpdateLastSeenView(views.APIView):
+    "Explicitly update `last_seen` field on source system"
+
+    http_method_names = ["post", "put", "patch", "head", "options", "trace"]
+
+    @extend_schema(
+        summary="Update `last_seen` field on source system",
+        responses={
+            "204": inline_serializer("no content", {}),
+            "403": inline_serializer("forbidden", {}),
+        },
+    )
+    def post(self, request, *args, **kwargs):
+        user = self.request.user
+        try:
+            user.source_system.update_last_seen()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except Exception:
+            pass
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    patch = post
+    put = post
 
 
 @extend_schema_view(

--- a/tests/incident/test_source_system.py
+++ b/tests/incident/test_source_system.py
@@ -16,6 +16,22 @@ from argus.incident.models import SourceSystem
 User = get_user_model()
 
 
+@tag("db", "api", "integration")
+class UpdateLastSeenViewTests(APITestCase):
+    def test_when_posting_it_should_update_last_seen(self):
+        source = SourceSystemFactory()
+        user_token = Token.objects.create(user=source.user)
+        rest_client = APIClient()
+        rest_client.credentials(HTTP_AUTHORIZATION=f"Token {user_token.key}")
+        url = reverse("v2:incident:source-heartbeat")
+
+        self.assertIsNone(source.last_seen)
+        response = rest_client.post(url)
+        self.assertEqual(response.status_code, 204)
+        source.refresh_from_db()
+        self.assertIsNotNone(source.last_seen)
+
+
 @tag("db")
 class SourceSystemUpdateLastSeenTests(TestCase):
     def test_updates_last_seen_field_to_given_timestamp(self):


### PR DESCRIPTION
## Scope and purpose

For #1160. 

This is a way for a source to explicitly update its own heartbeat.

## Testing tips

Ensure you are logged in as the correct user. The user must have a source, just a token is not enough.

If you get 403 with a source token, drf might get confused, preferring a login cookie before the token. Try from an anonymous browser window without logging in first.

### This pull request

* changes the API <!-- Ensure that v2 is backwards compatible, v3 can be changing things -->

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
