### PR TITLE
Move `has_duplicate` functionality to Media base class

### DIFF
--- a/docs/integrations/notifications/writing-notification-plugins.rst
+++ b/docs/integrations/notifications/writing-notification-plugins.rst
@@ -95,9 +95,12 @@ get_label
    If the label would be very long, for instance if the needed setting is a
    very long url (40+ characters), you should write your own ``get_label``.
 
-The method ``has_duplicate`` will receive a QuerySet of destinations and a dict
-of settings for a possible destination and should return True if a destination
-with such settings exists in the given QuerySet.
+has_duplicate
+   The method ``has_duplicate`` will receive a QuerySet of destinations and
+   a dict of settings for a possible destination and should return True if
+   a destination with such settings exists in the given QuerySet. By default it
+   will use ``MEDIA_SETTINGS_KEY`` to lookup the most important piece of
+   information in the settings.
 
 ``raise_if_not_deletable`` should check if a given destination can be deleted.
 This is used in case some destinations are managed by an outside source and

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -82,13 +82,14 @@ class NotificationMedium(ABC):
         pass
 
     @classmethod
-    @abstractmethod
     def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
         """
         Returns True if a destination with the given settings already exists
         in the given queryset
         """
-        pass
+        key = f"settings__{cls.MEDIA_SETTINGS_KEY}"
+        value = settings[cls.MEDIA_SETTINGS_KEY]
+        return queryset.filter(media_id=cls.MEDIA_SLUG, **{key: value}).exists()
 
     @classmethod
     def get_label(cls, destination: DestinationConfig) -> str:
@@ -240,14 +241,6 @@ class AppriseMedium(NotificationMedium):
             raise ValidationError({"destination_url": "Webhook already exists"})
 
         return form.cleaned_data
-
-    @classmethod
-    def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
-        """
-        Returns True if an Apprise destination with the same destination url
-        already exists in the given queryset
-        """
-        return queryset.filter(settings__destination_url=settings["destination_url"]).exists()
 
     @classmethod
     def get_relevant_address(cls, destination: DestinationConfig) -> Any:

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from django.contrib.auth import get_user_model
-    from django.db.models.query import QuerySet
 
     from ..serializers import RequestDestinationConfigSerializer
 
@@ -99,14 +98,6 @@ class EmailNotification(NotificationMedium):
             raise ValidationError({"email_address": "Email address already exists"})
 
         return form.cleaned_data
-
-    @classmethod
-    def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
-        """
-        Returns True if an email destination with the same email address
-        already exists in the given queryset
-        """
-        return queryset.filter(settings__email_address=settings["email_address"]).exists()
 
     @classmethod
     def get_relevant_address(cls, destination: DestinationConfig) -> Any:

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from django.contrib.auth import get_user_model
-    from django.db.models.query import QuerySet
 
     from ..models import DestinationConfig
     from ..serializers import RequestDestinationConfigSerializer
@@ -73,14 +72,6 @@ class SMSNotification(NotificationMedium):
             raise ValidationError({"phone_number": "Phone number already exists"})
 
         return form.cleaned_data
-
-    @classmethod
-    def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
-        """
-        Returns True if a sms destination with the same phone number
-        already exists in the given queryset
-        """
-        return queryset.filter(settings__phone_number=settings["phone_number"]).exists()
 
     @classmethod
     def get_relevant_address(cls, destination: DestinationConfig) -> Any:


### PR DESCRIPTION
## Scope and purpose

Very similar to #2015. Basically copied from #936. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
