### PR TITLE
Fix missing link affordance on URL tags and Ticket badge (fixes #1985)

### DIFF
--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_tags.html
@@ -4,7 +4,7 @@
   {% for tag in incident.deprecated_tags %}
     <span class="badge badge-xs badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
       {# djlint:off #}
-      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
+      {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a class="link" href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
       {# djlint:on #}
     </span>
   {% endfor %}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -25,7 +25,7 @@
                 <span class="badge badge-error">Unacknowledged</span>
               {% endif %}
               {% if incident.ticket_url %}
-                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
+                <span class="badge badge-success h-auto text-wrap break-all text-center"><a class="link" href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
               {% else %}
                 <span class="badge badge-error">No ticket</span>
               {% endif %}
@@ -37,7 +37,7 @@
               {% for tag in incident.deprecated_tags %}
                 <span class="badge badge-neutral-content badge-outline  h-auto text-wrap break-all text-center text-xs">
                   {# djlint:off #}
-                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
+                  {{ tag.key }}{{ tag.TAG_DELIMITER }}{% if tag.value|is_valid_url %}<a class="link" href="{{ tag.value }}" target="_blank" rel="noreferrer">{{ tag.value }}</a>{% else %}{{ tag.value }}{% endif %}
                   {# djlint:on #}
                 </span>
               {% endfor %}


### PR DESCRIPTION
## Scope and purpose

Fixes #1985 . 

This PR resolves an issue where URL-valued incident tags (in both the list view and detail view) and the status ticket badge were rendered as plain text. It updates the HTML templates to apply the `link` class to the corresponding anchor (`<a>`) tags, styling them as clickable links.

### This pull request
<!-- No API, database, or dependency changes apply to this PR -->


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
  - *Suggested message: "Style URL-valued incident tags and ticket badge as links"*
* [X] If this results in changes in the UI: Added screenshots of the before and after