### PR TITLE
Refactor event tests

### DIFF
--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -13,7 +13,7 @@ from argus.incident.models import Event, Incident
 from . import IncidentBasedAPITestCaseHelper
 
 
-class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
+class EventAPIStatefulIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper):
     def setUp(self):
         disconnect_signals()
 
@@ -38,15 +38,12 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         )
         self.open_incident.create_first_event()
 
-        self.stateless_incident = StatelessIncidentFactory(source=self.source1)
-        self.stateless_incident.create_first_event()
-
         self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
 
     def tearDown(self):
         connect_signals()
 
-    def test_when_posting_close_event_for_stateful_open_incident_then_incident_gets_closed(self):
+    def test_when_posting_close_event_for_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
 
         response = self.user1_rest_client.post(self.events_url(self.open_incident), close_event_dict)
@@ -56,7 +53,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.open_incident.open)
         self.assertEqual(self.open_incident.end_time, close_event_dict["timestamp"])
 
-    def test_when_posting_close_event_for_stateful_closed_incident_then_end_time_does_not_change(self):
+    def test_when_posting_close_event_for_closed_incident_then_end_time_does_not_change(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         original_end_time = self.closed_incident.end_time
 
@@ -69,7 +66,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.closed_incident.refresh_from_db()
         self.assertEqual(self.closed_incident.end_time, original_end_time)
 
-    def test_when_posting_reopen_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
+    def test_when_posting_reopen_event_for_closed_incident_then_incident_gets_reopened(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         response = self.user1_rest_client.post(self.events_url(self.closed_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
@@ -77,7 +74,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertTrue(self.closed_incident.open)
         self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
 
-    def test_when_posting_reopen_event_for_stateful_open_incident_then_return_bad_request(self):
+    def test_when_posting_reopen_event_for_open_incident_then_return_bad_request(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         original_end_time = self.open_incident.end_time
 
@@ -90,7 +87,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.open_incident.refresh_from_db()
         self.assertEqual(self.open_incident.end_time, original_end_time)
 
-    def test_when_posting_end_event_for_stateful_open_incident_then_incident_gets_closed(self):
+    def test_when_posting_end_event_for_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
         response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
@@ -100,7 +97,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.open_incident.open)
         self.assertEqual(self.open_incident.end_time, end_event_dict["timestamp"])
 
-    def test_when_posting_restart_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
+    def test_when_posting_restart_event_for_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
 
         response = self.source1_rest_client.post(self.events_url(self.closed_incident), restart_event_dict)
@@ -109,7 +106,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertTrue(self.closed_incident.open)
         self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
 
-    def test_when_posting_end_event_for_ended_and_restarted_stateful_incident_then_incident_gets_closed(self):
+    def test_when_posting_end_event_for_ended_and_restarted_incident_then_incident_gets_closed(self):
         restarted_incident = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(hours=1),
             source=self.source1,
@@ -169,6 +166,18 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertEqual(datetime_utils.make_naive(self.open_incident.end_time), datetime.max)
         self.assertEqual(self.open_incident.events.count(), count_before + 1)
 
+
+class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+        self.stateless_incident = StatelessIncidentFactory(source=self.source1)
+        self.stateless_incident.create_first_event()
+
+        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
+
     def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
@@ -179,7 +188,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
 
-    def test_when_posting_reopen_event_for_stateless_incident_then_incident_does_not_change(self):
+    def test_when_posting_reopen_event_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         )
@@ -189,7 +198,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
 
-    def test_when_posting_end_event_for_stateless_incident_then_incident_is_unchanged_and_event_is_recorded(self):
+    def test_when_posting_end_event_then_incident_does_not_change_and_event_is_recorded(self):
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
@@ -201,7 +210,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
-    def test_when_posting_restart_event_for_stateless_incident_then_incident_is_unchanged_and_event_is_recorded(self):
+    def test_when_posting_restart_event_then_incident_does_not_change_and_event_is_recorded(self):
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
@@ -213,7 +222,38 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
-    def test_posting_allowed_event_types_for_source_system_is_valid(self):
+
+class EventAPISourceSystemUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+        self.closed_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=2),
+            end_time=timezone.now() - timedelta(days=1),
+            source=self.source1,
+        )
+        self.closed_incident.create_first_event()
+        Event.objects.create(
+            incident=self.closed_incident,
+            actor=self.user1,
+            timestamp=self.closed_incident.end_time,
+            type=Event.Type.CLOSE,
+        )
+
+        self.open_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(weeks=1),
+            source=self.source1,
+        )
+        self.open_incident.create_first_event()
+
+        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_posting_allowed_event_types_for_source_system_user_then_event_is_created(self):
         def delete_start_event(incident: Incident):
             incident.start_event.delete()
 
@@ -238,7 +278,57 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
                 self.assertEqual(response.data["incident"], self.open_incident.pk)
 
-    def test_posting_allowed_event_types_for_end_user_is_valid(self):
+    def test_when_posting_disallowed_event_types_for_source_system_user_then_return_bad_request(self):
+        original_end_time = self.open_incident.end_time
+
+        source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
+        for event_type in source_system_disallowed_types:
+            with self.subTest(event_type=event_type):
+                event_count = Event.objects.count()
+
+                response = self.source1_rest_client.post(
+                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
+                )
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("type", response.data)
+                self.assertEqual(response.data["type"].code, "invalid")
+
+                self.assertEqual(Event.objects.count(), event_count)
+                self.open_incident.refresh_from_db()
+                self.assertEqual(self.open_incident.end_time, original_end_time)
+
+
+class EventAPIEndUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+        self.closed_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=2),
+            end_time=timezone.now() - timedelta(days=1),
+            source=self.source1,
+        )
+        self.closed_incident.create_first_event()
+        Event.objects.create(
+            incident=self.closed_incident,
+            actor=self.user1,
+            timestamp=self.closed_incident.end_time,
+            type=Event.Type.CLOSE,
+        )
+
+        self.open_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(weeks=1),
+            source=self.source1,
+        )
+        self.open_incident.create_first_event()
+
+        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_posting_allowed_event_types_for_end_user_then_event_is_created(self):
         def set_end_time_to(end_time):
             def set_end_time(incident: Incident):
                 incident.end_time = end_time
@@ -266,26 +356,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
                 self.assertEqual(response.data["incident"], self.open_incident.pk)
 
-    def test_posting_disallowed_event_types_for_source_system_is_invalid(self):
-        original_end_time = self.open_incident.end_time
-
-        source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
-        for event_type in source_system_disallowed_types:
-            with self.subTest(event_type=event_type):
-                event_count = Event.objects.count()
-
-                response = self.source1_rest_client.post(
-                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
-                )
-                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-                self.assertIn("type", response.data)
-                self.assertEqual(response.data["type"].code, "invalid")
-
-                self.assertEqual(Event.objects.count(), event_count)
-                self.open_incident.refresh_from_db()
-                self.assertEqual(self.open_incident.end_time, original_end_time)
-
-    def test_posting_disallowed_event_types_for_end_user_is_invalid(self):
+    def test_when_posting_disallowed_event_types_for_end_user_then_return_bad_request(self):
         original_end_time = self.open_incident.end_time
 
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -35,94 +34,77 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
     def tearDown(self):
         connect_signals()
 
-    @staticmethod
-    def _create_event_dict(event_type: str):
-        return {
-            "timestamp": timezone.now(),
-            "type": event_type,
-        }
+    def test_posting_close_and_reopen_events_properly_changes_stateful_incidents(self):
+        # Test closing incident
+        close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
+        event_timestamp = close_event_dict["timestamp"]
+        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
+        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
+        self.stateful_incident.refresh_from_db()
+        self.assertFalse(self.stateful_incident.open)
+        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
 
-    def _assert_response_field_invalid(self, response, field_name: str):
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn(field_name, response.data)
-        self.assertEqual(response.data[field_name].code, "invalid")
-
-    def _assert_posting_event_is_rejected_and_does_not_change_end_time(
-        self, post_data: dict, original_end_time: datetime, client: Client
-    ):
+        # It's illegal to close an already closed incident
+        original_end_time = self.stateful_incident.end_time
         event_count = Event.objects.count()
 
-        response = client.post(self.events_url(self.stateful_incident), post_data)
-        self._assert_response_field_invalid(response, "type")
+        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("type", response.data)
+        self.assertEqual(response.data["type"].code, "invalid")
 
         self.assertEqual(Event.objects.count(), event_count)
         self.stateful_incident.refresh_from_db()
         self.assertEqual(self.stateful_incident.end_time, original_end_time)
 
-    def _assert_posting_event_succeeds(self, post_data: dict, client: Client):
-        event_count = self.stateful_incident.events.count()
-
-        response = client.post(self.events_url(self.stateful_incident), post_data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
-        self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
-        self.assertEqual(response.data["incident"], self.stateful_incident.pk)
-
-    def _assert_incident_is_closed_at_timestamp(self, incident: Incident, timestamp: datetime):
-        incident.refresh_from_db()
-        self.assertFalse(incident.open)
-        self.assertEqual(incident.end_time, timestamp)
-
-    def _assert_incident_is_open(self, incident: Incident):
-        incident.refresh_from_db()
-        self.assertTrue(incident.open)
-        self.assertEqual(datetime_utils.make_naive(incident.end_time), datetime.max)
-
-    def test_posting_close_and_reopen_events_properly_changes_stateful_incidents(self):
-        # Test closing incident
-        close_event_dict = self._create_event_dict(Event.Type.CLOSE)
-        event_timestamp = close_event_dict["timestamp"]
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, event_timestamp)
-
-        # It's illegal to close an already closed incident
-        self._assert_posting_event_is_rejected_and_does_not_change_end_time(
-            close_event_dict, self.stateful_incident.end_time, self.user1_rest_client
-        )
-
         # Test reopening incident
-        reopen_event_dict = self._create_event_dict(Event.Type.REOPEN)
+        reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
-        self._assert_incident_is_open(self.stateful_incident)
+        self.stateful_incident.refresh_from_db()
+        self.assertTrue(self.stateful_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
 
         # It's illegal to reopen an already opened incident
-        self._assert_posting_event_is_rejected_and_does_not_change_end_time(
-            reopen_event_dict, self.stateful_incident.end_time, self.user1_rest_client
-        )
+        original_end_time = self.stateful_incident.end_time
+        event_count = Event.objects.count()
+
+        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("type", response.data)
+        self.assertEqual(response.data["type"].code, "invalid")
+
+        self.assertEqual(Event.objects.count(), event_count)
+        self.stateful_incident.refresh_from_db()
+        self.assertEqual(self.stateful_incident.end_time, original_end_time)
 
     def test_posting_end_and_restart_events_properly_changes_stateful_incidents(self):
         # Test ending incident
-        end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
+        end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
         event_timestamp = end_event_dict["timestamp"]
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, event_timestamp)
+        self.stateful_incident.refresh_from_db()
+        self.assertFalse(self.stateful_incident.open)
+        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
 
         # Test restarting incident
-        restart_event_dict = self._create_event_dict(Event.Type.INCIDENT_RESTART)
+        restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
-        self._assert_incident_is_open(self.stateful_incident)
+        self.stateful_incident.refresh_from_db()
+        self.assertTrue(self.stateful_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
 
         # Test ending again
-        end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
+        end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
         event_timestamp = end_event_dict["timestamp"]
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, event_timestamp)
+        self.stateful_incident.refresh_from_db()
+        self.assertFalse(self.stateful_incident.open)
+        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
 
     def test_given_closed_incident_when_source_posts_end_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does
@@ -131,15 +113,16 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         # incident must be accepted and recorded without re-touching end_time.
         count_before = self.stateful_incident.events.count()
 
-        self.stateful_incident.end_time = timezone.now()
+        self.stateful_incident.end_time = original_timestamp = timezone.now()
         self.stateful_incident.save(update_fields=["end_time"])
 
-        end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
+        end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, self.stateful_incident.end_time)
         self.stateful_incident.refresh_from_db()
+        self.assertFalse(self.stateful_incident.open)
+        self.assertEqual(self.stateful_incident.end_time, original_timestamp)
         self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
 
     def test_given_open_incident_when_source_posts_restart_then_records_event_without_state_change(self):
@@ -152,54 +135,53 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         count_before = self.stateful_incident.events.count()
 
-        restart_event_dict = self._create_event_dict(Event.Type.INCIDENT_RESTART)
+        restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self._assert_incident_is_open(self.stateful_incident)
         self.stateful_incident.refresh_from_db()
+        self.assertTrue(self.stateful_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
         self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
 
     def test_posting_close_and_reopen_events_does_not_change_stateless_incidents(self):
-        def assert_incident_stateless():
-            self.stateless_incident.refresh_from_db()
-            self.assertFalse(self.stateless_incident.stateful)
-            self.assertFalse(self.stateless_incident.open)
+        response = self.user1_rest_client.post(
+            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
+        self.stateless_incident.refresh_from_db()
+        self.assertFalse(self.stateless_incident.stateful)
+        self.assertFalse(self.stateless_incident.open)
 
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.CLOSE)
+            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         )
-        self._assert_response_field_invalid(response, "type")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
-        assert_incident_stateless()
-
-        response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.REOPEN)
-        )
-        self._assert_response_field_invalid(response, "type")
-        self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
-        assert_incident_stateless()
+        self.stateless_incident.refresh_from_db()
+        self.assertFalse(self.stateless_incident.stateful)
+        self.assertFalse(self.stateless_incident.open)
 
     def test_posting_end_and_restart_events_does_not_change_stateless_incidents_but_records_event(self):
-        def assert_incident_stateless():
-            self.stateless_incident.refresh_from_db()
-            self.assertFalse(self.stateless_incident.stateful)
-            self.assertFalse(self.stateless_incident.open)
-
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.INCIDENT_END)
+            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        assert_incident_stateless()
+        self.stateless_incident.refresh_from_db()
+        self.assertFalse(self.stateless_incident.stateful)
+        self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.INCIDENT_RESTART)
+            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        assert_incident_stateless()
+        self.stateless_incident.refresh_from_db()
+        self.assertFalse(self.stateless_incident.stateful)
+        self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 2)
 
     def test_posting_allowed_event_types_for_source_system_is_valid(self):
@@ -215,7 +197,17 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         for event_type, ensure_precondition in source_system_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
                 ensure_precondition(self.stateful_incident)
-                self._assert_posting_event_succeeds(self._create_event_dict(event_type), self.source1_rest_client)
+                event_count = self.stateful_incident.events.count()
+
+                response = self.source1_rest_client.post(
+                    self.events_url(self.stateful_incident),
+                    {"timestamp": timezone.now(), "type": event_type},
+                )
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+                self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
+                self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], self.stateful_incident.pk)
 
     def test_posting_allowed_event_types_for_end_user_is_valid(self):
         def set_end_time_to(end_time):
@@ -233,7 +225,17 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         for event_type, ensure_precondition in end_user_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
                 ensure_precondition(self.stateful_incident)
-                self._assert_posting_event_succeeds(self._create_event_dict(event_type), self.user1_rest_client)
+                event_count = self.stateful_incident.events.count()
+
+                response = self.user1_rest_client.post(
+                    self.events_url(self.stateful_incident),
+                    {"timestamp": timezone.now(), "type": event_type},
+                )
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+                self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
+                self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], self.stateful_incident.pk)
 
     def test_posting_disallowed_event_types_for_source_system_is_invalid(self):
         original_end_time = self.stateful_incident.end_time
@@ -241,9 +243,18 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
         for event_type in source_system_disallowed_types:
             with self.subTest(event_type=event_type):
-                self._assert_posting_event_is_rejected_and_does_not_change_end_time(
-                    self._create_event_dict(event_type), original_end_time, self.source1_rest_client
+                event_count = Event.objects.count()
+
+                response = self.source1_rest_client.post(
+                    self.events_url(self.stateful_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("type", response.data)
+                self.assertEqual(response.data["type"].code, "invalid")
+
+                self.assertEqual(Event.objects.count(), event_count)
+                self.stateful_incident.refresh_from_db()
+                self.assertEqual(self.stateful_incident.end_time, original_end_time)
 
     def test_posting_disallowed_event_types_for_end_user_is_invalid(self):
         original_end_time = self.stateful_incident.end_time
@@ -251,6 +262,15 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
         for event_type in end_user_disallowed_types:
             with self.subTest(event_type=event_type):
-                self._assert_posting_event_is_rejected_and_does_not_change_end_time(
-                    self._create_event_dict(event_type), original_end_time, self.user1_rest_client
+                event_count = Event.objects.count()
+
+                response = self.user1_rest_client.post(
+                    self.events_url(self.stateful_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("type", response.data)
+                self.assertEqual(response.data["type"].code, "invalid")
+
+                self.assertEqual(Event.objects.count(), event_count)
+                self.stateful_incident.refresh_from_db()
+                self.assertEqual(self.stateful_incident.end_time, original_end_time)

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -4,7 +4,6 @@ from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from django.utils.timezone import make_aware
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -21,17 +20,15 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         super().init_test_objects()
 
-        self.stateful_incident1 = StatefulIncidentFactory(
-            start_time=make_aware(datetime(2000, 1, 1)),
+        self.stateful_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(weeks=1),
             end_time=timezone.now() + timedelta(weeks=1),
             source=self.source1,
-            source_incident_id="1",
         )
-        self.stateful_incident1.create_first_event()
-        self.stateless_incident1 = StatelessIncidentFactory(
-            source_incident_id="2", source=self.stateful_incident1.source
-        )
-        self.stateless_incident1.create_first_event()
+        self.stateful_incident.create_first_event()
+
+        self.stateless_incident = StatelessIncidentFactory(source=self.source1)
+        self.stateless_incident.create_first_event()
 
         self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
 
@@ -55,22 +52,22 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
     ):
         event_count = Event.objects.count()
 
-        response = client.post(self.events_url(self.stateful_incident1), post_data)
+        response = client.post(self.events_url(self.stateful_incident), post_data)
         self._assert_response_field_invalid(response, "type")
 
         self.assertEqual(Event.objects.count(), event_count)
-        self.stateful_incident1.refresh_from_db()
-        self.assertEqual(self.stateful_incident1.end_time, original_end_time)
+        self.stateful_incident.refresh_from_db()
+        self.assertEqual(self.stateful_incident.end_time, original_end_time)
 
     def _assert_posting_event_succeeds(self, post_data: dict, client: Client):
-        event_count = self.stateful_incident1.events.count()
+        event_count = self.stateful_incident.events.count()
 
-        response = client.post(self.events_url(self.stateful_incident1), post_data)
+        response = client.post(self.events_url(self.stateful_incident), post_data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        self.assertEqual(self.stateful_incident1.events.count(), event_count + 1)
-        self.assertTrue(self.stateful_incident1.events.filter(pk=response.data["pk"]).exists())
-        self.assertEqual(response.data["incident"], self.stateful_incident1.pk)
+        self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
+        self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
+        self.assertEqual(response.data["incident"], self.stateful_incident.pk)
 
     def _assert_incident_is_closed_at_timestamp(self, incident: Incident, timestamp: datetime):
         incident.refresh_from_db()
@@ -83,108 +80,108 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertEqual(datetime_utils.make_naive(incident.end_time), datetime.max)
 
     def test_posting_close_and_reopen_events_properly_changes_stateful_incidents(self):
-        self.assertTrue(self.stateful_incident1.stateful)
-        self.assertTrue(self.stateful_incident1.open)
+        self.assertTrue(self.stateful_incident.stateful)
+        self.assertTrue(self.stateful_incident.open)
 
         # Test closing incident
         close_event_dict = self._create_event_dict(Event.Type.CLOSE)
         event_timestamp = close_event_dict["timestamp"]
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident1), close_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident1, event_timestamp)
+        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, event_timestamp)
 
         # It's illegal to close an already closed incident
         self._assert_posting_event_is_rejected_and_does_not_change_end_time(
-            close_event_dict, self.stateful_incident1.end_time, self.user1_rest_client
+            close_event_dict, self.stateful_incident.end_time, self.user1_rest_client
         )
 
         # Test reopening incident
         reopen_event_dict = self._create_event_dict(Event.Type.REOPEN)
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident1), reopen_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
-        self._assert_incident_is_open(self.stateful_incident1)
+        self._assert_incident_is_open(self.stateful_incident)
 
         # It's illegal to reopen an already opened incident
         self._assert_posting_event_is_rejected_and_does_not_change_end_time(
-            reopen_event_dict, self.stateful_incident1.end_time, self.user1_rest_client
+            reopen_event_dict, self.stateful_incident.end_time, self.user1_rest_client
         )
 
     def test_posting_end_and_restart_events_properly_changes_stateful_incidents(self):
-        self.assertTrue(self.stateful_incident1.stateful)
-        self.assertTrue(self.stateful_incident1.open)
+        self.assertTrue(self.stateful_incident.stateful)
+        self.assertTrue(self.stateful_incident.open)
 
         # Test ending incident
         end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
         event_timestamp = end_event_dict["timestamp"]
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident1), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident1, event_timestamp)
+        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, event_timestamp)
 
         # Test restarting incident
         restart_event_dict = self._create_event_dict(Event.Type.INCIDENT_RESTART)
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident1), restart_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
-        self._assert_incident_is_open(self.stateful_incident1)
+        self._assert_incident_is_open(self.stateful_incident)
 
         # Test ending again
         end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
         event_timestamp = end_event_dict["timestamp"]
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident1), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident1, event_timestamp)
+        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, event_timestamp)
 
     def test_given_closed_incident_when_source_posts_end_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does
         # not. Its event is recorded for the audit trail (201) but update_incident is
         # skipped, so the incident is unchanged. Here: END on an already-closed
         # incident must be accepted and recorded without re-touching end_time.
-        count_before = self.stateful_incident1.events.count()
+        count_before = self.stateful_incident.events.count()
 
-        self.stateful_incident1.end_time = timezone.now()
-        self.stateful_incident1.save(update_fields=["end_time"])
+        self.stateful_incident.end_time = timezone.now()
+        self.stateful_incident.save(update_fields=["end_time"])
 
         end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident1), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self._assert_incident_is_closed_at_timestamp(self.stateful_incident1, self.stateful_incident1.end_time)
-        self.stateful_incident1.refresh_from_db()
-        self.assertEqual(self.stateful_incident1.events.count(), count_before + 1)
+        self._assert_incident_is_closed_at_timestamp(self.stateful_incident, self.stateful_incident.end_time)
+        self.stateful_incident.refresh_from_db()
+        self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
 
     def test_given_open_incident_when_source_posts_restart_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does
         # not. Its event is recorded for the audit trail (201) but update_incident is
         # skipped, so the incident is unchanged. Here: RESTART on an already-open
         # incident must be accepted and recorded without re-touching end_time.
-        self.stateful_incident1.end_time = datetime_utils.INFINITY_REPR
-        self.stateful_incident1.save(update_fields=["end_time"])
+        self.stateful_incident.end_time = datetime_utils.INFINITY_REPR
+        self.stateful_incident.save(update_fields=["end_time"])
 
-        count_before = self.stateful_incident1.events.count()
+        count_before = self.stateful_incident.events.count()
 
         restart_event_dict = self._create_event_dict(Event.Type.INCIDENT_RESTART)
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident1), restart_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self._assert_incident_is_open(self.stateful_incident1)
-        self.stateful_incident1.refresh_from_db()
-        self.assertEqual(self.stateful_incident1.events.count(), count_before + 1)
+        self._assert_incident_is_open(self.stateful_incident)
+        self.stateful_incident.refresh_from_db()
+        self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
 
     def test_posting_close_and_reopen_events_does_not_change_stateless_incidents(self):
         def assert_incident_stateless():
-            self.stateless_incident1.refresh_from_db()
-            self.assertFalse(self.stateless_incident1.stateful)
-            self.assertFalse(self.stateless_incident1.open)
+            self.stateless_incident.refresh_from_db()
+            self.assertFalse(self.stateless_incident.stateful)
+            self.assertFalse(self.stateless_incident.open)
 
         assert_incident_stateless()
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident1), self._create_event_dict(Event.Type.CLOSE)
+            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.CLOSE)
         )
         self._assert_response_field_invalid(response, "type")
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
         assert_incident_stateless()
 
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident1), self._create_event_dict(Event.Type.REOPEN)
+            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.REOPEN)
         )
         self._assert_response_field_invalid(response, "type")
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
@@ -192,26 +189,26 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
     def test_posting_end_and_restart_events_does_not_change_stateless_incidents_but_records_event(self):
         def assert_incident_stateless():
-            self.stateless_incident1.refresh_from_db()
-            self.assertFalse(self.stateless_incident1.stateful)
-            self.assertFalse(self.stateless_incident1.open)
+            self.stateless_incident.refresh_from_db()
+            self.assertFalse(self.stateless_incident.stateful)
+            self.assertFalse(self.stateless_incident.open)
 
-        event_count = self.stateless_incident1.events.count()
+        event_count = self.stateless_incident.events.count()
 
         assert_incident_stateless()
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident1), self._create_event_dict(Event.Type.INCIDENT_END)
+            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.INCIDENT_END)
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         assert_incident_stateless()
-        self.assertEqual(self.stateless_incident1.events.count(), event_count + 1)
+        self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident1), self._create_event_dict(Event.Type.INCIDENT_RESTART)
+            self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.INCIDENT_RESTART)
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         assert_incident_stateless()
-        self.assertEqual(self.stateless_incident1.events.count(), event_count + 2)
+        self.assertEqual(self.stateless_incident.events.count(), event_count + 2)
 
     def test_posting_allowed_event_types_for_source_system_is_valid(self):
         def delete_start_event(incident: Incident):
@@ -225,7 +222,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         }
         for event_type, ensure_precondition in source_system_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.stateful_incident1)
+                ensure_precondition(self.stateful_incident)
                 self._assert_posting_event_succeeds(self._create_event_dict(event_type), self.source1_rest_client)
 
     def test_posting_allowed_event_types_for_end_user_is_valid(self):
@@ -243,11 +240,11 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         }
         for event_type, ensure_precondition in end_user_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.stateful_incident1)
+                ensure_precondition(self.stateful_incident)
                 self._assert_posting_event_succeeds(self._create_event_dict(event_type), self.user1_rest_client)
 
     def test_posting_disallowed_event_types_for_source_system_is_invalid(self):
-        original_end_time = self.stateful_incident1.end_time
+        original_end_time = self.stateful_incident.end_time
 
         source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
         for event_type in source_system_disallowed_types:
@@ -257,7 +254,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 )
 
     def test_posting_disallowed_event_types_for_end_user_is_invalid(self):
-        original_end_time = self.stateful_incident1.end_time
+        original_end_time = self.stateful_incident.end_time
 
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
         for event_type in end_user_disallowed_types:

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -32,12 +32,11 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
             type=Event.Type.CLOSE,
         )
 
-        self.stateful_incident = StatefulIncidentFactory(
+        self.open_incident = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(weeks=1),
-            end_time=timezone.now() + timedelta(weeks=1),
             source=self.source1,
         )
-        self.stateful_incident.create_first_event()
+        self.open_incident.create_first_event()
 
         self.stateless_incident = StatelessIncidentFactory(source=self.source1)
         self.stateless_incident.create_first_event()
@@ -50,12 +49,12 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
     def test_when_posting_close_event_for_stateful_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
 
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.open_incident), close_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), close_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, close_event_dict["timestamp"])
+        self.open_incident.refresh_from_db()
+        self.assertFalse(self.open_incident.open)
+        self.assertEqual(self.open_incident.end_time, close_event_dict["timestamp"])
 
     def test_when_posting_close_event_for_stateful_closed_incident_then_end_time_does_not_change(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
@@ -80,26 +79,26 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
     def test_when_posting_reopen_event_for_stateful_open_incident_then_return_bad_request(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
-        original_end_time = self.stateful_incident.end_time
+        original_end_time = self.open_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.open_incident), reopen_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
         self.assertEqual(response.data["type"].code, "invalid")
 
-        self.stateful_incident.refresh_from_db()
-        self.assertEqual(self.stateful_incident.end_time, original_end_time)
+        self.open_incident.refresh_from_db()
+        self.assertEqual(self.open_incident.end_time, original_end_time)
 
     def test_when_posting_end_event_for_stateful_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, end_event_dict["timestamp"])
+        self.open_incident.refresh_from_db()
+        self.assertFalse(self.open_incident.open)
+        self.assertEqual(self.open_incident.end_time, end_event_dict["timestamp"])
 
     def test_when_posting_restart_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
@@ -131,11 +130,11 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, end_event_dict["timestamp"])
+        self.open_incident.refresh_from_db()
+        self.assertFalse(self.open_incident.open)
+        self.assertEqual(self.open_incident.end_time, end_event_dict["timestamp"])
 
     def test_given_closed_incident_when_source_posts_end_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does
@@ -159,19 +158,16 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         # not. Its event is recorded for the audit trail (201) but update_incident is
         # skipped, so the incident is unchanged. Here: RESTART on an already-open
         # incident must be accepted and recorded without re-touching end_time.
-        self.stateful_incident.end_time = datetime_utils.INFINITY_REPR
-        self.stateful_incident.save(update_fields=["end_time"])
-
-        count_before = self.stateful_incident.events.count()
+        count_before = self.open_incident.events.count()
 
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.open_incident), restart_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.stateful_incident.refresh_from_db()
-        self.assertTrue(self.stateful_incident.open)
-        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
-        self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
+        self.open_incident.refresh_from_db()
+        self.assertTrue(self.open_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.open_incident.end_time), datetime.max)
+        self.assertEqual(self.open_incident.events.count(), count_before + 1)
 
     def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
@@ -229,18 +225,18 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         }
         for event_type, ensure_precondition in source_system_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.stateful_incident)
-                event_count = self.stateful_incident.events.count()
+                ensure_precondition(self.open_incident)
+                event_count = self.open_incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.stateful_incident),
+                    self.events_url(self.open_incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
-                self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.stateful_incident.pk)
+                self.assertEqual(self.open_incident.events.count(), event_count + 1)
+                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], self.open_incident.pk)
 
     def test_posting_allowed_event_types_for_end_user_is_valid(self):
         def set_end_time_to(end_time):
@@ -257,21 +253,21 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         }
         for event_type, ensure_precondition in end_user_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.stateful_incident)
-                event_count = self.stateful_incident.events.count()
+                ensure_precondition(self.open_incident)
+                event_count = self.open_incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.stateful_incident),
+                    self.events_url(self.open_incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
-                self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.stateful_incident.pk)
+                self.assertEqual(self.open_incident.events.count(), event_count + 1)
+                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], self.open_incident.pk)
 
     def test_posting_disallowed_event_types_for_source_system_is_invalid(self):
-        original_end_time = self.stateful_incident.end_time
+        original_end_time = self.open_incident.end_time
 
         source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
         for event_type in source_system_disallowed_types:
@@ -279,18 +275,18 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = Event.objects.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.stateful_incident), {"timestamp": timezone.now(), "type": event_type}
+                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
                 self.assertEqual(Event.objects.count(), event_count)
-                self.stateful_incident.refresh_from_db()
-                self.assertEqual(self.stateful_incident.end_time, original_end_time)
+                self.open_incident.refresh_from_db()
+                self.assertEqual(self.open_incident.end_time, original_end_time)
 
     def test_posting_disallowed_event_types_for_end_user_is_invalid(self):
-        original_end_time = self.stateful_incident.end_time
+        original_end_time = self.open_incident.end_time
 
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
         for event_type in end_user_disallowed_types:
@@ -298,12 +294,12 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = Event.objects.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.stateful_incident), {"timestamp": timezone.now(), "type": event_type}
+                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
                 self.assertEqual(Event.objects.count(), event_count)
-                self.stateful_incident.refresh_from_db()
-                self.assertEqual(self.stateful_incident.end_time, original_end_time)
+                self.open_incident.refresh_from_db()
+                self.assertEqual(self.open_incident.end_time, original_end_time)

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -80,9 +80,6 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertEqual(datetime_utils.make_naive(incident.end_time), datetime.max)
 
     def test_posting_close_and_reopen_events_properly_changes_stateful_incidents(self):
-        self.assertTrue(self.stateful_incident.stateful)
-        self.assertTrue(self.stateful_incident.open)
-
         # Test closing incident
         close_event_dict = self._create_event_dict(Event.Type.CLOSE)
         event_timestamp = close_event_dict["timestamp"]
@@ -107,9 +104,6 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         )
 
     def test_posting_end_and_restart_events_properly_changes_stateful_incidents(self):
-        self.assertTrue(self.stateful_incident.stateful)
-        self.assertTrue(self.stateful_incident.open)
-
         # Test ending incident
         end_event_dict = self._create_event_dict(Event.Type.INCIDENT_END)
         event_timestamp = end_event_dict["timestamp"]
@@ -172,7 +166,6 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
             self.assertFalse(self.stateless_incident.stateful)
             self.assertFalse(self.stateless_incident.open)
 
-        assert_incident_stateless()
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.CLOSE)
         )
@@ -195,7 +188,6 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         event_count = self.stateless_incident.events.count()
 
-        assert_incident_stateless()
         response = self.source1_rest_client.post(
             self.events_url(self.stateless_incident), self._create_event_dict(Event.Type.INCIDENT_END)
         )

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -19,6 +19,19 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         super().init_test_objects()
 
+        self.closed_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=2),
+            end_time=timezone.now() - timedelta(days=1),
+            source=self.source1,
+        )
+        self.closed_incident.create_first_event()
+        Event.objects.create(
+            incident=self.closed_incident,
+            actor=self.user1,
+            timestamp=self.closed_incident.end_time,
+            type=Event.Type.CLOSE,
+        )
+
         self.stateful_incident = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(weeks=1),
             end_time=timezone.now() + timedelta(weeks=1),
@@ -34,96 +47,112 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
     def tearDown(self):
         connect_signals()
 
-    def test_posting_close_and_reopen_events_properly_changes_stateful_incidents(self):
-        # Test closing incident
+    def test_when_posting_close_event_for_stateful_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
-        event_timestamp = close_event_dict["timestamp"]
+
         response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
+
+        self.assertEqual(parse_datetime(response.data["timestamp"]), close_event_dict["timestamp"])
         self.stateful_incident.refresh_from_db()
         self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
+        self.assertEqual(self.stateful_incident.end_time, close_event_dict["timestamp"])
 
-        # It's illegal to close an already closed incident
-        original_end_time = self.stateful_incident.end_time
-        event_count = Event.objects.count()
+    def test_when_posting_close_event_for_stateful_closed_incident_then_end_time_does_not_change(self):
+        close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
+        original_end_time = self.closed_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.closed_incident), close_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
         self.assertEqual(response.data["type"].code, "invalid")
 
-        self.assertEqual(Event.objects.count(), event_count)
-        self.stateful_incident.refresh_from_db()
-        self.assertEqual(self.stateful_incident.end_time, original_end_time)
+        self.closed_incident.refresh_from_db()
+        self.assertEqual(self.closed_incident.end_time, original_end_time)
 
-        # Test reopening incident
+    def test_when_posting_reopen_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.closed_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertTrue(self.stateful_incident.open)
-        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
+        self.closed_incident.refresh_from_db()
+        self.assertTrue(self.closed_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
 
-        # It's illegal to reopen an already opened incident
+    def test_when_posting_reopen_event_for_stateful_open_incident_then_return_bad_request(self):
+        reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         original_end_time = self.stateful_incident.end_time
-        event_count = Event.objects.count()
 
         response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
         self.assertEqual(response.data["type"].code, "invalid")
 
-        self.assertEqual(Event.objects.count(), event_count)
         self.stateful_incident.refresh_from_db()
         self.assertEqual(self.stateful_incident.end_time, original_end_time)
 
-    def test_posting_end_and_restart_events_properly_changes_stateful_incidents(self):
-        # Test ending incident
+    def test_when_posting_end_event_for_stateful_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        event_timestamp = end_event_dict["timestamp"]
+
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
+
+        self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         self.stateful_incident.refresh_from_db()
         self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
+        self.assertEqual(self.stateful_incident.end_time, end_event_dict["timestamp"])
 
-        # Test restarting incident
+    def test_when_posting_restart_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertTrue(self.stateful_incident.open)
-        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
 
-        # Test ending again
+        response = self.source1_rest_client.post(self.events_url(self.closed_incident), restart_event_dict)
+        self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
+        self.closed_incident.refresh_from_db()
+        self.assertTrue(self.closed_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
+
+    def test_when_posting_end_event_for_ended_and_restarted_stateful_incident_then_incident_gets_closed(self):
+        restarted_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(hours=1),
+            source=self.source1,
+        )
+        restarted_incident.create_first_event()
+        Event.objects.create(
+            incident=self.closed_incident,
+            actor=self.source1_user,
+            timestamp=timezone.now() - timedelta(minutes=30),
+            type=Event.Type.INCIDENT_END,
+        )
+        Event.objects.create(
+            incident=self.closed_incident,
+            actor=self.source1_user,
+            timestamp=timezone.now() - timedelta(minutes=10),
+            type=Event.Type.INCIDENT_RESTART,
+        )
+
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        event_timestamp = end_event_dict["timestamp"]
+
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
+        self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         self.stateful_incident.refresh_from_db()
         self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
+        self.assertEqual(self.stateful_incident.end_time, end_event_dict["timestamp"])
 
     def test_given_closed_incident_when_source_posts_end_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does
         # not. Its event is recorded for the audit trail (201) but update_incident is
         # skipped, so the incident is unchanged. Here: END on an already-closed
         # incident must be accepted and recorded without re-touching end_time.
-        count_before = self.stateful_incident.events.count()
-
-        self.stateful_incident.end_time = original_timestamp = timezone.now()
-        self.stateful_incident.save(update_fields=["end_time"])
+        count_before = self.closed_incident.events.count()
+        original_timestamp = self.closed_incident.end_time
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.closed_incident), end_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, original_timestamp)
-        self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
+        self.closed_incident.refresh_from_db()
+        self.assertFalse(self.closed_incident.open)
+        self.assertEqual(self.closed_incident.end_time, original_timestamp)
+        self.assertEqual(self.closed_incident.events.count(), count_before + 1)
 
     def test_given_open_incident_when_source_posts_restart_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -173,7 +173,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
         self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
 
-    def test_posting_close_and_reopen_events_does_not_change_stateless_incidents(self):
+    def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         )
@@ -183,6 +183,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
 
+    def test_when_posting_reopen_event_for_stateless_incident_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         )
@@ -192,7 +193,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
 
-    def test_posting_end_and_restart_events_does_not_change_stateless_incidents_but_records_event(self):
+    def test_when_posting_end_event_for_stateless_incident_then_incident_is_unchanged_and_event_is_recorded(self):
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
@@ -204,6 +205,9 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
+    def test_when_posting_restart_event_for_stateless_incident_then_incident_is_unchanged_and_event_is_recorded(self):
+        event_count = self.stateless_incident.events.count()
+
         response = self.source1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
         )
@@ -211,7 +215,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.stateless_incident.refresh_from_db()
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
-        self.assertEqual(self.stateless_incident.events.count(), event_count + 2)
+        self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
     def test_posting_allowed_event_types_for_source_system_is_valid(self):
         def delete_start_event(incident: Incident):

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -9,7 +9,7 @@ from rest_framework.test import APITestCase
 from argus.util import datetime_utils
 from argus.util.testing import disconnect_signals, connect_signals
 from argus.incident.factories import StatefulIncidentFactory, StatelessIncidentFactory
-from argus.incident.models import Event, Incident
+from argus.incident.models import Event
 from . import IncidentBasedAPITestCaseHelper
 
 
@@ -248,35 +248,36 @@ class EventAPISourceSystemUserTests(APITestCase, IncidentBasedAPITestCaseHelper)
         )
         self.open_incident.create_first_event()
 
+        self.open_incident_without_start_event = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(weeks=1),
+            source=self.source1,
+        )
+
         self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
 
     def tearDown(self):
         connect_signals()
 
     def test_when_posting_allowed_event_types_for_source_system_user_then_event_is_created(self):
-        def delete_start_event(incident: Incident):
-            incident.start_event.delete()
-
-        source_system_allowed_types_and_preconditions = {
-            Event.Type.INCIDENT_START: delete_start_event,
-            Event.Type.INCIDENT_END: lambda incident: None,
-            Event.Type.INCIDENT_RESTART: lambda incident: None,
-            Event.Type.OTHER: lambda incident: None,
+        source_system_allowed_types_and_incidents = {
+            Event.Type.INCIDENT_START: self.open_incident_without_start_event,
+            Event.Type.INCIDENT_END: self.open_incident,
+            Event.Type.INCIDENT_RESTART: self.closed_incident,
+            Event.Type.OTHER: self.open_incident,
         }
-        for event_type, ensure_precondition in source_system_allowed_types_and_preconditions.items():
+        for event_type, incident in source_system_allowed_types_and_incidents.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.open_incident)
-                event_count = self.open_incident.events.count()
+                event_count = incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.open_incident),
+                    self.events_url(incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.open_incident.events.count(), event_count + 1)
-                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.open_incident.pk)
+                self.assertEqual(incident.events.count(), event_count + 1)
+                self.assertTrue(incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], incident.pk)
 
     def test_when_posting_disallowed_event_types_for_source_system_user_then_return_bad_request(self):
         original_end_time = self.open_incident.end_time
@@ -284,7 +285,7 @@ class EventAPISourceSystemUserTests(APITestCase, IncidentBasedAPITestCaseHelper)
         source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
         for event_type in source_system_disallowed_types:
             with self.subTest(event_type=event_type):
-                event_count = Event.objects.count()
+                event_count = self.open_incident.events.count()
 
                 response = self.source1_rest_client.post(
                     self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
@@ -293,7 +294,7 @@ class EventAPISourceSystemUserTests(APITestCase, IncidentBasedAPITestCaseHelper)
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
-                self.assertEqual(Event.objects.count(), event_count)
+                self.assertEqual(self.open_incident.events.count(), event_count)
                 self.open_incident.refresh_from_db()
                 self.assertEqual(self.open_incident.end_time, original_end_time)
 
@@ -329,32 +330,24 @@ class EventAPIEndUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
         connect_signals()
 
     def test_when_posting_allowed_event_types_for_end_user_then_event_is_created(self):
-        def set_end_time_to(end_time):
-            def set_end_time(incident: Incident):
-                incident.end_time = end_time
-                incident.save()
-
-            return set_end_time
-
-        end_user_allowed_types_and_preconditions = {
-            Event.Type.CLOSE: set_end_time_to("infinity"),
-            Event.Type.REOPEN: set_end_time_to(timezone.now()),
-            Event.Type.OTHER: lambda incident: None,
+        end_user_allowed_types_and_incidents = {
+            Event.Type.CLOSE: self.open_incident,
+            Event.Type.REOPEN: self.closed_incident,
+            Event.Type.OTHER: self.open_incident,
         }
-        for event_type, ensure_precondition in end_user_allowed_types_and_preconditions.items():
+        for event_type, incident in end_user_allowed_types_and_incidents.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.open_incident)
-                event_count = self.open_incident.events.count()
+                event_count = incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.open_incident),
+                    self.events_url(incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.open_incident.events.count(), event_count + 1)
-                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.open_incident.pk)
+                self.assertEqual(incident.events.count(), event_count + 1)
+                self.assertTrue(incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], incident.pk)
 
     def test_when_posting_disallowed_event_types_for_end_user_then_return_bad_request(self):
         original_end_time = self.open_incident.end_time
@@ -362,7 +355,7 @@ class EventAPIEndUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
         for event_type in end_user_disallowed_types:
             with self.subTest(event_type=event_type):
-                event_count = Event.objects.count()
+                event_count = self.open_incident.events.count()
 
                 response = self.user1_rest_client.post(
                     self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
@@ -371,6 +364,6 @@ class EventAPIEndUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
-                self.assertEqual(Event.objects.count(), event_count)
+                self.assertEqual(self.open_incident.events.count(), event_count)
                 self.open_incident.refresh_from_db()
                 self.assertEqual(self.open_incident.end_time, original_end_time)

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -181,7 +181,7 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
     def tearDown(self):
         connect_signals()
 
-    def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
+    def test_when_posting_close_event_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         )

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -13,10 +13,8 @@ from argus.incident.models import Event
 from . import IncidentBasedAPITestCaseHelper
 
 
-class EventAPIStatefulIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper):
-    def setUp(self):
-        disconnect_signals()
-
+class StatefulEventBasedAPITestCaseHelper(IncidentBasedAPITestCaseHelper):
+    def init_test_objects(self):
         super().init_test_objects()
 
         self.closed_incident = StatefulIncidentFactory(
@@ -37,6 +35,13 @@ class EventAPIStatefulIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper)
             source=self.source1,
         )
         self.open_incident.create_first_event()
+
+
+class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        self.init_test_objects()
 
         self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
 
@@ -226,30 +231,11 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
 
-class EventAPISourceSystemUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
+class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
     def setUp(self):
         disconnect_signals()
 
         super().init_test_objects()
-
-        self.closed_incident = StatefulIncidentFactory(
-            start_time=timezone.now() - timedelta(days=2),
-            end_time=timezone.now() - timedelta(days=1),
-            source=self.source1,
-        )
-        self.closed_incident.create_first_event()
-        Event.objects.create(
-            incident=self.closed_incident,
-            actor=self.user1,
-            timestamp=self.closed_incident.end_time,
-            type=Event.Type.CLOSE,
-        )
-
-        self.open_incident = StatefulIncidentFactory(
-            start_time=timezone.now() - timedelta(weeks=1),
-            source=self.source1,
-        )
-        self.open_incident.create_first_event()
 
         self.open_incident_without_start_event = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(weeks=1),
@@ -302,30 +288,11 @@ class EventAPISourceSystemUserTests(APITestCase, IncidentBasedAPITestCaseHelper)
                 self.assertEqual(self.open_incident.end_time, original_end_time)
 
 
-class EventAPIEndUserTests(APITestCase, IncidentBasedAPITestCaseHelper):
+class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
     def setUp(self):
         disconnect_signals()
 
         super().init_test_objects()
-
-        self.closed_incident = StatefulIncidentFactory(
-            start_time=timezone.now() - timedelta(days=2),
-            end_time=timezone.now() - timedelta(days=1),
-            source=self.source1,
-        )
-        self.closed_incident.create_first_event()
-        Event.objects.create(
-            incident=self.closed_incident,
-            actor=self.user1,
-            timestamp=self.closed_incident.end_time,
-            type=Event.Type.CLOSE,
-        )
-
-        self.open_incident = StatefulIncidentFactory(
-            start_time=timezone.now() - timedelta(weeks=1),
-            source=self.source1,
-        )
-        self.open_incident.create_first_event()
 
         self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
 

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -237,33 +237,34 @@ class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHe
 
         super().init_test_objects()
 
+        self.open_incident_without_start_event = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(weeks=1),
+            source=self.source1,
+        )
+
     def tearDown(self):
         connect_signals()
 
     def test_when_posting_allowed_event_types_for_source_system_user_then_event_is_created(self):
-        def delete_start_event(incident: Incident):
-            incident.start_event.delete()
-
-        source_system_allowed_types_and_preconditions = {
-            Event.Type.INCIDENT_START: delete_start_event,
-            Event.Type.INCIDENT_END: lambda incident: None,
-            Event.Type.INCIDENT_RESTART: lambda incident: None,
-            Event.Type.OTHER: lambda incident: None,
+        source_system_allowed_types_and_incidents = {
+            Event.Type.INCIDENT_START: self.open_incident_without_start_event,
+            Event.Type.INCIDENT_END: self.open_incident,
+            Event.Type.INCIDENT_RESTART: self.closed_incident,
+            Event.Type.OTHER: self.open_incident,
         }
-        for event_type, ensure_precondition in source_system_allowed_types_and_preconditions.items():
+        for event_type, incident in source_system_allowed_types_and_incidents.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.open_incident)
-                event_count = self.open_incident.events.count()
+                event_count = incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    get_events_url(self.open_incident),
+                    get_events_url(incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.open_incident.events.count(), event_count + 1)
-                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.open_incident.pk)
+                self.assertEqual(incident.events.count(), event_count + 1)
+                self.assertTrue(incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], incident.pk)
 
     def test_when_posting_disallowed_event_types_for_source_system_user_then_return_bad_request(self):
         original_end_time = self.open_incident.end_time
@@ -271,7 +272,7 @@ class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHe
         source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
         for event_type in source_system_disallowed_types:
             with self.subTest(event_type=event_type):
-                event_count = Event.objects.count()
+                event_count = self.open_incident.events.count()
 
                 response = self.source1_rest_client.post(
                     get_events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
@@ -280,7 +281,7 @@ class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHe
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
-                self.assertEqual(Event.objects.count(), event_count)
+                self.assertEqual(self.open_incident.events.count(), event_count)
                 self.open_incident.refresh_from_db()
                 self.assertEqual(self.open_incident.end_time, original_end_time)
 
@@ -295,32 +296,24 @@ class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
         connect_signals()
 
     def test_when_posting_allowed_event_types_for_end_user_then_event_is_created(self):
-        def set_end_time_to(end_time):
-            def set_end_time(incident: Incident):
-                incident.end_time = end_time
-                incident.save()
-
-            return set_end_time
-
-        end_user_allowed_types_and_preconditions = {
-            Event.Type.CLOSE: set_end_time_to("infinity"),
-            Event.Type.REOPEN: set_end_time_to(timezone.now()),
-            Event.Type.OTHER: lambda incident: None,
+        end_user_allowed_types_and_incidents = {
+            Event.Type.CLOSE: self.open_incident,
+            Event.Type.REOPEN: self.closed_incident,
+            Event.Type.OTHER: self.open_incident,
         }
-        for event_type, ensure_precondition in end_user_allowed_types_and_preconditions.items():
+        for event_type, incident in end_user_allowed_types_and_incidents.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.open_incident)
-                event_count = self.open_incident.events.count()
+                event_count = incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    get_events_url(self.open_incident),
+                    get_events_url(incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.open_incident.events.count(), event_count + 1)
-                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.open_incident.pk)
+                self.assertEqual(incident.events.count(), event_count + 1)
+                self.assertTrue(incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], incident.pk)
 
     def test_when_posting_disallowed_event_types_for_end_user_then_return_bad_request(self):
         original_end_time = self.open_incident.end_time
@@ -328,7 +321,7 @@ class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
         for event_type in end_user_disallowed_types:
             with self.subTest(event_type=event_type):
-                event_count = Event.objects.count()
+                event_count = self.open_incident.events.count()
 
                 response = self.user1_rest_client.post(
                     get_events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
@@ -337,6 +330,6 @@ class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
-                self.assertEqual(Event.objects.count(), event_count)
+                self.assertEqual(self.open_incident.events.count(), event_count)
                 self.open_incident.refresh_from_db()
                 self.assertEqual(self.open_incident.end_time, original_end_time)

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -19,6 +19,19 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         super().init_test_objects()
 
+        self.closed_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(days=2),
+            end_time=timezone.now() - timedelta(days=1),
+            source=self.source1,
+        )
+        self.closed_incident.create_first_event()
+        Event.objects.create(
+            incident=self.closed_incident,
+            actor=self.user1,
+            timestamp=self.closed_incident.end_time,
+            type=Event.Type.CLOSE,
+        )
+
         self.stateful_incident = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(weeks=1),
             end_time=timezone.now() + timedelta(weeks=1),
@@ -34,96 +47,112 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
     def tearDown(self):
         connect_signals()
 
-    def test_posting_close_and_reopen_events_properly_changes_stateful_incidents(self):
-        # Test closing incident
+    def test_when_posting_close_event_for_stateful_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
-        event_timestamp = close_event_dict["timestamp"]
+
         response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
+
+        self.assertEqual(parse_datetime(response.data["timestamp"]), close_event_dict["timestamp"])
         self.stateful_incident.refresh_from_db()
         self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
+        self.assertEqual(self.stateful_incident.end_time, close_event_dict["timestamp"])
 
-        # It's illegal to close an already closed incident
-        original_end_time = self.stateful_incident.end_time
-        event_count = Event.objects.count()
+    def test_when_posting_close_event_for_stateful_closed_incident_then_end_time_does_not_change(self):
+        close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
+        original_end_time = self.closed_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.closed_incident), close_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
         self.assertEqual(response.data["type"].code, "invalid")
 
-        self.assertEqual(Event.objects.count(), event_count)
-        self.stateful_incident.refresh_from_db()
-        self.assertEqual(self.stateful_incident.end_time, original_end_time)
+        self.closed_incident.refresh_from_db()
+        self.assertEqual(self.closed_incident.end_time, original_end_time)
 
-        # Test reopening incident
+    def test_when_posting_reopen_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.closed_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertTrue(self.stateful_incident.open)
-        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
+        self.closed_incident.refresh_from_db()
+        self.assertTrue(self.closed_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
 
-        # It's illegal to reopen an already opened incident
+    def test_when_posting_reopen_event_for_stateful_open_incident_then_return_bad_request(self):
+        reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         original_end_time = self.stateful_incident.end_time
-        event_count = Event.objects.count()
 
         response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
         self.assertEqual(response.data["type"].code, "invalid")
 
-        self.assertEqual(Event.objects.count(), event_count)
         self.stateful_incident.refresh_from_db()
         self.assertEqual(self.stateful_incident.end_time, original_end_time)
 
-    def test_posting_end_and_restart_events_properly_changes_stateful_incidents(self):
-        # Test ending incident
+    def test_when_posting_end_event_for_stateful_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        event_timestamp = end_event_dict["timestamp"]
+
         response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
+
+        self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         self.stateful_incident.refresh_from_db()
         self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
+        self.assertEqual(self.stateful_incident.end_time, end_event_dict["timestamp"])
 
-        # Test restarting incident
+    def test_when_posting_restart_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertTrue(self.stateful_incident.open)
-        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
 
-        # Test ending again
+        response = self.source1_rest_client.post(self.events_url(self.closed_incident), restart_event_dict)
+        self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
+        self.closed_incident.refresh_from_db()
+        self.assertTrue(self.closed_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
+
+    def test_when_posting_end_event_for_ended_and_restarted_stateful_incident_then_incident_gets_closed(self):
+        restarted_incident = StatefulIncidentFactory(
+            start_time=timezone.now() - timedelta(hours=1),
+            source=self.source1,
+        )
+        restarted_incident.create_first_event()
+        Event.objects.create(
+            incident=restarted_incident,
+            actor=self.source1_user,
+            timestamp=timezone.now() - timedelta(minutes=30),
+            type=Event.Type.INCIDENT_END,
+        )
+        Event.objects.create(
+            incident=restarted_incident,
+            actor=self.source1_user,
+            timestamp=timezone.now() - timedelta(minutes=10),
+            type=Event.Type.INCIDENT_RESTART,
+        )
+
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        event_timestamp = end_event_dict["timestamp"]
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
-        self.assertEqual(parse_datetime(response.data["timestamp"]), event_timestamp)
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, event_timestamp)
+
+        response = self.source1_rest_client.post(self.events_url(restarted_incident), end_event_dict)
+        self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
+        restarted_incident.refresh_from_db()
+        self.assertFalse(restarted_incident.open)
+        self.assertEqual(restarted_incident.end_time, end_event_dict["timestamp"])
 
     def test_given_closed_incident_when_source_posts_end_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does
         # not. Its event is recorded for the audit trail (201) but update_incident is
         # skipped, so the incident is unchanged. Here: END on an already-closed
         # incident must be accepted and recorded without re-touching end_time.
-        count_before = self.stateful_incident.events.count()
-
-        self.stateful_incident.end_time = original_timestamp = timezone.now()
-        self.stateful_incident.save(update_fields=["end_time"])
+        count_before = self.closed_incident.events.count()
+        original_timestamp = self.closed_incident.end_time
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.closed_incident), end_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, original_timestamp)
-        self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
+        self.closed_incident.refresh_from_db()
+        self.assertFalse(self.closed_incident.open)
+        self.assertEqual(self.closed_incident.end_time, original_timestamp)
+        self.assertEqual(self.closed_incident.events.count(), count_before + 1)
 
     def test_given_open_incident_when_source_posts_restart_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -9,8 +9,12 @@ from rest_framework.test import APITestCase
 from argus.util import datetime_utils
 from argus.util.testing import disconnect_signals, connect_signals
 from argus.incident.factories import StatefulIncidentFactory, StatelessIncidentFactory
-from argus.incident.models import Event
+from argus.incident.models import Event, Incident
 from . import IncidentBasedAPITestCaseHelper
+
+
+def get_events_url(incident: Incident):
+    return reverse("v2:incident:incident-events", args=[incident.pk])
 
 
 class StatefulEventBasedAPITestCaseHelper(IncidentBasedAPITestCaseHelper):
@@ -43,15 +47,13 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
 
         self.init_test_objects()
 
-        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
-
     def tearDown(self):
         connect_signals()
 
     def test_when_posting_close_event_for_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
 
-        response = self.user1_rest_client.post(self.events_url(self.open_incident), close_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.open_incident), close_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), close_event_dict["timestamp"])
         self.open_incident.refresh_from_db()
@@ -62,7 +64,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         original_end_time = self.closed_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.closed_incident), close_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.closed_incident), close_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
@@ -73,7 +75,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
 
     def test_when_posting_reopen_event_for_closed_incident_then_incident_gets_reopened(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
-        response = self.user1_rest_client.post(self.events_url(self.closed_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.closed_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
         self.closed_incident.refresh_from_db()
         self.assertTrue(self.closed_incident.open)
@@ -83,7 +85,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         original_end_time = self.open_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.open_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.open_incident), reopen_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
@@ -95,7 +97,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
     def test_when_posting_end_event_for_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.open_incident), end_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         self.open_incident.refresh_from_db()
@@ -105,7 +107,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
     def test_when_posting_restart_event_for_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
 
-        response = self.source1_rest_client.post(self.events_url(self.closed_incident), restart_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.closed_incident), restart_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
         self.closed_incident.refresh_from_db()
         self.assertTrue(self.closed_incident.open)
@@ -132,7 +134,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(restarted_incident), end_event_dict)
+        response = self.source1_rest_client.post(get_events_url(restarted_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         restarted_incident.refresh_from_db()
         self.assertFalse(restarted_incident.open)
@@ -147,7 +149,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
         original_timestamp = self.closed_incident.end_time
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        response = self.source1_rest_client.post(self.events_url(self.closed_incident), end_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.closed_incident), end_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.closed_incident.refresh_from_db()
@@ -163,7 +165,7 @@ class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHe
         count_before = self.open_incident.events.count()
 
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
-        response = self.source1_rest_client.post(self.events_url(self.open_incident), restart_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.open_incident), restart_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.open_incident.refresh_from_db()
@@ -181,14 +183,12 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
         self.stateless_incident = StatelessIncidentFactory(source=self.source1)
         self.stateless_incident.create_first_event()
 
-        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
-
     def tearDown(self):
         connect_signals()
 
     def test_when_posting_close_event_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
@@ -198,7 +198,7 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
 
     def test_when_posting_reopen_event_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
@@ -210,7 +210,7 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.stateless_incident.refresh_from_db()
@@ -222,7 +222,7 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.stateless_incident.refresh_from_db()
@@ -242,8 +242,6 @@ class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHe
             source=self.source1,
         )
 
-        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
-
     def tearDown(self):
         connect_signals()
 
@@ -259,7 +257,7 @@ class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHe
                 event_count = incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(incident),
+                    get_events_url(incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -277,7 +275,7 @@ class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHe
                 event_count = self.open_incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
+                    get_events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)
@@ -294,8 +292,6 @@ class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
 
         super().init_test_objects()
 
-        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
-
     def tearDown(self):
         connect_signals()
 
@@ -310,7 +306,7 @@ class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
                 event_count = incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(incident),
+                    get_events_url(incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -328,7 +324,7 @@ class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
                 event_count = self.open_incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
+                    get_events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -178,6 +178,9 @@ class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper
 
         self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
 
+    def tearDown(self):
+        connect_signals()
+
     def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
             self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -32,12 +32,11 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
             type=Event.Type.CLOSE,
         )
 
-        self.stateful_incident = StatefulIncidentFactory(
+        self.open_incident = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(weeks=1),
-            end_time=timezone.now() + timedelta(weeks=1),
             source=self.source1,
         )
-        self.stateful_incident.create_first_event()
+        self.open_incident.create_first_event()
 
         self.stateless_incident = StatelessIncidentFactory(source=self.source1)
         self.stateless_incident.create_first_event()
@@ -50,12 +49,12 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
     def test_when_posting_close_event_for_stateful_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
 
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), close_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.open_incident), close_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), close_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, close_event_dict["timestamp"])
+        self.open_incident.refresh_from_db()
+        self.assertFalse(self.open_incident.open)
+        self.assertEqual(self.open_incident.end_time, close_event_dict["timestamp"])
 
     def test_when_posting_close_event_for_stateful_closed_incident_then_end_time_does_not_change(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
@@ -80,26 +79,26 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
     def test_when_posting_reopen_event_for_stateful_open_incident_then_return_bad_request(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
-        original_end_time = self.stateful_incident.end_time
+        original_end_time = self.open_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.stateful_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(self.events_url(self.open_incident), reopen_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
         self.assertEqual(response.data["type"].code, "invalid")
 
-        self.stateful_incident.refresh_from_db()
-        self.assertEqual(self.stateful_incident.end_time, original_end_time)
+        self.open_incident.refresh_from_db()
+        self.assertEqual(self.open_incident.end_time, original_end_time)
 
     def test_when_posting_end_event_for_stateful_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
-        self.stateful_incident.refresh_from_db()
-        self.assertFalse(self.stateful_incident.open)
-        self.assertEqual(self.stateful_incident.end_time, end_event_dict["timestamp"])
+        self.open_incident.refresh_from_db()
+        self.assertFalse(self.open_incident.open)
+        self.assertEqual(self.open_incident.end_time, end_event_dict["timestamp"])
 
     def test_when_posting_restart_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
@@ -159,19 +158,16 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         # not. Its event is recorded for the audit trail (201) but update_incident is
         # skipped, so the incident is unchanged. Here: RESTART on an already-open
         # incident must be accepted and recorded without re-touching end_time.
-        self.stateful_incident.end_time = datetime_utils.INFINITY_REPR
-        self.stateful_incident.save(update_fields=["end_time"])
-
-        count_before = self.stateful_incident.events.count()
+        count_before = self.open_incident.events.count()
 
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
-        response = self.source1_rest_client.post(self.events_url(self.stateful_incident), restart_event_dict)
+        response = self.source1_rest_client.post(self.events_url(self.open_incident), restart_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.stateful_incident.refresh_from_db()
-        self.assertTrue(self.stateful_incident.open)
-        self.assertEqual(datetime_utils.make_naive(self.stateful_incident.end_time), datetime.max)
-        self.assertEqual(self.stateful_incident.events.count(), count_before + 1)
+        self.open_incident.refresh_from_db()
+        self.assertTrue(self.open_incident.open)
+        self.assertEqual(datetime_utils.make_naive(self.open_incident.end_time), datetime.max)
+        self.assertEqual(self.open_incident.events.count(), count_before + 1)
 
     def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
@@ -229,18 +225,18 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         }
         for event_type, ensure_precondition in source_system_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.stateful_incident)
-                event_count = self.stateful_incident.events.count()
+                ensure_precondition(self.open_incident)
+                event_count = self.open_incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.stateful_incident),
+                    self.events_url(self.open_incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
-                self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.stateful_incident.pk)
+                self.assertEqual(self.open_incident.events.count(), event_count + 1)
+                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], self.open_incident.pk)
 
     def test_posting_allowed_event_types_for_end_user_is_valid(self):
         def set_end_time_to(end_time):
@@ -257,21 +253,21 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         }
         for event_type, ensure_precondition in end_user_allowed_types_and_preconditions.items():
             with self.subTest(event_type=event_type):
-                ensure_precondition(self.stateful_incident)
-                event_count = self.stateful_incident.events.count()
+                ensure_precondition(self.open_incident)
+                event_count = self.open_incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.stateful_incident),
+                    self.events_url(self.open_incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-                self.assertEqual(self.stateful_incident.events.count(), event_count + 1)
-                self.assertTrue(self.stateful_incident.events.filter(pk=response.data["pk"]).exists())
-                self.assertEqual(response.data["incident"], self.stateful_incident.pk)
+                self.assertEqual(self.open_incident.events.count(), event_count + 1)
+                self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
+                self.assertEqual(response.data["incident"], self.open_incident.pk)
 
     def test_posting_disallowed_event_types_for_source_system_is_invalid(self):
-        original_end_time = self.stateful_incident.end_time
+        original_end_time = self.open_incident.end_time
 
         source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
         for event_type in source_system_disallowed_types:
@@ -279,18 +275,18 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = Event.objects.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.stateful_incident), {"timestamp": timezone.now(), "type": event_type}
+                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
                 self.assertEqual(Event.objects.count(), event_count)
-                self.stateful_incident.refresh_from_db()
-                self.assertEqual(self.stateful_incident.end_time, original_end_time)
+                self.open_incident.refresh_from_db()
+                self.assertEqual(self.open_incident.end_time, original_end_time)
 
     def test_posting_disallowed_event_types_for_end_user_is_invalid(self):
-        original_end_time = self.stateful_incident.end_time
+        original_end_time = self.open_incident.end_time
 
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
         for event_type in end_user_disallowed_types:
@@ -298,12 +294,12 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = Event.objects.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.stateful_incident), {"timestamp": timezone.now(), "type": event_type}
+                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)
                 self.assertEqual(response.data["type"].code, "invalid")
 
                 self.assertEqual(Event.objects.count(), event_count)
-                self.stateful_incident.refresh_from_db()
-                self.assertEqual(self.stateful_incident.end_time, original_end_time)
+                self.open_incident.refresh_from_db()
+                self.assertEqual(self.open_incident.end_time, original_end_time)

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -127,11 +127,11 @@ class EventAPIStatefulIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper)
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
+        response = self.source1_rest_client.post(self.events_url(restarted_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
-        self.open_incident.refresh_from_db()
-        self.assertFalse(self.open_incident.open)
-        self.assertEqual(self.open_incident.end_time, end_event_dict["timestamp"])
+        restarted_incident.refresh_from_db()
+        self.assertFalse(restarted_incident.open)
+        self.assertEqual(restarted_incident.end_time, end_event_dict["timestamp"])
 
     def test_given_closed_incident_when_source_posts_end_then_records_event_without_state_change(self):
         # An end user posting a state-invalid event gets a 400; a source system does

--- a/tests/incident/test_event.py
+++ b/tests/incident/test_event.py
@@ -13,10 +13,12 @@ from argus.incident.models import Event, Incident
 from . import IncidentBasedAPITestCaseHelper
 
 
-class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
-    def setUp(self):
-        disconnect_signals()
+def get_events_url(incident: Incident):
+    return reverse("v2:incident:incident-events", args=[incident.pk])
 
+
+class StatefulEventBasedAPITestCaseHelper(IncidentBasedAPITestCaseHelper):
+    def init_test_objects(self):
         super().init_test_objects()
 
         self.closed_incident = StatefulIncidentFactory(
@@ -38,29 +40,31 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         )
         self.open_incident.create_first_event()
 
-        self.stateless_incident = StatelessIncidentFactory(source=self.source1)
-        self.stateless_incident.create_first_event()
 
-        self.events_url = lambda incident: reverse("v2:incident:incident-events", args=[incident.pk])
+class EventAPIStatefulIncidentTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        self.init_test_objects()
 
     def tearDown(self):
         connect_signals()
 
-    def test_when_posting_close_event_for_stateful_open_incident_then_incident_gets_closed(self):
+    def test_when_posting_close_event_for_open_incident_then_incident_gets_closed(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
 
-        response = self.user1_rest_client.post(self.events_url(self.open_incident), close_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.open_incident), close_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), close_event_dict["timestamp"])
         self.open_incident.refresh_from_db()
         self.assertFalse(self.open_incident.open)
         self.assertEqual(self.open_incident.end_time, close_event_dict["timestamp"])
 
-    def test_when_posting_close_event_for_stateful_closed_incident_then_end_time_does_not_change(self):
+    def test_when_posting_close_event_for_closed_incident_then_end_time_does_not_change(self):
         close_event_dict = {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         original_end_time = self.closed_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.closed_incident), close_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.closed_incident), close_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
@@ -69,19 +73,19 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.closed_incident.refresh_from_db()
         self.assertEqual(self.closed_incident.end_time, original_end_time)
 
-    def test_when_posting_reopen_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
+    def test_when_posting_reopen_event_for_closed_incident_then_incident_gets_reopened(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
-        response = self.user1_rest_client.post(self.events_url(self.closed_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.closed_incident), reopen_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), reopen_event_dict["timestamp"])
         self.closed_incident.refresh_from_db()
         self.assertTrue(self.closed_incident.open)
         self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
 
-    def test_when_posting_reopen_event_for_stateful_open_incident_then_return_bad_request(self):
+    def test_when_posting_reopen_event_for_open_incident_then_return_bad_request(self):
         reopen_event_dict = {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         original_end_time = self.open_incident.end_time
 
-        response = self.user1_rest_client.post(self.events_url(self.open_incident), reopen_event_dict)
+        response = self.user1_rest_client.post(get_events_url(self.open_incident), reopen_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("type", response.data)
@@ -90,26 +94,26 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.open_incident.refresh_from_db()
         self.assertEqual(self.open_incident.end_time, original_end_time)
 
-    def test_when_posting_end_event_for_stateful_open_incident_then_incident_gets_closed(self):
+    def test_when_posting_end_event_for_open_incident_then_incident_gets_closed(self):
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(self.open_incident), end_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.open_incident), end_event_dict)
 
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         self.open_incident.refresh_from_db()
         self.assertFalse(self.open_incident.open)
         self.assertEqual(self.open_incident.end_time, end_event_dict["timestamp"])
 
-    def test_when_posting_restart_event_for_stateful_closed_incident_then_incident_gets_reopened(self):
+    def test_when_posting_restart_event_for_closed_incident_then_incident_gets_reopened(self):
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
 
-        response = self.source1_rest_client.post(self.events_url(self.closed_incident), restart_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.closed_incident), restart_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), restart_event_dict["timestamp"])
         self.closed_incident.refresh_from_db()
         self.assertTrue(self.closed_incident.open)
         self.assertEqual(datetime_utils.make_naive(self.closed_incident.end_time), datetime.max)
 
-    def test_when_posting_end_event_for_ended_and_restarted_stateful_incident_then_incident_gets_closed(self):
+    def test_when_posting_end_event_for_ended_and_restarted_incident_then_incident_gets_closed(self):
         restarted_incident = StatefulIncidentFactory(
             start_time=timezone.now() - timedelta(hours=1),
             source=self.source1,
@@ -130,7 +134,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
 
-        response = self.source1_rest_client.post(self.events_url(restarted_incident), end_event_dict)
+        response = self.source1_rest_client.post(get_events_url(restarted_incident), end_event_dict)
         self.assertEqual(parse_datetime(response.data["timestamp"]), end_event_dict["timestamp"])
         restarted_incident.refresh_from_db()
         self.assertFalse(restarted_incident.open)
@@ -145,7 +149,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         original_timestamp = self.closed_incident.end_time
 
         end_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
-        response = self.source1_rest_client.post(self.events_url(self.closed_incident), end_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.closed_incident), end_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.closed_incident.refresh_from_db()
@@ -161,7 +165,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         count_before = self.open_incident.events.count()
 
         restart_event_dict = {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
-        response = self.source1_rest_client.post(self.events_url(self.open_incident), restart_event_dict)
+        response = self.source1_rest_client.post(get_events_url(self.open_incident), restart_event_dict)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.open_incident.refresh_from_db()
@@ -169,9 +173,22 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertEqual(datetime_utils.make_naive(self.open_incident.end_time), datetime.max)
         self.assertEqual(self.open_incident.events.count(), count_before + 1)
 
-    def test_when_posting_close_event_for_stateless_incident_then_incident_does_not_change(self):
+
+class EventAPIStatelessIncidentTests(APITestCase, IncidentBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+        self.stateless_incident = StatelessIncidentFactory(source=self.source1)
+        self.stateless_incident.create_first_event()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_posting_close_event_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.CLOSE}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
@@ -179,9 +196,9 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
 
-    def test_when_posting_reopen_event_for_stateless_incident_then_incident_does_not_change(self):
+    def test_when_posting_reopen_event_then_incident_does_not_change(self):
         response = self.user1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.REOPEN}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["type"], "Cannot change the state of a stateless incident.")
@@ -189,11 +206,11 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.stateful)
         self.assertFalse(self.stateless_incident.open)
 
-    def test_when_posting_end_event_for_stateless_incident_then_incident_is_unchanged_and_event_is_recorded(self):
+    def test_when_posting_end_event_then_incident_does_not_change_and_event_is_recorded(self):
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_END}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.stateless_incident.refresh_from_db()
@@ -201,11 +218,11 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
-    def test_when_posting_restart_event_for_stateless_incident_then_incident_is_unchanged_and_event_is_recorded(self):
+    def test_when_posting_restart_event_then_incident_does_not_change_and_event_is_recorded(self):
         event_count = self.stateless_incident.events.count()
 
         response = self.source1_rest_client.post(
-            self.events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
+            get_events_url(self.stateless_incident), {"timestamp": timezone.now(), "type": Event.Type.INCIDENT_RESTART}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.stateless_incident.refresh_from_db()
@@ -213,7 +230,17 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
         self.assertFalse(self.stateless_incident.open)
         self.assertEqual(self.stateless_incident.events.count(), event_count + 1)
 
-    def test_posting_allowed_event_types_for_source_system_is_valid(self):
+
+class EventAPISourceSystemUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_posting_allowed_event_types_for_source_system_user_then_event_is_created(self):
         def delete_start_event(incident: Incident):
             incident.start_event.delete()
 
@@ -229,7 +256,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = self.open_incident.events.count()
 
                 response = self.source1_rest_client.post(
-                    self.events_url(self.open_incident),
+                    get_events_url(self.open_incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -238,7 +265,36 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
                 self.assertEqual(response.data["incident"], self.open_incident.pk)
 
-    def test_posting_allowed_event_types_for_end_user_is_valid(self):
+    def test_when_posting_disallowed_event_types_for_source_system_user_then_return_bad_request(self):
+        original_end_time = self.open_incident.end_time
+
+        source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
+        for event_type in source_system_disallowed_types:
+            with self.subTest(event_type=event_type):
+                event_count = Event.objects.count()
+
+                response = self.source1_rest_client.post(
+                    get_events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
+                )
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("type", response.data)
+                self.assertEqual(response.data["type"].code, "invalid")
+
+                self.assertEqual(Event.objects.count(), event_count)
+                self.open_incident.refresh_from_db()
+                self.assertEqual(self.open_incident.end_time, original_end_time)
+
+
+class EventAPIEndUserTests(APITestCase, StatefulEventBasedAPITestCaseHelper):
+    def setUp(self):
+        disconnect_signals()
+
+        super().init_test_objects()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_posting_allowed_event_types_for_end_user_then_event_is_created(self):
         def set_end_time_to(end_time):
             def set_end_time(incident: Incident):
                 incident.end_time = end_time
@@ -257,7 +313,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = self.open_incident.events.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.open_incident),
+                    get_events_url(self.open_incident),
                     {"timestamp": timezone.now(), "type": event_type},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -266,26 +322,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 self.assertTrue(self.open_incident.events.filter(pk=response.data["pk"]).exists())
                 self.assertEqual(response.data["incident"], self.open_incident.pk)
 
-    def test_posting_disallowed_event_types_for_source_system_is_invalid(self):
-        original_end_time = self.open_incident.end_time
-
-        source_system_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_SOURCE_SYSTEMS
-        for event_type in source_system_disallowed_types:
-            with self.subTest(event_type=event_type):
-                event_count = Event.objects.count()
-
-                response = self.source1_rest_client.post(
-                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
-                )
-                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-                self.assertIn("type", response.data)
-                self.assertEqual(response.data["type"].code, "invalid")
-
-                self.assertEqual(Event.objects.count(), event_count)
-                self.open_incident.refresh_from_db()
-                self.assertEqual(self.open_incident.end_time, original_end_time)
-
-    def test_posting_disallowed_event_types_for_end_user_is_invalid(self):
+    def test_when_posting_disallowed_event_types_for_end_user_then_return_bad_request(self):
         original_end_time = self.open_incident.end_time
 
         end_user_disallowed_types = set(Event.Type.values) - Event.ALLOWED_TYPES_FOR_END_USERS
@@ -294,7 +331,7 @@ class EventAPITests(APITestCase, IncidentBasedAPITestCaseHelper):
                 event_count = Event.objects.count()
 
                 response = self.user1_rest_client.post(
-                    self.events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
+                    get_events_url(self.open_incident), {"timestamp": timezone.now(), "type": event_type}
                 )
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn("type", response.data)


### PR DESCRIPTION
## Scope and purpose

Dependent on #1504. After I added tests to this file in that pull request I decided it is time to make this test easier to read and for new tests to be added if wanted.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
