### PR TITLE
Add apprise to all-plugins docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,10 +71,6 @@ CMD ["/cmd-argus.sh"]
 # extends `build` instead and copy the resulting venv.)
 FROM base AS all-plugins
 USER root
-RUN pip install \
-    argus-ticket-github \
-    argus-ticket-gitlab \
-    argus-ticket-jira \
-    argus-ticket-rt \
-    argus-notification-msteams
+COPY --from=build /src/pyproject.toml /tmp/pyproject.toml
+RUN pip install --group /tmp/pyproject.toml:all-plugins
 USER argus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dynamic = ["version"]
 "Homepage" = "https://github.com/Uninett/Argus"
 
 [project.optional-dependencies]
-apprise = ["apprise>=1.9.6"]
+apprise = ["apprise>=1.9.6"] # When updating version requirement also update it in dependency group "all-plugins"
 htmx = []  # for outdated install procedures
 docs = ["sphinx>=2.2.0"]
 dev = [
@@ -75,6 +75,12 @@ dev = [
     "build",  # for debugging builds/installs
 ]
 jsonlogging = ["python-json-logger"]
+
+[dependency-groups]
+all-plugins = [
+    "argus-ticket-github", "argus-ticket-gitlab", "argus-ticket-jira",
+    "argus-ticket-rt", "argus-notification-msteams", "apprise>=1.9.6"
+]
 
 [tool.hatch.version]
 source = "versioningit"


### PR DESCRIPTION
## Scope and purpose

Dependent on #1980.

Adds a dependency group containing all Sikt-maintained plugins and apprise. Uses that dependency group when building the "all-plugins" target.

Apprise was made an optional dependency in #1951.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
