### PR TITLE
Add notify_type parameter to AppriseMedium send

### DIFF
--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -261,7 +261,7 @@ class AppriseMedium(NotificationMedium):
         return subject, message
 
     @classmethod
-    def send(cls, event: Event, destinations: Iterable[DestinationConfig], **_) -> bool:
+    def send(cls, event: Event, destinations: Iterable[DestinationConfig], notify_type=None, **_) -> bool:
         """
         Sends an Apprise notification about a given event to the given destinations
 
@@ -290,7 +290,10 @@ class AppriseMedium(NotificationMedium):
             notifier = Apprise()
             notifier.add(destination_url)
 
-            result = notifier.notify(body=message, title=subject)
+            kwargs = {"body": message, "title": subject}
+            if notify_type is not None:
+                kwargs["notify_type"] = notify_type
+            result = notifier.notify(**kwargs)
 
             if not result:
                 failed += 1

--- a/tests/notificationprofile/destinations/test_apprise.py
+++ b/tests/notificationprofile/destinations/test_apprise.py
@@ -285,3 +285,25 @@ class AppriseMediumBehaviorTests(TestCase):
                 result = AppriseMedium.send(self.event, [self.destination])
         self.assertFalse(result)
         self.assertIn("not installed", cm.output[0])
+
+    @patch("argus.notificationprofile.media.base.Apprise")
+    def test_given_no_notify_type_notifier_should_be_called_without_notify_type(self, mock_apprise):
+        instance = mock_apprise.return_value
+        instance.notify.return_value = True
+
+        with self.settings(SEND_NOTIFICATIONS=True):
+            AppriseMedium.send(self.event, [self.destination])
+
+        _, call_kwargs = instance.notify.call_args
+        self.assertNotIn("notify_type", call_kwargs)
+
+    @patch("argus.notificationprofile.media.base.Apprise")
+    def test_given_notify_type_notifier_should_be_called_with_notify_type(self, mock_apprise):
+        instance = mock_apprise.return_value
+        instance.notify.return_value = True
+
+        with self.settings(SEND_NOTIFICATIONS=True):
+            AppriseMedium.send(self.event, [self.destination], notify_type="warning")
+
+        _, call_kwargs = instance.notify.call_args
+        self.assertEqual(call_kwargs["notify_type"], "warning")


### PR DESCRIPTION
## Scope and purpose

Fixes #1989.

Does not make a difference as is, but it allows for the simplification of argus_notification_msteams.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
