### PR TITLE
Improve rendering of long incident tags

### DIFF
--- a/changelog.d/1986.fixed.md
+++ b/changelog.d/1986.fixed.md
@@ -1,0 +1,1 @@
+Long tag values now render in a readable, constrained badge layout in both the incident list and incident detail views, without squishing the tag key.

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
@@ -2,10 +2,16 @@
 {% load argus_htmx %}
 <div class="flex gap-1 flex-wrap">
   {% for tag in incident.deprecated_tags %}
-    <span class="badge badge-xs badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
-      {# djlint:off #}
-      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
-      {# djlint:on #}
+    <span class="badge badge-xs badge-neutral-content badge-outline h-auto max-w-96 items-start gap-0.5 px-1.5 py-0.5 text-left text-xs"
+          title="{{ tag.key }}{{ tag.TAG_DELIMITER }}{{ tag.value }}">
+      <span class="shrink-0 whitespace-nowrap">{{ tag.key }}{{ tag.TAG_DELIMITER }}</span>
+      <span class="min-w-0 break-words">
+        {% if tag.value|is_valid_url %}
+          <a href="{{ tag.value }}" target="_blank" rel="noreferrer" class="break-words">{{ tag.value }}</a>
+        {% else %}
+          {{ tag.value }}
+        {% endif %}
+      </span>
     </span>
   {% endfor %}
 </div>

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -33,15 +33,9 @@
           </section>
           <section id="tags" class="card card-base">
             <h2 class="card-title">Tags</h2>
-            <p class="card-body flex-row flex-wrap gap-0.5">
-              {% for tag in incident.deprecated_tags %}
-                <span class="badge badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
-                  {# djlint:off #}
-                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
-                  {# djlint:on #}
-                </span>
-              {% endfor %}
-            </p>
+            <div class="card-body">
+              {% include "htmx/incident/cells/_incident_tags.html" %}
+            </div>
           </section>
           <section id="primary-details" class="card card-base">
             <h2 class="card-title">Primary details (#{{ incident.pk }})</h2>
@@ -189,3 +183,4 @@
     {% endblock incident_detail %}
   </div>
 {% endblock main %}
+

--- a/tests/htmx/incident/test_tag_rendering.py
+++ b/tests/htmx/incident/test_tag_rendering.py
@@ -1,0 +1,35 @@
+from django.template.loader import render_to_string
+from django.test import TestCase
+from django.urls import reverse
+
+from argus.auth.factories import PersonUserFactory
+from argus.incident.factories import create_fake_incident
+
+
+class TestIncidentTagRendering(TestCase):
+    def setUp(self):
+        self.user = PersonUserFactory()
+        self.incident = create_fake_incident(
+            tags=[
+                "host=web02.example.com",
+                "dashboard=https://grafana.example.com/d/abc123/host-overview"
+                "?orgId=1&var-host=web02.example.com&from=now-6h&to=now",
+            ]
+        )
+
+    def test_incident_tags_partial_uses_non_squishing_layout_for_long_values(self):
+        html = render_to_string("htmx/incident/cells/_incident_tags.html", {"incident": self.incident})
+
+        self.assertIn("max-w-96", html)
+        self.assertIn("whitespace-nowrap", html)
+        self.assertIn("break-words", html)
+        self.assertNotIn("break-all", html)
+
+    def test_incident_detail_renders_shared_tags_partial(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("htmx:incident-detail", kwargs={"pk": self.incident.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "max-w-96")
+        self.assertContains(response, "whitespace-nowrap")


### PR DESCRIPTION
## Scope and purpose

Fixes #1986.

This PR fixes poor rendering of incident tags with long values (for example long URLs or long error messages). Previously, the tag badge used aggressive breaking that caused awkward mid-word wrapping and could squeeze the key into a narrow vertical strip while the value wrapped separately.

The change updates tag badge markup/styles so:
- the key stays readable and does not collapse
- long values wrap more naturally
- badge width is constrained to a sensible maximum
- full tag content is still available via hover title text

The same rendering is now reused on both the incident list and incident detail page, so behavior is consistent.

### This pull request
- does not add, change, or remove dependencies
- does not change the database
- does not change the API


## Contributor Checklist

- [x] Added a changelog fragment for towncrier
- [x] Added/amended tests for new/changed code
- [ ] Added/changed documentation, including updates to the user manual if feature flow or UI is considerably changed
- [ ] Linted/formatted the code with ruff and djLint, easiest by using pre-commit
- [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
- [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
- [ ] If this results in changes in the UI: Added screenshots of the before and after
- [ ] If this results in changes to the database model: Updated the ER diagram

Notes:
- No further follow-up issues are required for this specific fix.
- Please attach before/after screenshots when opening the PR.