### PR TITLE
Improve handling of uninstalled media in frontend

### DIFF
--- a/changelog.d/1453.added.md
+++ b/changelog.d/1453.added.md
@@ -1,0 +1,1 @@
+Added warnings to be shown for destinations and notification profiles where the medium is not installed

--- a/src/argus/htmx/destination/forms.py
+++ b/src/argus/htmx/destination/forms.py
@@ -13,6 +13,7 @@ class DestinationFormCreate(ModelForm):
         # Serializer request the request object
         self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
+        self.fields["media"].queryset = Media.objects.filter(installed=True)
 
     class Meta:
         model = DestinationConfig
@@ -80,11 +81,16 @@ class DestinationFormCreate(ModelForm):
 
 class DestinationFormUpdate(DestinationFormCreate):
     def __init__(self, *args, **kwargs):
-        if instance := kwargs.get("instance"):
+        instance = kwargs.get("instance")
+        if instance:
             settings_key = _get_settings_key_for_media(instance.media)
             # Extract settings value (email address etc.) from JSONField
             instance.settings = instance.settings.get(settings_key)
         super().__init__(*args, **kwargs)
+        if instance and not instance.media.installed:
+            # Disable editing when there is no plugin to validate against
+            self.fields["label"].disabled = True
+            self.fields["settings"].disabled = True
 
     class Meta:
         model = DestinationConfig
@@ -120,9 +126,14 @@ class DestinationFormUpdate(DestinationFormCreate):
         )
 
 
-def _get_settings_key_for_media(media: Media) -> str:
+def _get_settings_key_for_media(media: Media) -> str | None:
     """Returns the required settings key for the given media,
     e.g. "email_address", "phone_number"
+
+    Returns None if the medium is not installed, since there is then no
+    plugin to ask for the schema.
     """
+    if not media.installed:
+        return None
     medium = api_safely_get_medium_object(media.slug)
     return medium.MEDIA_JSON_SCHEMA["required"][0]

--- a/src/argus/htmx/destination/forms.py
+++ b/src/argus/htmx/destination/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms import ModelForm
 
-from argus.notificationprofile.media import safely_get_medium_object
+from argus.notificationprofile.media import MEDIA_CLASSES_DICT, safely_get_medium_object
 from argus.notificationprofile.models import DestinationConfig, Media
 from argus.notificationprofile.v2.serializers import RequestDestinationConfigSerializer
 
@@ -13,6 +13,8 @@ class DestinationFormCreate(ModelForm):
         # Serializer request the request object
         self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
+        # Ensure media without plugins aren't shown
+        self.fields["media"].queryset = Media.objects.filter(installed=True, slug__in=MEDIA_CLASSES_DICT.keys())
 
     class Meta:
         model = DestinationConfig
@@ -80,11 +82,16 @@ class DestinationFormCreate(ModelForm):
 
 class DestinationFormUpdate(DestinationFormCreate):
     def __init__(self, *args, **kwargs):
-        if instance := kwargs.get("instance"):
+        instance = kwargs.get("instance")
+        if instance:
             settings_key = _get_settings_key_for_media(instance.media)
             # Extract settings value (email address etc.) from JSONField
             instance.settings = instance.settings.get(settings_key)
         super().__init__(*args, **kwargs)
+        if instance and not instance.media.installed:
+            # Disable editing when there is no plugin to validate against
+            self.fields["label"].disabled = True
+            self.fields["settings"].disabled = True
 
     class Meta:
         model = DestinationConfig
@@ -120,9 +127,14 @@ class DestinationFormUpdate(DestinationFormCreate):
         )
 
 
-def _get_settings_key_for_media(media: Media) -> str:
+def _get_settings_key_for_media(media: Media) -> str | None:
     """Returns the required settings key for the given media,
     e.g. "email_address", "phone_number"
+
+    Returns None if the medium is not installed, since there is then no
+    plugin to ask for the schema.
     """
+    if not media.installed:
+        return None
     medium = safely_get_medium_object(media.slug)
     return medium.MEDIA_JSON_SCHEMA["required"][0]

--- a/src/argus/htmx/destination/views.py
+++ b/src/argus/htmx/destination/views.py
@@ -23,8 +23,8 @@ def _attach_delete_state(form, make_modal):
     to a plain string, so we fetch a fresh copy from DB for the deletability check.
     """
     destination = DestinationConfig.objects.get(pk=form.instance.pk)
+    medium = safely_get_medium_object(destination.media.slug, strict=False)
     try:
-        medium = safely_get_medium_object(destination.media.slug)
         medium.raise_if_not_deletable(destination)
     except NotificationMedium.NotDeletableError as e:
         form.delete_disabled = True
@@ -166,8 +166,8 @@ class DestinationUpdateView(DestinationMixin, UpdateView):
 class DestinationDeleteView(DestinationMixin, DeleteView):
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
+        medium = safely_get_medium_object(self.object.media.slug, strict=False)
         try:
-            medium = safely_get_medium_object(self.object.media.slug)
             medium.raise_if_not_deletable(self.object)
         except NotificationMedium.NotDeletableError as e:
             update_forms = _get_update_forms(request.user)

--- a/src/argus/htmx/destination/views.py
+++ b/src/argus/htmx/destination/views.py
@@ -23,8 +23,11 @@ def _attach_delete_state(form, make_modal):
     to a plain string, so we fetch a fresh copy from DB for the deletability check.
     """
     destination = DestinationConfig.objects.get(pk=form.instance.pk)
+    # raise_if_not_deletable is a generic check on the base class (managed status,
+    # profiles in use) that every medium inherits unchanged, so it doesn't need a
+    # real plugin object even when the medium itself isn't installed.
+    medium = api_safely_get_medium_object(destination.media.slug) if destination.media.installed else NotificationMedium
     try:
-        medium = api_safely_get_medium_object(destination.media.slug)
         medium.raise_if_not_deletable(destination)
     except NotificationMedium.NotDeletableError as e:
         form.delete_disabled = True
@@ -166,8 +169,10 @@ class DestinationUpdateView(DestinationMixin, UpdateView):
 class DestinationDeleteView(DestinationMixin, DeleteView):
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
+        medium = (
+            api_safely_get_medium_object(self.object.media.slug) if self.object.media.installed else NotificationMedium
+        )
         try:
-            medium = api_safely_get_medium_object(self.object.media.slug)
             medium.raise_if_not_deletable(self.object)
         except NotificationMedium.NotDeletableError as e:
             update_forms = _get_update_forms(request.user)

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -28,9 +28,13 @@ class NoColonMixin:
 class DestinationFieldMixin:
     def _get_destination_choices(self, user):
         choices = []
-        for dc in DestinationConfig.objects.filter(user=user).order_by("media", "pk"):
-            MediaPlugin = MEDIA_CLASSES_DICT[dc.media.slug]
-            label = dc.label if dc.label else MediaPlugin.get_label(dc)
+        for dc in DestinationConfig.objects.filter(user=user).select_related("media").order_by("media", "pk"):
+            if not dc.media.installed:
+                label = "Medium not installed"
+            elif dc.label:
+                label = dc.label
+            else:
+                label = MEDIA_CLASSES_DICT[dc.media.slug].get_label(dc)
             choices.append((dc.id, f"{dc.media.name}: {label}"))
         return choices
 

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -30,7 +30,7 @@ class DestinationFieldMixin:
         choices = []
         for dc in DestinationConfig.objects.filter(user=user).select_related("media"):
             if not dc.media.installed:
-                label = "medium not installed"
+                label = "Medium not installed"
             else:
                 label = MEDIA_CLASSES_DICT[dc.media.slug].get_label(dc)
             choices.append((dc.id, f"{dc.media.name}: {label}"))

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -28,9 +28,11 @@ class NoColonMixin:
 class DestinationFieldMixin:
     def _get_destination_choices(self, user):
         choices = []
-        for dc in DestinationConfig.objects.filter(user=user):
-            MediaPlugin = MEDIA_CLASSES_DICT[dc.media.slug]
-            label = MediaPlugin.get_label(dc)
+        for dc in DestinationConfig.objects.filter(user=user).select_related("media"):
+            if not dc.media.installed:
+                label = "medium not installed"
+            else:
+                label = MEDIA_CLASSES_DICT[dc.media.slug].get_label(dc)
             choices.append((dc.id, f"{dc.media.name}: {label}"))
         return choices
 

--- a/src/argus/htmx/templates/htmx/destination/_destination_table.html
+++ b/src/argus/htmx/templates/htmx/destination/_destination_table.html
@@ -36,10 +36,18 @@
           <tr id="destination-create"></tr>
           {% for form in update_forms %}
             <tr class="align-top">
-              <td>
+              <td class="whitespace-nowrap">
                 {% csrf_token %}
                 {% for hidden_field in form.hidden_fields %}{{ hidden_field }}{% endfor %}
-                <span class="badge badge-outline mt-1.5">{{ form.instance.media.name }}</span>
+                <span class="inline-flex items-center gap-1 mt-1.5">
+                  <span class="badge badge-outline">{{ form.instance.media.name }}</span>
+                  {% if not form.instance.media.installed %}
+                    <span class="text-warning text-lg w-5"
+                          title="This medium is not installed. No notifications will be sent to this destination.">
+                      <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                    </span>
+                  {% endif %}
+                </span>
               </td>
               <td>
                 {% render_field form.label class+="input input-bordered input-sm w-full" %}
@@ -51,12 +59,14 @@
               </td>
               <td>
                 <div class="flex gap-1 items-center">
-                  <button type="button"
-                          hx-post="{% url 'htmx:destination-update' pk=form.instance.pk %}"
-                          hx-include="closest tr"
-                          hx-target="#destination-table"
-                          hx-swap="outerHTML"
-                          class="btn btn-primary btn-sm">Save</button>
+                  {% if form.instance.media.installed %}
+                    <button type="button"
+                            hx-post="{% url 'htmx:destination-update' pk=form.instance.pk %}"
+                            hx-include="closest tr"
+                            hx-target="#destination-table"
+                            hx-swap="outerHTML"
+                            class="btn btn-primary btn-sm">Save</button>
+                  {% endif %}
                   {% if form.delete_disabled %}
                     <span class="tooltip tooltip-left tooltip-warning cursor-not-allowed"
                           data-tip="{{ form.delete_tooltip }}">

--- a/src/argus/htmx/templates/htmx/destination/_destination_table.html
+++ b/src/argus/htmx/templates/htmx/destination/_destination_table.html
@@ -36,10 +36,18 @@
           <tr id="destination-create"></tr>
           {% for form in update_forms %}
             <tr class="align-top">
-              <td>
+              <td class="whitespace-nowrap">
                 {% csrf_token %}
                 {% for hidden_field in form.hidden_fields %}{{ hidden_field }}{% endfor %}
-                <span class="badge badge-outline mt-1.5">{{ form.instance.media.name }}</span>
+                <span class="inline-flex items-center gap-1 mt-1.5">
+                  <span class="badge badge-outline">{{ form.instance.media.name }}</span>
+                  {% if not form.instance.media.installed %}
+                    <span class="text-warning text-lg tooltip tooltip-right w-5 before:bg-base-200 before:text-base-content after:bg-base-200"
+                          data-tip="This medium is not installed. No notifications will be sent to this destination.">
+                      <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                    </span>
+                  {% endif %}
+                </span>
               </td>
               <td>
                 {% render_field form.label class+="input input-bordered input-sm w-full" %}
@@ -51,12 +59,14 @@
               </td>
               <td>
                 <div class="flex gap-1 items-center">
-                  <button type="button"
-                          hx-post="{% url 'htmx:destination-update' pk=form.instance.pk %}"
-                          hx-include="closest tr"
-                          hx-target="#destination-table"
-                          hx-swap="outerHTML"
-                          class="btn btn-primary btn-sm">Save</button>
+                  {% if form.instance.media.installed %}
+                    <button type="button"
+                            hx-post="{% url 'htmx:destination-update' pk=form.instance.pk %}"
+                            hx-include="closest tr"
+                            hx-target="#destination-table"
+                            hx-swap="outerHTML"
+                            class="btn btn-primary btn-sm">Save</button>
+                  {% endif %}
                   {% if form.delete_disabled %}
                     <span class="tooltip tooltip-left tooltip-warning cursor-not-allowed"
                           data-tip="{{ form.delete_tooltip }}">

--- a/src/argus/htmx/templates/htmx/destination/_destination_table.html
+++ b/src/argus/htmx/templates/htmx/destination/_destination_table.html
@@ -42,8 +42,8 @@
                 <span class="inline-flex items-center gap-1 mt-1.5">
                   <span class="badge badge-outline">{{ form.instance.media.name }}</span>
                   {% if not form.instance.media.installed %}
-                    <span class="text-warning text-lg tooltip tooltip-right w-5 before:bg-base-200 before:text-base-content after:bg-base-200"
-                          data-tip="This medium is not installed. No notifications will be sent to this destination.">
+                    <span class="text-warning text-lg w-5"
+                          title="This medium is not installed. No notifications will be sent to this destination.">
                       <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
                     </span>
                   {% endif %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
@@ -34,7 +34,17 @@
       {% if destinations %}
         <span class="border-l border-base-content/20 pl-3 flex items-center gap-1 flex-wrap">
           <i class="fa-regular fa-bell text-xs" aria-hidden="true"></i>
-          {% for dest in destinations %}<span class="badge badge-sm badge-outline">{{ dest }}</span>{% endfor %}
+          {% for dest in destinations %}
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="badge badge-sm badge-outline">{{ dest }}</span>
+              {% if not dest.media.installed %}
+                <span class="text-warning text-lg tooltip tooltip-right w-5 before:bg-base-200 before:text-base-content after:bg-base-200"
+                      data-tip="This destination's medium is not installed. No notifications will be sent to it.">
+                  <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                </span>
+              {% endif %}
+            </span>
+          {% endfor %}
         </span>
       {% endif %}
     {% endwith %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
@@ -34,7 +34,17 @@
       {% if destinations %}
         <span class="border-l border-base-content/20 pl-3 flex items-center gap-1 flex-wrap">
           <i class="fa-regular fa-bell text-xs" aria-hidden="true"></i>
-          {% for dest in destinations %}<span class="badge badge-sm badge-outline">{{ dest }}</span>{% endfor %}
+          {% for dest in destinations %}
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="badge badge-sm badge-outline">{{ dest }}</span>
+              {% if not dest.media.installed %}
+                <span class="text-warning text-lg w-5"
+                      title="This destination's medium is not installed. No notifications will be sent to it.">
+                  <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                </span>
+              {% endif %}
+            </span>
+          {% endfor %}
         </span>
       {% endif %}
     {% endwith %}

--- a/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
+++ b/src/argus/htmx/templates/htmx/notificationprofile/_notificationprofile_summary.html
@@ -38,8 +38,8 @@
             <span class="inline-flex items-center gap-1 whitespace-nowrap">
               <span class="badge badge-sm badge-outline">{{ dest }}</span>
               {% if not dest.media.installed %}
-                <span class="text-warning text-lg tooltip tooltip-right w-5 before:bg-base-200 before:text-base-content after:bg-base-200"
-                      data-tip="This destination's medium is not installed. No notifications will be sent to it.">
+                <span class="text-warning text-lg w-5"
+                      title="This destination's medium is not installed. No notifications will be sent to it.">
                   <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
                 </span>
               {% endif %}

--- a/src/argus/notificationprofile/factories.py
+++ b/src/argus/notificationprofile/factories.py
@@ -11,6 +11,7 @@ __all__ = [
     "TimeRecurrenceFactory",
     "MinimalTimeRecurrenceFactory",
     "MaximalTimeRecurrenceFactory",
+    "MediaFactory",
     "DestinationConfigFactory",
     "NotificationProfileFactory",
 ]

--- a/src/argus/notificationprofile/media/__init__.py
+++ b/src/argus/notificationprofile/media/__init__.py
@@ -14,6 +14,7 @@ from argus.util.utils import import_class_from_dotted_path
 from ..models import DestinationConfig, Media, NotificationProfile
 from ..filterwrapper import NotificationProfileFilterWrapper
 from ..utils import are_notifications_enabled
+from .base import NotificationMedium
 
 filter_backend = get_filter_backend()
 FallbackFilterWrapper = filter_backend.FallbackFilterWrapper
@@ -47,10 +48,13 @@ _media_classes = [import_class_from_dotted_path(media_plugin) for media_plugin i
 MEDIA_CLASSES_DICT = {media_class.MEDIA_SLUG: media_class for media_class in _media_classes}
 
 
-def safely_get_medium_object(media_slug):
+def safely_get_medium_object(media_slug, strict: bool = True):
+    "Returns the medium object for the given slug, or a base medium if strict=False and it's not installed"
     try:
         classobj = MEDIA_CLASSES_DICT[media_slug]
     except KeyError:
+        if not strict:
+            return NotificationMedium
         raise ValidationError(f'Medium "{media_slug}" is not installed.')
     obj = classobj()
     return obj

--- a/tests/htmx/destination/test_forms.py
+++ b/tests/htmx/destination/test_forms.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from argus.htmx.destination.forms import DestinationFormCreate, DestinationFormUpdate
+from argus.notificationprofile.factories import DestinationConfigFactory, MediaFactory
+
+
+class TestDestinationForm(TestCase):
+    def test_given_medium_with_no_plugin_it_should_not_be_a_valid_choice(self):
+        fake_media = MediaFactory()
+        form = DestinationFormCreate()
+
+        self.assertNotIn(fake_media, form.fields["media"].queryset)
+
+    def test_given_uninstalled_medium_it_should_disable_editing(self):
+        uninstalled_media = MediaFactory(installed=False)
+        destination = DestinationConfigFactory(media=uninstalled_media, settings={"test_key": "test_val"})
+
+        form = DestinationFormUpdate(instance=destination)
+
+        self.assertTrue(form.fields["label"].disabled)
+        self.assertTrue(form.fields["settings"].disabled)

--- a/tests/htmx/destination/test_forms.py
+++ b/tests/htmx/destination/test_forms.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from argus.htmx.destination.forms import DestinationFormUpdate
+from argus.notificationprofile.factories import DestinationConfigFactory, MediaFactory
+
+
+class TestDestinationFormUpdate(TestCase):
+    def test_given_uninstalled_medium_it_should_disable_editing(self):
+        uninstalled_media = MediaFactory(installed=False)
+        destination = DestinationConfigFactory(media=uninstalled_media, settings={"test_key": "test_val"})
+
+        form = DestinationFormUpdate(instance=destination)
+
+        self.assertTrue(form.fields["label"].disabled)
+        self.assertTrue(form.fields["settings"].disabled)

--- a/tests/htmx/destination/test_views.py
+++ b/tests/htmx/destination/test_views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from argus.auth.factories import PersonUserFactory
 from argus.notificationprofile.factories import (
     DestinationConfigFactory,
+    MediaFactory,
     NotificationProfileFactory,
     TimeslotFactory,
 )
@@ -97,6 +98,19 @@ class TestDestinationListView(DestinationViewTestCase):
         form = self._get_form_for(response, destination)
         self.assertTrue(form.delete_disabled)
         self.assertIn("defined by an outside source", form.delete_tooltip)
+
+    def test_given_uninstalled_medium_it_should_still_have_delete_enabled(self):
+        uninstalled_media = MediaFactory(installed=False)
+        destination = DestinationConfigFactory(
+            user=self.user,
+            media=uninstalled_media,
+            settings={"test_key": "test_val"},
+        )
+
+        response = self.client.get(self.url)
+
+        form = self._get_form_for(response, destination)
+        self.assertFalse(form.delete_disabled)
 
     def test_it_should_only_show_own_destinations(self):
         other_user = PersonUserFactory()
@@ -271,3 +285,17 @@ class TestDestinationDeleteView(DestinationViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("error_msg", response.context)
         self.assertTrue(DestinationConfig.objects.filter(pk=self.destination.pk).exists())
+
+    def test_given_uninstalled_medium_it_should_still_be_deletable(self):
+        uninstalled_media = MediaFactory(installed=False)
+        destination = DestinationConfigFactory(
+            user=self.user,
+            media=uninstalled_media,
+            settings={"test_key": "test_val"},
+        )
+        url = reverse("htmx:destination-delete", kwargs={"pk": destination.pk})
+
+        response = self.client.post(url)
+
+        self.assertRedirects(response, reverse("htmx:destination-list"), fetch_redirect_response=False)
+        self.assertFalse(DestinationConfig.objects.filter(pk=destination.pk).exists())

--- a/tests/htmx/notificationprofile/test_forms.py
+++ b/tests/htmx/notificationprofile/test_forms.py
@@ -3,7 +3,12 @@ from django.test import tag, TestCase
 from argus.auth.factories import PersonUserFactory
 from argus.filter.factories import FilterFactory
 from argus.htmx.notificationprofile.views import NotificationProfileForm
-from argus.notificationprofile.factories import NotificationProfileFactory, TimeslotFactory
+from argus.notificationprofile.factories import (
+    DestinationConfigFactory,
+    MediaFactory,
+    NotificationProfileFactory,
+    TimeslotFactory,
+)
 from argus.util.testing import connect_signals, disconnect_signals
 
 
@@ -98,3 +103,14 @@ class NotificationProfileFormTests(TestCase):
         )
 
         self.assertTrue(form.is_valid())
+
+    def test_given_destination_with_uninstalled_medium_it_should_flag_choice_instead_of_crashing(self):
+        uninstalled_media = MediaFactory(installed=False)
+        destination = DestinationConfigFactory(
+            user=self.user, media=uninstalled_media, settings={"test_key": "test_val"}
+        )
+
+        form = NotificationProfileForm(user=self.user)
+
+        choice_labels = dict(form.fields["destinations"].choices)
+        self.assertIn("not installed", choice_labels[destination.id])

--- a/tests/htmx/notificationprofile/test_views.py
+++ b/tests/htmx/notificationprofile/test_views.py
@@ -3,10 +3,13 @@ from django.urls import reverse
 
 from argus.auth.factories import PersonUserFactory
 from argus.notificationprofile.factories import (
+    DestinationConfigFactory,
+    MediaFactory,
     NotificationProfileFactory,
     TimeslotFactory,
 )
 from argus.filter.factories import FilterFactory
+from argus.notificationprofile.models import Media
 
 
 @override_settings(AUTHENTICATION_BACKENDS=["django.contrib.auth.backends.ModelBackend"])
@@ -41,6 +44,33 @@ class TestNotificationProfileListView(NotificationProfileViewTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["object_list"]), 1)
+
+    def test_when_profile_has_destination_with_uninstalled_medium_it_should_show_warning(self):
+        timeslot = TimeslotFactory(user=self.user)
+        profile = NotificationProfileFactory(user=self.user, timeslot=timeslot)
+        uninstalled_media = MediaFactory(installed=False)
+        destination = DestinationConfigFactory(
+            user=self.user, media=uninstalled_media, settings={"test_key": "test_val"}
+        )
+        profile.destinations.add(destination)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "not installed")
+
+    def test_when_profile_has_only_installed_media_destinations_it_should_not_show_warning(self):
+        timeslot = TimeslotFactory(user=self.user)
+        profile = NotificationProfileFactory(user=self.user, timeslot=timeslot)
+        destination = DestinationConfigFactory(
+            user=self.user, media=Media.objects.get(slug="email"), settings={"email_address": "test@test.com"}
+        )
+        profile.destinations.add(destination)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "not installed")
 
 
 class TestNotificationProfileDetailView(NotificationProfileViewTestCase):

--- a/tests/notificationprofile/test_media.py
+++ b/tests/notificationprofile/test_media.py
@@ -1,15 +1,18 @@
 import logging
 
 from django.test import TestCase, override_settings
+from rest_framework.exceptions import ValidationError
 
 from argus.auth.factories import PersonUserFactory
 from argus.filter.factories import FilterFactory
 from argus.incident.factories import EventFactory, create_fake_incident
 from argus.incident.models import get_or_create_default_instances, Event
 from argus.notificationprofile import factories
+from argus.notificationprofile.media import safely_get_medium_object
 from argus.notificationprofile.media import find_destinations_for_event
 from argus.notificationprofile.media import find_destinations_for_many_events
 from argus.notificationprofile.media import get_notification_media
+from argus.notificationprofile.media.base import NotificationMedium
 from argus.notificationprofile.media.email import modelinstance_to_dict
 from argus.notificationprofile.models import Media
 from argus.util.testing import disconnect_signals, connect_signals
@@ -209,3 +212,19 @@ class GetNotificationMediaTests(TestCase):
 
         self.not_installed_medium.refresh_from_db()
         self.assertTrue(self.not_installed_medium.installed)
+
+
+class ApiSafelyGetMediumObjectTests(TestCase):
+    def test_given_installed_medium_it_should_return_the_medium_object(self):
+        medium = safely_get_medium_object("email")
+
+        self.assertNotEqual(medium, NotificationMedium)
+
+    def test_given_unknown_slug_and_strict_it_should_raise_validation_error(self):
+        with self.assertRaises(ValidationError):
+            safely_get_medium_object("missing")
+
+    def test_given_unknown_slug_and_not_strict_it_should_return_base_medium(self):
+        medium = safely_get_medium_object("missing", strict=False)
+
+        self.assertEqual(medium, NotificationMedium)


### PR DESCRIPTION
## Scope and purpose

Fixes #1453.

In addition to adding the warning described in the issue, also disables editing of uninstalled destinations.

Before:
<img width="1919" height="667" alt="image" src="https://github.com/user-attachments/assets/305e0899-4d88-4080-be43-c9c2d0a6b973" />

Destination menu raises an error when a destination is uninstalled, otherwise it looks like this:
<img width="1919" height="667" alt="image" src="https://github.com/user-attachments/assets/452c80b6-959a-4ede-8a84-6ec2f86608df" />


After:

[Screencast from 2026-07-30 12-28-35.webm](https://github.com/user-attachments/assets/46d61ca5-5baa-4589-bd8c-19ae7da014bf)



## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If this results in changes in the UI: Added screenshots of the before and after

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
