### PR TITLE
Add `zabbix-argus-glue` to known glue service list

### DIFF
--- a/changelog.d/+doc-zabbix-argus.added.md
+++ b/changelog.d/+doc-zabbix-argus.added.md
@@ -1,0 +1,1 @@
+Added `zabbix-argus-glue` to documented list of known glue services

--- a/docs/integrations/glue-services/index.rst
+++ b/docs/integrations/glue-services/index.rst
@@ -43,6 +43,18 @@ Zino
 This is a standalone process that connects to both the Zino and Argus APIs and
 exchanges/synchronizes information between them.
 
+Zabbix
+~~~~~~
+
+| Home: https://www.zabbix.com/
+| Source: https://github.com/Uninett/zabbix-argus-glue
+| PyPI: `zabbix-argus-glue <https://pypi.org/project/zabbix-argus-glue/>`_
+
+This is a standalone service that synchronizes Zabbix 7.2+ problems with Argus
+incidents. It combines a webhook receiver for near real-time updates with a
+reconciliation poller that periodically corrects any drift between the two
+systems.
+
 
 Mist Systems Administration (Juniper)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Scope and purpose

Fixes #1936. Depends on Uninett/zabbix-argus-glue#6.

Adds the Zabbix glue service to the list of glue services maintained by Argus developers, giving users a documented, officially-maintained option for synchronizing Zabbix problems with Argus incidents.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code — N/A, documentation-only change
* [x] Added/changed documentation, including updates to the user manual if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
