### PR TITLE
Enable manual rebuilds and a latest tag for Docker images

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -49,6 +49,13 @@ jobs:
             tag="$latest_tag"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          # Only move the `latest` tag when building the current latest release,
+          # so a manual rebuild of an older release does not clobber it.
+          if [ "$tag" = "$latest_tag" ]; then
+            echo "latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "latest=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -68,6 +75,7 @@ jobs:
         with:
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
+            type=raw,value=latest,enable=${{ steps.release.outputs.latest }}
           images: ${{ matrix.image }}
 
       - name: Build and push backend Docker image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -6,6 +6,12 @@ on:
     types:
       - published
       - edited
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version tag to (re)build, e.g. v2.9.1 (a bare 2.9.1 is also accepted). Defaults to the latest release."
+        required: false
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -25,8 +31,29 @@ jobs:
             target: all-plugins
 
     steps:
+      - name: Determine release tag to build
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          latest_tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="$RELEASE_TAG"
+          elif [ -n "$INPUT_VERSION" ]; then
+            tag="$INPUT_VERSION"
+            # Release tags are v-prefixed; tolerate a bare version such as 2.9.1
+            case "$tag" in v*) ;; *) tag="v$tag" ;; esac
+          else
+            tag="$latest_tag"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release.outputs.tag }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -40,7 +67,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
           images: ${{ matrix.image }}
 
       - name: Build and push backend Docker image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Determine release tag to build
-        id: release
+        id: resolve_tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.release.outputs.tag }}
+          ref: ${{ steps.resolve_tag.outputs.tag }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -74,8 +74,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
-            type=raw,value=latest,enable=${{ steps.release.outputs.latest }}
+            type=semver,pattern={{version}},value=${{ steps.resolve_tag.outputs.tag }}
+            type=raw,value=latest,enable=${{ steps.resolve_tag.outputs.latest }}
           images: ${{ matrix.image }}
 
       - name: Build and push backend Docker image

--- a/changelog.d/+docker-image-manual-rebuild.added.md
+++ b/changelog.d/+docker-image-manual-rebuild.added.md
@@ -1,0 +1,1 @@
+The Docker image publishing workflow can now be triggered manually to (re)build any past release, and tags the newest release as `latest`.


### PR DESCRIPTION
## Scope and purpose

The Docker image publishing workflow only ran on GitHub release events, so there was no way to rebuild a past release's image — e.g. after the image recipe changes (#923) or a base-image security update — without cutting a new release.

This adds a manual `workflow_dispatch` trigger with an optional `version` input that (re)builds any past release (defaulting to the latest), resolves the release tag explicitly (release event tag, dispatch input, or latest release as a fallback), and additionally tags the newest release as `latest`. The `latest` tag is guarded so that manually rebuilding an older release does not move it. User-controlled inputs are passed through the environment and never interpolated into the shell, since the job holds a `packages: write` token. See [`.github/workflows/docker-images.yml`](https://github.com/Uninett/Argus/blob/0b4c139c3e2a64cb319daf78f9c26ed6b9bd14ab/.github/workflows/docker-images.yml).

This mirrors the approach in [Uninett/zino#557](https://github.com/Uninett/zino/pull/557). As there, a `release`-triggered run uses the workflow file as it existed at the release's tagged commit, so the change takes effect for releases cut after it merges; existing releases can be rebuilt on demand with the new `version` input.

### This pull request
* changes CI configuration only

## Contributor Checklist

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style) (pre-commit passed; no Python changed)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
