### PR TITLE
Read TIME_ZONE from the environment

### DIFF
--- a/changelog.d/1963.added.md
+++ b/changelog.d/1963.added.md
@@ -1,0 +1,3 @@
+The time zone is now configurable via the `TIME_ZONE` environment variable
+(default `Europe/Oslo`, unchanged). The `TIME_ZONE` variable already shipped in
+`docker-compose.yml` previously had no effect.

--- a/docs/reference/site-specific-settings.rst
+++ b/docs/reference/site-specific-settings.rst
@@ -43,6 +43,17 @@ Django-specific settings
   .. warning:: Keep the :setting:`SECRET_KEY` secret, as it is relevant to the
     security and integrity of your Argus instance.
 
+.. setting:: TIME_ZONE
+
+* :setting:`TIME_ZONE` (optional) the time zone Argus uses to *display*
+  timestamps, as an IANA name (e.g. ``Europe/Oslo``, ``UTC``). Defaults to
+  ``Europe/Oslo``.
+
+  Note that this setting only affects how timestamps are presented. Internally,
+  all timestamps are stored in UTC, so changing :setting:`TIME_ZONE` does not
+  alter existing data — it only changes the time zone the values are rendered
+  in.
+
 .. _site-specific-settings-additional-apps:
 
 Settings for adding additional Django apps

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -166,7 +166,7 @@ USE_I18N = True
 
 USE_TZ = True
 
-TIME_ZONE = "Europe/Oslo"
+TIME_ZONE = get_str_env("TIME_ZONE", "Europe/Oslo")
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
## Scope and purpose

The `TIME_ZONE` setting was hardcoded to `Europe/Oslo`, yet a `TIME_ZONE` environment variable has shipped in the bundled `docker-compose.yml` ever since the [development compose setup was first added in 2020](https://github.com/Uninett/Argus/commit/1c335cb5) — with no effect, because no settings file ever read it. Deployers reasonably expect that variable to work.

This reads `TIME_ZONE` via `get_str_env`, the same mechanism every other deployment setting uses, keeping the `Europe/Oslo` default so existing deployments are unaffected.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code (routes an existing setting through the standard `get_str_env` helper, like every other env-configurable setting; none carry dedicated tests)
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
