### PR TITLE
Slim the production Docker image with a multi-stage build

### DIFF
--- a/changelog.d/923.fixed.md
+++ b/changelog.d/923.fixed.md
@@ -1,0 +1,1 @@
+Slimmed down the production Docker image with a multi-stage build, so the build toolchain and the full source tree (including its git history) are no longer baked into the published image.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,26 +8,47 @@
 # If you're in the repository root try:
 #   docker build -f docker/Dockerfile .
 
-FROM python:3.13-trixie AS base
+# ── build stage ─────────────────────────────────────
+# Builds the virtualenv in a throwaway stage. git is required here because the
+# Argus version is derived from git metadata by versioningit at install time;
+# the C toolchain and -dev headers cover any dependencies without binary
+# wheels. None of these build dependencies end up in the runtime image.
+FROM python:3.13-slim-trixie AS build
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends tini build-essential
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential libpq-dev libffi-dev libssl-dev git \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Install some dev requirements that aren't part of the minimal dependencies:
+# Runtime dependencies that aren't part of the minimal package dependencies:
 RUN pip install "psycopg[binary]" django-extensions python-dotenv gunicorn
+
+COPY . /src
+RUN pip install /src
+
+# ── runtime base ────────────────────────────────────
+# Slim runtime image that carries over only the virtualenv built above, so
+# neither the build toolchain nor the source tree (including its git history)
+# bloat the published image.
+FROM python:3.13-slim-trixie AS base
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY --from=build $VIRTUAL_ENV $VIRTUAL_ENV
 
 # Make an unprivileged user to run the server
 RUN useradd --system argus
 # Ensure this user has privileges to collect static resources in /static
 RUN mkdir -p /static && chown argus /static
 ENV STATIC_ROOT=/static
-
-COPY . /src
-RUN pip install '/src' && rm -rf /src
 
 # Install API backend settings suitable for Docker deployment
 RUN mkdir /extrapython
@@ -44,7 +65,10 @@ ENTRYPOINT ["/usr/bin/tini", "-v", "--"]
 CMD ["/cmd-argus.sh"]
 
 # ── all-plugins target ──────────────────────────────
-# Includes all Sikt-maintained notification and ticket plugins
+# Includes all Sikt-maintained notification and ticket plugins. These are
+# pure-Python wheels, so they install on the slim runtime without the build
+# toolchain. (If a plugin ever needs compilation, install them in a stage that
+# extends `build` instead and copy the resulting venv.)
 FROM base AS all-plugins
 USER root
 RUN pip install \


### PR DESCRIPTION
## Scope and purpose

Closes #923.

The production image's single build stage runs `COPY . /src`, which bakes the entire working tree — including the full `.git` history and any uncommitted local files — into a permanent image layer; the trailing `rm -rf /src` can't reclaim it, because Docker layers are additive. On top of that the image is built from the full `python:3.13-trixie` (buildpack-deps) base with `build-essential` left in at runtime. None of that belongs in a published runtime image.

This splits the build in two: a throwaway `build` stage compiles the virtualenv (it keeps `git` and the `.git` directory, which `versioningit` needs to derive the package version at install time), and a slim `python:3.13-slim-trixie` runtime stage copies over only `/opt/venv`. The source tree, git history and build toolchain never reach the published image. The optional `all-plugins` target is preserved. See the new [`docker/Dockerfile`](https://github.com/Uninett/Argus/blob/88af6dd8a187de9831308be95b8edb4d68405705/docker/Dockerfile).

Effect: the base image **drops from ~1.43 GB to ~329 MB** (all-plugins ~360 MB), and the published image no longer carries the repository's git history or any local files. The version is still resolved correctly by `versioningit` inside the runtime image (verified via `importlib.metadata`), because it is baked into the installed package metadata during the build stage.

The approach mirrors the multi-stage pattern already used by [zino](https://github.com/Uninett/zino/blob/master/Dockerfile) and nav-container, as suggested in the issue.

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
