### PR TITLE
Make media docs value fields consistent

### DIFF
--- a/docs/integrations/notifications/email-plugin.rst
+++ b/docs/integrations/notifications/email-plugin.rst
@@ -8,8 +8,7 @@ This plugin is enabled by default.
 This plugin uses the email server settings provided by Django itself to
 configure the server.
 
-The settings-field for an email-destination contains an
-``email_address``-field.
+The settings-field for an email-destination contains an email address.
 
 The managed-field will be set to ``True`` if the User model-instance has its
 ``email_address``-field set. If the email-address has ``managed`` set to ``True``, that

--- a/docs/integrations/notifications/sms-plugin.rst
+++ b/docs/integrations/notifications/sms-plugin.rst
@@ -25,9 +25,9 @@ then the resulting address is::
 
     sms+345656787643@example.com
 
-The settings-field for an SMS-destination contains only a ``phone_number``,
-which is a string that includes the international calling code, see for
-instance `Wikipedia: List of mobile telephone prefixes by country
+The settings-field for an SMS-destination contains a phone number
+including the international calling code, see for instance `Wikipedia:
+List of mobile telephone prefixes by country
 <https://en.wikipedia.org/wiki/List_of_mobile_telephone_prefixes_by_country>`__.
 
 The library used to validate that the number is a real phone number is based on


### PR DESCRIPTION
## Scope and purpose

Fixes #1924 .


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
