### PR TITLE
Use destination label in profile dropdown

### DIFF
--- a/changelog.d/2018.fixed.md
+++ b/changelog.d/2018.fixed.md
@@ -1,0 +1,1 @@
+Show the destination label set by the user in the dropdown when adding/updating a notification profile

--- a/src/argus/htmx/notificationprofile/views.py
+++ b/src/argus/htmx/notificationprofile/views.py
@@ -30,7 +30,7 @@ class DestinationFieldMixin:
         choices = []
         for dc in DestinationConfig.objects.filter(user=user).order_by("media", "pk"):
             MediaPlugin = MEDIA_CLASSES_DICT[dc.media.slug]
-            label = MediaPlugin.get_label(dc)
+            label = dc.label if dc.label else MediaPlugin.get_label(dc)
             choices.append((dc.id, f"{dc.media.name}: {label}"))
         return choices
 


### PR DESCRIPTION
## Scope and purpose

I noticed when working on #2015 that in the destination dropdown when adding/updating a notification profile it will always show the label that is generated with `Medium.get_label` and not the label that a user set. This will change it so that this label is used if it is set. 

## Screenshots
### Before
<img width="1232" height="726" alt="image" src="https://github.com/user-attachments/assets/8259e728-c4ab-4052-a07f-278f2d96e8a0" />

### After
<img width="1232" height="726" alt="image" src="https://github.com/user-attachments/assets/f81bf2bf-2c15-4489-b2ec-ff328f57a838" />


## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [X] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
