### PR TITLE
Fixed incident list not reacting to filtering changes when a saved filter is selected

### DIFF
--- a/changelog.d/1940.fixed.md
+++ b/changelog.d/1940.fixed.md
@@ -1,0 +1,1 @@
+Fixed incident list not reacting to filtering changes when a saved filter is selected

--- a/src/argus/htmx/incident/filter.py
+++ b/src/argus/htmx/incident/filter.py
@@ -292,8 +292,13 @@ def incident_list_filter(request, qs, use_empty_filter=False):
             del request.session["selected_filter"]
             filter_pk, filter_obj = None, None
     if filter_obj:
-        form = IncidentFilterForm(_convert_filterblob(filter_obj.filter.copy()))
-        LOG.trace("using stored filter: %s", filter_obj.filter)
+        form_data = _normalize_form_data(request)
+        if form_data.keys() & IncidentFilterForm.DEFAULT_VALUES.keys():
+            form = IncidentFilterForm(form_data)
+            LOG.trace("using form data (overriding stored filter): %s", form_data)
+        else:
+            form = IncidentFilterForm(_convert_filterblob(filter_obj.filter.copy()))
+            LOG.trace("using stored filter: %s", filter_obj.filter)
     else:
         form_data = _normalize_form_data(request)
         if request.method == "POST":

--- a/tests/htmx/incident/test_filter.py
+++ b/tests/htmx/incident/test_filter.py
@@ -138,6 +138,26 @@ class TestIncidentListFilter(TestCase):
         form, _ = incident_list_filter(self.request, self.qs)
         assert form.to_filterblob()["maxlevel"] == maxlevel
 
+    def test_when_saved_filter_is_selected_and_request_has_form_params_then_it_should_use_the_form_params(self):
+        # The saved filter (maxlevel=1) would exclude the level-5 incident. Form params
+        # in the request must override the saved filter's params, so maxlevel=5 wins and
+        # the incident becomes visible again.
+        self.request.session["selected_filter"] = self.valid_filter.pk
+        self.request.GET = QueryDict("maxlevel=5&tags=")
+        form, qs = incident_list_filter(self.request, self.qs)
+        assert form.is_valid()  # guard against the wrong-reason pass: an invalid form filters nothing
+        assert form.to_filterblob()["maxlevel"] == 5  # form param won over saved maxlevel=1
+        assert self.incident in qs  # ...and the override actually reaches the queryset
+
+    def test_when_saved_filter_is_selected_and_request_has_no_form_params_then_it_should_use_the_saved_filter(self):
+        # sort/sort_order are always present as hidden inputs but are not form params,
+        # so they must not count as an override and the saved filter still applies.
+        self.request.session["selected_filter"] = self.valid_filter.pk
+        self.request.GET = QueryDict("sort=start_time&sort_order=desc")
+        form, qs = incident_list_filter(self.request, self.qs)
+        assert form.to_filterblob()["maxlevel"] == 1  # saved filter value, not overridden
+        assert self.incident not in qs  # saved filter still filters the queryset
+
     def test_post_request_without_selected_filter_should_use_post_parameters_as_form_data(self):
         maxlevel = 3
         request = self.factory.post("random-url", {}, content_type="application/json")


### PR DESCRIPTION
## Scope and purpose

Fixes #1940. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
