### PR TITLE
Update planned maintenance docs

### DIFF
--- a/docs/reference/planned-maintenance.rst
+++ b/docs/reference/planned-maintenance.rst
@@ -2,8 +2,8 @@
 Planned maintenance
 ===================
 
-To interact with planned maintenance tasks visit the admin interface at:
-``/admin/argus_plannedmaintenance/plannedmaintenancetask/``.
+To interact with planned maintenance tasks visit the dedicated page at:
+``/plannedmaintenance/`` or use the user menu to navigate to it.
 
 A planned maintenance task consists of a start time and an end time (where the latter
 is by default infinity). Those define the period during which planned work is happening
@@ -24,20 +24,13 @@ suppressed if all of the filters apply to that event.
 The planned maintenance task list
 =================================
 
-In the admin you can view a list of planned maintenance tasks, filter them and search
-for specific ones.
+From the maintenance list page you can mark planned maintenance tasks as finished,
+which will set an open task's end time to the current time. Tasks that have not
+started yet can be deleted.
 
-You can also select multiple planned maintenance tasks and delete them or mark them as
-finished. Marking a task as finished will set an open task's end time to the current
-time. If you mark a task as finished that has not begun yet, then that task will be
-deleted.
+If you want to add a planned maintenance task click the ``Create new`` button.
+It is also possible to create copies of existing tasks to make recurring maintenance
+easier.
 
-Adding/editing a planned maintenance task
-=========================================
-
-If you want to add a planned maintenance task click the
-``Add planned maintenance task`` button. If you want to see details for a specific
-task or edit it, click the username in the column ``created by``.
-
-You can mark an existing task as finished and see its history by clicking on the
-buttons in the top right corner of the edit page.
+You can also edit tasks that are ongoing or scheduled and view details for finished
+tasks by clicking on ``Edit`` / ``View``.


### PR DESCRIPTION
## Scope and purpose

When working on a little presentation to our internal customers I noticed that the planned maintenance documentation is quite outdated. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
