### PR TITLE
fix: add link affordance to URL tags and Ticket badge (closes #1985)

### DIFF
--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
@@ -4,7 +4,7 @@
   {% for tag in incident.deprecated_tags %}
     <span class="badge badge-xs badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
       {# djlint:off #}
-      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
+      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer" class="link">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
       {# djlint:on #}
     </span>
   {% endfor %}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -25,7 +25,7 @@
                 <span class="badge badge-error">Unacknowledged</span>
               {% endif %}
               {% if incident.ticket_url %}
-                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
+                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank" class="link">Ticket {{ incident.ticket_url }}</a></span>
               {% else %}
                 <span class="badge badge-error">No ticket</span>
               {% endif %}
@@ -37,7 +37,7 @@
               {% for tag in incident.deprecated_tags %}
                 <span class="badge badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
                   {# djlint:off #}
-                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
+                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer" class="link">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
                   {# djlint:on #}
                 </span>
               {% endfor %}


### PR DESCRIPTION
## What
Adds `class="link"` (DaisyUI utility) to the three anchor elements that were rendering as plain text despite being clickable hyperlinks.

## Changes
- `cells/_incident_tags.html` line 7 — URL-valued tag in the list view
- `incident_detail.html` line 28 — Ticket badge in the Status block
- `incident_detail.html` line 40 — URL-valued tag on the detail page

All three now match the visual treatment already applied to the ticket link at line 112 of `incident_detail.html`.

## Before / After
- Before: URLs render in same colour and weight as surrounding text, no underline
- After: URLs show underline and link colour via DaisyUI `link` class, consistent with the rest of the UI

Closes #1985