### PR TITLE
Move `get_relevant_address` functionality to MediaPlugin base class

### DIFF
--- a/docs/integrations/notifications/writing-notification-plugins.rst
+++ b/docs/integrations/notifications/writing-notification-plugins.rst
@@ -102,6 +102,11 @@ has_duplicate
    will use ``MEDIA_SETTINGS_KEY`` to lookup the most important piece of
    information in the settings.
 
+get_relevant_address
+   Used by ``send``. You should only need to override this if the key in
+   MEDIA_SETTINGS_KEY is insuffcient to look up the actual configuration of the
+   destinations of the type set by MEDIA_SLUG.
+
 ``raise_if_not_deletable`` should check if a given destination can be deleted.
 This is used in case some destinations are managed by an outside source and
 should not be able to be deleted by a user. If that is the case a

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -102,11 +102,8 @@ class NotificationMedium(ABC):
     def get_relevant_address(cls, destination: DestinationConfig) -> Any:
         """
         Returns the "address" to send the message to
-
-        The type of the address depends on the medium, it must be something
-        ``cls.send()`` understands.
         """
-        raise NotImplementedError
+        return destination.settings[cls.MEDIA_SETTINGS_KEY]
 
     @classmethod
     def get_relevant_destinations(cls, destinations: Iterable[DestinationConfig]) -> set[DestinationConfig]:
@@ -241,11 +238,6 @@ class AppriseMedium(NotificationMedium):
             raise ValidationError({"destination_url": "Webhook already exists"})
 
         return form.cleaned_data
-
-    @classmethod
-    def get_relevant_address(cls, destination: DestinationConfig) -> Any:
-        """Returns the Apprise destination url the message should be sent to"""
-        return destination.settings["destination_url"]
 
     @staticmethod
     def create_message_context(event: Event):

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from django import forms
 from django.conf import settings
@@ -98,11 +98,6 @@ class EmailNotification(NotificationMedium):
             raise ValidationError({"email_address": "Email address already exists"})
 
         return form.cleaned_data
-
-    @classmethod
-    def get_relevant_address(cls, destination: DestinationConfig) -> Any:
-        """Returns an email address the message should be sent to"""
-        return destination.settings["email_address"]
 
     @staticmethod
     def create_message_context(event: Event):

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -7,7 +7,7 @@ recipient's phone number. The email body must contain the message text.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from django import forms
 from django.conf import settings
@@ -72,11 +72,6 @@ class SMSNotification(NotificationMedium):
             raise ValidationError({"phone_number": "Phone number already exists"})
 
         return form.cleaned_data
-
-    @classmethod
-    def get_relevant_address(cls, destination: DestinationConfig) -> Any:
-        "Get a single phone number from the destination, as a string"
-        return destination.settings["phone_number"]
 
     @classmethod
     def send(cls, event: Event, destinations: Iterable[DestinationConfig], **_) -> bool:


### PR DESCRIPTION
## Scope and purpose

Similar to #2015. Copied from #936.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
