### PR TITLE
Ensure Apprise is installed when Apprise-derived media are activated

### DIFF
--- a/changelog.d/1965.fixed.md
+++ b/changelog.d/1965.fixed.md
@@ -1,0 +1,1 @@
+Added check on startup for if an Apprise-derived medium is activated without the Apprise package itself being installed.

--- a/src/argus/notificationprofile/signals.py
+++ b/src/argus/notificationprofile/signals.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import ProgrammingError
 
 from argus.notificationprofile.media import EMAIL_DESTINATION_SLUG, send_notifications_to_users
@@ -34,6 +35,16 @@ def sync_media(sender, **kwargs):
     Check if all media in Media has a respective class"""
 
     from .media import MEDIA_CLASSES_DICT
+    from .media.base import Apprise, AppriseMedium
+
+    if Apprise is None:
+        missing = sorted(cls.__name__ for cls in MEDIA_CLASSES_DICT.values() if issubclass(cls, AppriseMedium))
+        if missing:
+            raise ImproperlyConfigured(
+                "MEDIA_PLUGINS lists media that require the 'apprise' package, which is not installed: "
+                f'{", ".join(missing)}. Install the "apprise" extra (`pip install argus-server[apprise]`) '
+                "or remove these media from MEDIA_PLUGINS."
+            )
 
     apps = kwargs["apps"]
     try:

--- a/src/argus/site/settings/dev.py
+++ b/src/argus/site/settings/dev.py
@@ -23,6 +23,15 @@ INTERNAL_IPS = ["127.0.0.1"]
 
 INSTALLED_APPS += ["django_extensions"]  # noqa: F405
 
+# Mock to bypass Apprise check for development.
+try:
+    import apprise  # noqa: F401
+except ImportError:
+    import sys
+    from unittest.mock import MagicMock
+
+    sys.modules["apprise"] = MagicMock()
+
 # Paths to plugins
 MEDIA_PLUGINS = [
     "argus.notificationprofile.media.email.EmailNotification",

--- a/src/argus/site/settings/test_CI.py
+++ b/src/argus/site/settings/test_CI.py
@@ -34,6 +34,16 @@ except ValueError:
     pass
 MIDDLEWARE = middleware
 
+# Hack to bypass Apprise check for running tests.
+# Remove as soon as the real Apprise library is included in the test environment.
+try:
+    import apprise  # noqa: F401
+except ImportError:
+    import sys
+    from unittest.mock import MagicMock
+
+    sys.modules["apprise"] = MagicMock()
+
 # Paths to plugins
 MEDIA_PLUGINS = [
     "argus.notificationprofile.media.email.EmailNotification",

--- a/tests/notificationprofile/test_signals.py
+++ b/tests/notificationprofile/test_signals.py
@@ -1,8 +1,38 @@
 from unittest.mock import Mock, patch
 
-from django.test import SimpleTestCase, tag
+from django.apps import apps
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase, TestCase, tag
 
-from argus.notificationprofile.signals import task_background_send_notification
+from argus.notificationprofile.media.base import AppriseMedium
+from argus.notificationprofile.media.email import EmailNotification
+from argus.notificationprofile.media.slack import SlackNotification
+from argus.notificationprofile.signals import sync_media, task_background_send_notification
+
+
+@tag("integration", "signal")
+class SyncMediaAppriseAvailabilityTests(TestCase):
+    @patch("argus.notificationprofile.media.base.Apprise", object())
+    def test_when_apprise_is_available_should_not_raise(self):
+        sync_media(None, apps=apps)
+
+    @patch("argus.notificationprofile.media.base.Apprise", None)
+    @patch("argus.notificationprofile.media.MEDIA_CLASSES_DICT", {"email": EmailNotification})
+    def test_when_apprise_is_missing_and_no_apprise_derived_medium_is_configured_should_not_raise(self):
+        sync_media(None, apps=apps)
+
+    @patch("argus.notificationprofile.media.base.Apprise", None)
+    @patch(
+        "argus.notificationprofile.media.MEDIA_CLASSES_DICT",
+        {"slack": SlackNotification, "apprise": AppriseMedium, "email": EmailNotification},
+    )
+    def test_when_apprise_is_missing_should_raise_with_only_apprise_derived_medium(self):
+        with self.assertRaises(ImproperlyConfigured) as cm:
+            sync_media(None)
+
+        self.assertIn("SlackNotification", str(cm.exception))
+        self.assertIn("AppriseMedium, SlackNotification", str(cm.exception))
+        self.assertNotIn("EmailNotification", str(cm.exception))
 
 
 @tag("unit", "signal")


### PR DESCRIPTION
## Scope and purpose

Fixes #1965.


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
