### PR TITLE
fix: add link affordance to URL-valued tags and ticket badge

### DIFF
--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
@@ -4,7 +4,7 @@
   {% for tag in incident.deprecated_tags %}
     <span class="badge badge-xs badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
       {# djlint:off #}
-      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
+      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a class="link" href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
       {# djlint:on #}
     </span>
   {% endfor %}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -25,7 +25,7 @@
                 <span class="badge badge-error">Unacknowledged</span>
               {% endif %}
               {% if incident.ticket_url %}
-                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
+                <span class="badge badge-success h-auto text-wrap break-all text-center"><a class="link" href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
               {% else %}
                 <span class="badge badge-error">No ticket</span>
               {% endif %}
@@ -37,7 +37,7 @@
               {% for tag in incident.deprecated_tags %}
                 <span class="badge badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
                   {# djlint:off #}
-                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
+                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a class="link" href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
                   {# djlint:on #}
                 </span>
               {% endfor %}


### PR DESCRIPTION
## Summary

Adds DaisyUI's `link` CSS class to clickable URL anchors in tag values and the Ticket status badge so they are visually distinguishable as links (underline + link colour), consistent with how other links are styled elsewhere in the UI.

Closes #1985

## Changes

### Problem
Under Tailwind's preflight reset, `<a>` tags without an explicit CSS class inherit `color`/`text-decoration` from their parent badge element. This made URL-valued tags and the Ticket badge look identical to plain text — users couldn't tell they were clickable without hovering.

### Fix
Added `class="link"` to three anchor elements:

| Location | File | Lines |
|----------|------|-------|
| Tag value in list view | `cells/_incident_tags.html` | Line 7 |
| Tag value in detail page | `incident_detail.html` | (tags section) |
| Ticket badge in Status block | `incident_detail.html` | (status section) |

The `link` class is already used in the same detail page for the ticket URL at the bottom of the Primary Details section (line ~112), so this follows the existing pattern.

## Verification
- ✅ Uses existing DaisyUI utility (`link`) already employed elsewhere in the codebase
- ✅ No new CSS or dependencies needed
- ✅ Minimal changes — single attribute addition per element