### PR TITLE
Sort destination dropdown in profile page

### DIFF
--- a/changelog.d/2017.fixed.md
+++ b/changelog.d/2017.fixed.md
@@ -1,0 +1,1 @@
+Sorted the destination dropdown by media when adding/updating a notification profile

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -28,7 +28,7 @@ class NoColonMixin:
 class DestinationFieldMixin:
     def _get_destination_choices(self, user):
         choices = []
-        for dc in DestinationConfig.objects.filter(user=user):
+        for dc in DestinationConfig.objects.filter(user=user).order_by("media", "pk"):
             MediaPlugin = MEDIA_CLASSES_DICT[dc.media.slug]
             label = MediaPlugin.get_label(dc)
             choices.append((dc.id, f"{dc.media.name}: {label}"))


### PR DESCRIPTION
## Scope and purpose

This is when adding/updating destinations of a notification profile. 

Go to `/notifications/` and click on `New Profile` and click to add a destination, see that the dropdown is now sorted by media. 

## Screenshots
### Before
<img width="1232" height="734" alt="Screenshot from 2026-08-03 12-02-51" src="https://github.com/user-attachments/assets/f56d39ad-6fc2-4119-8975-a05ddc6a5c13" />

### After
<img width="1232" height="734" alt="image" src="https://github.com/user-attachments/assets/507916ff-ffc1-4330-aaba-5adb982832fa" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
