### PR TITLE
Rename `teardown` functions in tests to `tearDown`

### DIFF
--- a/tests/auth/test_knox_views.py
+++ b/tests/auth/test_knox_views.py
@@ -13,7 +13,7 @@ class JsonAuthenticationTests(APITestCase):
     def setUp(self):
         disconnect_signals()
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_authenticate_golden_path(self):

--- a/tests/auth/test_views.py
+++ b/tests/auth/test_views.py
@@ -19,7 +19,7 @@ class ViewTests(APITestCase):
         self.user2_rest_client = APIClient()
         self.user2_rest_client.force_authenticate(user=self.user2)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_can_get_specific_user(self):

--- a/tests/filter/test_queryset_filters.py
+++ b/tests/filter/test_queryset_filters.py
@@ -52,7 +52,7 @@ class FilteredIncidentsHelpersTests(TestCase):
         IncidentTagRelationFactory(tag=self.tag3, incident=self.incident2, added_by=self.user1)
         self.all_incidents = Incident.objects.all()
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_incidents_with_source_systems_empty_if_no_incidents_with_these_source_systems(self):
@@ -152,7 +152,7 @@ class FilteredIncidentsTests(TestCase):
         IncidentTagRelationFactory(tag=self.tag2, incident=self.incident2, added_by=self.user1)
         IncidentTagRelationFactory(tag=self.tag3, incident=self.incident2, added_by=self.user1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_filtered_incidents_returns_empty_if_no_incident_fits_filter(self):

--- a/tests/htmx/incident/test_filter.py
+++ b/tests/htmx/incident/test_filter.py
@@ -32,7 +32,7 @@ class TestIncidentFilterForm(TestCase):
         }
         self.valid_form = IncidentFilterForm(self.valid_field_values)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_if_form_is_valid_then_filterblob_should_contain_correct_open_value(self):
@@ -101,7 +101,7 @@ class TestIncidentListFilter(TestCase):
         SessionMiddleware(lambda x: x).process_request(self.request)
         MessageMiddleware(lambda x: x).process_request(self.request)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_nonexistent_filter_should_return_unfiltered_queryset_and_repair_session(self):
@@ -158,7 +158,7 @@ class TestCreateNamedFilter(TestCase):
             "acked": True,
         }
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_if_input_is_valid_it_should_return_a_filter(self):

--- a/tests/htmx/notificationprofile/test_forms.py
+++ b/tests/htmx/notificationprofile/test_forms.py
@@ -24,7 +24,7 @@ class NotificationProfileFormTests(TestCase):
 
         self.filter = FilterFactory(user=self.user)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_form_with_different_name_as_other_profiles_is_valid(self):

--- a/tests/incident/test_change_event.py
+++ b/tests/incident/test_change_event.py
@@ -28,7 +28,7 @@ class ChangeEventTests(APITestCase, IncidentBasedAPITestCaseHelper):
             source=self.source1,
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_change_event_is_created_on_level_changes(self):

--- a/tests/incident/test_views.py
+++ b/tests/incident/test_views.py
@@ -81,7 +81,7 @@ class IncidentAPITestCase(APITestCase):
         self.admin = AdminUserFactory()
         self.client.force_authenticate(user=self.user)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
 
@@ -188,7 +188,7 @@ class IncidentViewSetTestCase(APITestCase):
         self.admin = AdminUserFactory()
         self.client.force_authenticate(user=self.user)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def add_open_incident_with_start_event_and_tag(self, description="incident"):

--- a/tests/notificationprofile/destinations/test_email.py
+++ b/tests/notificationprofile/destinations/test_email.py
@@ -180,7 +180,7 @@ class EmailSignalTests(APITestCase):
         self.user1 = PersonUserFactory()
         self.user2 = PersonUserFactory(email="")
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_default_email_destination_should_be_created_if_user_has_email(self):
@@ -220,7 +220,7 @@ class EmailMediumViewTests(APITestCase):
         self.user1_rest_client = APIClient()
         self.user1_rest_client.force_authenticate(user=user1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_json_schema_for_email(self):
@@ -269,7 +269,7 @@ class EmailDestinationViewTests(APITestCase):
         )
         self.notification_profile1.destinations.set([self.managed_email_destination])
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_delete_unmanaged_unused_email_destination(self):

--- a/tests/notificationprofile/destinations/test_sms.py
+++ b/tests/notificationprofile/destinations/test_sms.py
@@ -178,7 +178,7 @@ class SMSMediumViewTests(APITestCase):
         self.user1_rest_client = APIClient()
         self.user1_rest_client.force_authenticate(user=user1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_json_schema_for_sms(self):
@@ -226,7 +226,7 @@ class SMSDestinationViewTests(APITestCase):
             settings={"phone_number": "+4747474747"},
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_create_sms_destination_with_valid_values(self):

--- a/tests/notificationprofile/test_models.py
+++ b/tests/notificationprofile/test_models.py
@@ -52,7 +52,7 @@ class TimeRecurrenceTests(TestCase, IncidentAPITestCaseHelper):
             end=parse_time("00:30:01"),
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_timestamp_is_within_false_if_before_recurrence(self):
@@ -143,7 +143,7 @@ class TimeslotTests(TestCase, IncidentAPITestCaseHelper):
             end=TimeRecurrence.DAY_END,
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_timestamp_is_within_recurrences_true_if_within_recurrences(self):

--- a/tests/notificationprofile/test_views.py
+++ b/tests/notificationprofile/test_views.py
@@ -56,7 +56,7 @@ class NotificationProfileViewTests(APITestCase):
         self.synced_email_destination = self.user1.destinations.get()
         self.notification_profile1.destinations.set([self.synced_email_destination])
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_list_is_reachable(self):
@@ -244,7 +244,7 @@ class NotificationIncidentViewTests(APITestCase):
         self.notification_profile1 = NotificationProfileFactory(user=user1, timeslot=timeslot1)
         self.notification_profile1.filters.add(filter1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_list_of_all_incidents_matched_by_notification_profile(self):
@@ -292,7 +292,7 @@ class NotificationFilterIncidentViewTests(APITestCase):
         self.notification_profile1 = NotificationProfileFactory(user=user1, timeslot=timeslot1)
         self.notification_profile1.filters.add(filter1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_filterpreview_returns_only_incidents_matching_specified_filter(self):
@@ -343,7 +343,7 @@ class FilterViewTests(APITestCase):
         notification_profile1 = NotificationProfileFactory(user=self.user1, timeslot=timeslot1)
         notification_profile1.filters.add(self.filter1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_list_is_reachable(self):
@@ -446,7 +446,7 @@ class MediumViewTests(APITestCase):
         self.user1_rest_client = APIClient()
         self.user1_rest_client.force_authenticate(user=user1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_all_media(self):
@@ -487,7 +487,7 @@ class DestinationViewTests(APITestCase):
             managed=None,
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_list_of_all_destinations(self):
@@ -555,7 +555,7 @@ class TimeslotViewTests(APITestCase):
         notification_profile1 = NotificationProfileFactory(user=self.user1, timeslot=self.timeslot1)
         notification_profile1.filters.add(filter1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_list_is_reachable(self):

--- a/tests/notificationprofile/v3/test_views.py
+++ b/tests/notificationprofile/v3/test_views.py
@@ -20,7 +20,7 @@ class MediumViewTests(APITestCase):
         self.user1_rest_client = APIClient()
         self.user1_rest_client.force_authenticate(user=user1)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_all_media(self):
@@ -61,7 +61,7 @@ class DestinationViewTests(APITestCase):
             managed=None,
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_should_get_list_of_all_destinations(self):

--- a/tests/plannedmaintenance/test_models.py
+++ b/tests/plannedmaintenance/test_models.py
@@ -19,7 +19,7 @@ class PlannedMaintenanceQuerySetTests(TestCase):
         self.current_pm = PlannedMaintenanceFactory(start_time=now - timedelta(minutes=5))
         self.past_pm = PlannedMaintenanceFactory(start_time=now - timedelta(days=1), end_time=now - timedelta(hours=12))
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_future_returns_only_pms_with_start_time_in_future(self):
@@ -92,7 +92,7 @@ class PlannedMaintenanceTaskTests(TestCase):
             end_time=timezone.now() - MODIFICATION_WINDOW_PM - timedelta(hours=1),
         )
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_given_open_pm_task_modifiable_is_true(self):

--- a/tests/plannedmaintenance/test_utils.py
+++ b/tests/plannedmaintenance/test_utils.py
@@ -23,7 +23,7 @@ class TestIncidentsCoveredByPlannedMaintenanceTask(TestCase):
         self.open_incident = StatefulIncidentFactory(level=5)
         self.maxlevel_filter = FilterFactory(filter={"maxlevel": 5})
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_returns_only_open_incidents(self):
@@ -72,7 +72,7 @@ class TestEventCoveredByPlannedMaintenanceTasks(TestCase):
         self.current_pm = PlannedMaintenanceFactory()
         self.maxlevel_filter = FilterFactory(filter={"maxlevel": self.default_level})
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_given_relevant_event_return_true(self):
@@ -132,7 +132,7 @@ class TestConnectIncidentWithPlannedMaintenanceTasks(TestCase):
         self.not_covering_pm = PlannedMaintenanceFactory()
         self.not_covering_pm.filters.add(self.not_hitting_filter)
 
-    def teardown(self):
+    def tearDown(self):
         connect_signals()
 
     def test_given_incident_with_fitting_pms_connects_them(self):


### PR DESCRIPTION
## Scope and purpose

As observed in #1930. Ref: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.SimpleTestCase.databases

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
