### PR TITLE
Move common validation functionality to media plugin base class

### DIFF
--- a/changelog.d/2023.changed.md
+++ b/changelog.d/2023.changed.md
@@ -1,0 +1,6 @@
+Collected the validation functionality of the media plugins in the base class
+Removed the ability to version a media plugin
+Changed the plugins that are shipped with Argus to use new validation functionality
+
+This will break existing 3rd party media plugins since the function signature of the validate function has changed as
+is not as tightly coupled with the API anymore, please have a look at the updated media plugin docs.

--- a/docs/integrations/notifications/writing-notification-plugins.rst
+++ b/docs/integrations/notifications/writing-notification-plugins.rst
@@ -60,6 +60,9 @@ MEDIA_SETTINGS_KEY
    required in the json schema. For example for an email plugin this would be
    "email_address" or for a SMS plugin it would be "phone_number".
 
+Form
+   The ``forms.Form`` used to validate the settings-field.
+
 Class methods for sending notifications
 ---------------------------------------
 
@@ -107,6 +110,24 @@ get_relevant_address
    MEDIA_SETTINGS_KEY is insuffcient to look up the actual configuration of the
    destinations of the type set by MEDIA_SLUG.
 
+validate
+   The function ``validate`` makes sure that a destination with the given
+   medium, label and settings can be updated or created. It uses the
+   ``validate_settings`` method to validate the settings-field, a form
+   (CommonDestinationConfigForm) to validate the media and label-fields, and an
+   optional DestinationConfig instance for checking that readonly values were
+   not changed and that no duplicates are created. The validated form is
+   returned if ok, otherwise a ``ValidationError`` should be raised. It is
+   unlikely that you will ever need to override this method.
+
+validate_settings
+   This method validates the actual contents of the settings-field using the
+   ``Form`` that is defined and an optional DestinationConfig instance for
+   the function ``has_duplicate`` that can be used here to ensure that no two
+   destinations with the same settings will be created. A ``ValidationError``
+   should be raised  if the given settings are invalid, and the validated and
+   cleaned data should be returned if not.
+
 ``raise_if_not_deletable`` should check if a given destination can be deleted.
 This is used in case some destinations are managed by an outside source and
 should not be able to be deleted by a user. If that is the case a
@@ -115,15 +136,6 @@ should not be able to be deleted by a user. If that is the case a
 The method ``update`` only has to be implemented if the regular update method
 of Django isn't sufficient. This can be the case if additional settings need to
 be updated.
-
-Finally the function ``validate`` makes sure that a destination with the given
-settings can be updated or created. The function ``has_duplicate`` can be used
-here to ensure that not two destinations with the same settings will be
-created. Additionally the settings themselves should also be validated. For
-example for SMS the given phone number will be checked. Django forms can be
-helpful for validation. A ``ValidationError`` should be raised if the given
-settings are invalid and the validated and cleaned data should be returned if
-not.
 
 Writing destination plugins using Apprise
 -----------------------------------------

--- a/src/argus/auth/factories.py
+++ b/src/argus/auth/factories.py
@@ -25,9 +25,7 @@ class PersonUserFactory(BaseUserFactory):
 
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    email = factory.LazyAttribute(
-        lambda o: "%s.%s@%s" % (o.first_name.lower(), o.last_name.lower(), factory.Faker("safe_domain_name"))
-    )
+    email = factory.LazyAttribute(lambda o: "%s.%s@example.com" % (o.first_name.lower(), o.last_name.lower()))
     username = email
     password = factory.django.Password("very SECRET P455w0rD")
 

--- a/src/argus/notificationprofile/media/__init__.py
+++ b/src/argus/notificationprofile/media/__init__.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.db import connections
 from rest_framework.exceptions import ValidationError
 
-from argus.constants import API_STABLE_VERSION
 from argus.filter import get_filter_backend
 from argus.util.utils import import_class_from_dotted_path
 
@@ -48,12 +47,12 @@ _media_classes = [import_class_from_dotted_path(media_plugin) for media_plugin i
 MEDIA_CLASSES_DICT = {media_class.MEDIA_SLUG: media_class for media_class in _media_classes}
 
 
-def api_safely_get_medium_object(media_slug, version: str = API_STABLE_VERSION):
+def api_safely_get_medium_object(media_slug):
     try:
         classobj = MEDIA_CLASSES_DICT[media_slug]
     except KeyError:
         raise ValidationError(f'Medium "{media_slug}" is not installed.')
-    obj = classobj(version)
+    obj = classobj()
     return obj
 
 

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -17,6 +17,7 @@ from rest_framework.exceptions import ValidationError
 
 from argus.notificationprofile.models import DestinationConfig
 from argus.constants import API_STABLE_VERSION
+from argus.notificationprofile.models import Media
 from argus.notificationprofile.utils import are_notifications_enabled
 from argus.util.datetime_utils import INFINITY, LOCAL_INFINITY
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from types import NoneType
+    from typing import Optional
 
     from django.contrib.auth import get_user_model
     from django.db.models.query import QuerySet
@@ -43,6 +45,17 @@ def modelinstance_to_dict(obj):
     dict_ = vars(obj).copy()
     dict_.pop("_state")
     return dict_
+
+
+class CommonDestinationConfigForm(forms.ModelForm):
+    class Meta:
+        model = DestinationConfig
+        fields = ["label", "media", "settings"]
+
+    # Settings is being set as not required for the field required errors from the plugin forms to bubble up
+    def __init__(self, *args, **kwargs):
+        super(CommonDestinationConfigForm, self).__init__(*args, **kwargs)
+        self.fields["settings"].required = False
 
 
 class NotificationMedium(ABC):
@@ -73,13 +86,99 @@ class NotificationMedium(ABC):
         self.version = version
 
     @classmethod
-    @abstractmethod
-    def validate(cls, instance: RequestDestinationConfigSerializer, dict: dict, user: User) -> dict:
+    def validate(
+        cls, data: dict, user: User, instance: Optional[DestinationConfig] = None
+    ) -> CommonDestinationConfigForm:
         """
-        Validates the settings of destination and returns a dict with
-        validated and cleaned data
+        Validates that a destination can be created/updated with the given values
+
+        Returns a form with the cleaned data if all is valid and raises a
+        ValidationError if not
         """
-        pass
+        if instance:
+            cls.validate_instance(data, user, instance)
+
+            # Copy attributes of the destination to avoid field required errors
+            for field in CommonDestinationConfigForm.Meta.fields:
+                if field not in data and getattr(instance, field):
+                    data[field] = getattr(instance, field)
+
+        form = CommonDestinationConfigForm(data)
+
+        # Check that the label and medium are valid values
+        if not form.is_valid():
+            code = "invalid"
+            detail = form.errors.get_json_data()
+            raise forms.ValidationError(message=detail, code=code)
+
+        # Check that no destination with this medium and label already exists for this user
+        qs = user.destinations.filter(media_id=data.get("media"))
+        if instance:
+            qs = qs.exclude(pk=instance.pk)
+
+        if data.get("label") and qs.filter(label=data.get("label")).exists():
+            code = "duplicate_label"
+            message = Media.error_messages["duplicate_label"]
+            raise forms.ValidationError(message={"label": message}, code=code)
+
+        # Check that the settings are valid
+        settings = data.get("settings", {})
+        if not isinstance(settings, dict):
+            code = "settings_type"
+            message = Media.error_messages["settings_type"]
+            raise forms.ValidationError(message={"settings": message}, code=code)
+
+        cleaned_settings = cls.validate_settings(settings, user, instance=instance)
+        form.cleaned_data["settings"] = cleaned_settings
+        form.cleaned_data["user"] = user
+        return form
+
+    @classmethod
+    def validate_instance(cls, data: dict, user: User, instance: DestinationConfig):
+        """
+        Validates that none of the readonly fields of an instance are being
+        changed
+
+        Raises a ValidationError if they are
+        """
+        if data.get("media") and data.get("media").slug != instance.media.slug:
+            code = "readonly_media"
+            message = Media.error_messages["readonly_media"]
+            raise forms.ValidationError(message={"media": [message]}, code=code)
+
+        if instance.user != user:
+            code = "readonly_user"
+            message = Media.error_messages["readonly_user"]
+            raise forms.ValidationError(message={"user": [message]}, code=code)
+
+    @classmethod
+    def validate_settings(
+        cls,
+        data: dict,
+        user: User,
+        instance: Optional[DestinationConfig] = None,
+    ) -> dict:
+        """
+        Validates the settings of a destination and returns a cleaned settings
+        dict and raises a ValidationError if the settings are invalid
+        """
+        form = cls.Form(data=data)
+
+        if not form.is_valid():
+            code = "invalid"
+            message = form.errors.get_json_data()
+            raise forms.ValidationError(message=message, code=code)
+
+        qs = user.destinations
+        if instance:
+            qs = qs.exclude(pk=instance.pk)
+
+        if cls.has_duplicate(qs, form.cleaned_data):
+            code = "duplicate"
+            detail = Media.error_messages["duplicate"]
+            raise forms.ValidationError(message=detail, code=code)
+
+        return form.cleaned_data
 
     @classmethod
     def has_duplicate(cls, queryset: QuerySet, settings: dict) -> bool:
@@ -170,7 +269,9 @@ class NotificationMedium(ABC):
         If the destination is marked as managed and the settings are being updated,
         a copy of the original will be made before changing the destination.
         """
-        if "label" in validated_data and "settings" not in validated_data:
+        if "label" in validated_data and (
+            "settings" not in validated_data or destination.settings == validated_data["settings"]
+        ):
             destination.label = validated_data.get("label")
             destination.save()
             return destination

--- a/src/argus/notificationprofile/media/base.py
+++ b/src/argus/notificationprofile/media/base.py
@@ -13,7 +13,6 @@ from django import forms
 from django.conf import settings
 from django.db import transaction
 from django.template.loader import render_to_string
-from rest_framework.exceptions import ValidationError
 
 from argus.notificationprofile.models import DestinationConfig
 from argus.constants import API_STABLE_VERSION
@@ -31,7 +30,6 @@ if TYPE_CHECKING:
     from django.db.models.query import QuerySet
 
     from argus.incident.models import Event
-    from ..serializers import RequestDestinationConfigSerializer
 
     User = get_user_model()
 
@@ -325,22 +323,6 @@ class AppriseMedium(NotificationMedium):
 
     class Form(forms.Form):
         destination_url = forms.URLField()
-
-    @classmethod
-    def validate(cls, instance: RequestDestinationConfigSerializer, apprise_dict: dict, user: User) -> dict:
-        """
-        Validates the settings of an Apprise destination and returns a dict
-        with validated and cleaned data
-        """
-        form = cls.Form(apprise_dict["settings"])
-        if not form.is_valid():
-            raise ValidationError(form.errors)
-        if user.destinations.filter(
-            media_id=cls.MEDIA_SLUG, settings__destination_url=form.cleaned_data["destination_url"]
-        ).exists():
-            raise ValidationError({"destination_url": "Webhook already exists"})
-
-        return form.cleaned_data
 
     @staticmethod
     def create_message_context(event: Event):

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -7,7 +7,6 @@ from django import forms
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from rest_framework.exceptions import ValidationError
 
 from argus.incident.models import Event
 from .base import NotificationMedium, modelinstance_to_dict
@@ -19,8 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from django.contrib.auth import get_user_model
-
-    from ..serializers import RequestDestinationConfigSerializer
 
     User = get_user_model()
 
@@ -69,23 +66,6 @@ class EmailNotification(NotificationMedium):
 
     class Form(forms.Form):
         email_address = forms.EmailField()
-
-    def validate(self, instance: RequestDestinationConfigSerializer, email_dict: dict, user: User) -> dict:
-        """
-        Validates the settings of an email destination and returns a dict
-        with validated and cleaned data
-        """
-        form = self.Form(email_dict["settings"])
-        if not form.is_valid():
-            raise ValidationError(form.errors)
-        if form.cleaned_data["email_address"] == instance.context["request"].user.email:
-            raise ValidationError("This email address is already registered in another destination.")
-        if user.destinations.filter(
-            media_id=self.MEDIA_SLUG, settings__email_address=form.cleaned_data["email_address"]
-        ).exists():
-            raise ValidationError({"email_address": "Email address already exists"})
-
-        return form.cleaned_data
 
     @staticmethod
     def create_message_context(event: Event):

--- a/src/argus/notificationprofile/media/email.py
+++ b/src/argus/notificationprofile/media/email.py
@@ -9,7 +9,6 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from rest_framework.exceptions import ValidationError
 
-from argus.constants import API_STABLE_VERSION
 from argus.incident.models import Event
 from .base import NotificationMedium, modelinstance_to_dict
 from ..models import DestinationConfig
@@ -68,19 +67,8 @@ class EmailNotification(NotificationMedium):
         },
     }
 
-    class FormV3(forms.Form):
+    class Form(forms.Form):
         email_address = forms.EmailField()
-
-    class FormV2(forms.Form):
-        synced = forms.BooleanField(disabled=True, required=False, initial=False)
-        email_address = forms.EmailField()
-
-    def __init__(self, version: str = API_STABLE_VERSION):
-        super().__init__(version)
-        if version == "v2":
-            self.Form = self.FormV2
-        else:
-            self.Form = self.FormV3
 
     def validate(self, instance: RequestDestinationConfigSerializer, email_dict: dict, user: User) -> dict:
         """

--- a/src/argus/notificationprofile/media/slack.py
+++ b/src/argus/notificationprofile/media/slack.py
@@ -34,14 +34,13 @@ class SlackNotification(AppriseMedium):
     class Form(forms.Form):
         destination_url = forms.CharField()
 
-    @classmethod
-    def validate(cls, instance, slack_dict, user):
-        cleaned_data = super().validate(instance, slack_dict, user)
-        destination_url = cleaned_data["destination_url"]
-        if not destination_url.startswith(("https://hooks.slack.com/", "slack://")):
-            raise ValidationError(
-                {
-                    "destination_url": "Not a valid Slack destination URL. Use a Slack incoming webhook (https://hooks.slack.com/...) or an Apprise Slack URL (slack://...)."
-                }
-            )
-        return cleaned_data
+        def clean_destination_url(self):
+            destination_url = self.cleaned_data["destination_url"]
+            if not destination_url.startswith(("https://hooks.slack.com/", "slack://")):
+                raise ValidationError(
+                    {
+                        "destination_url": "Not a valid Slack destination URL. Use a Slack incoming webhook (https://hooks.slack.com/...) or an Apprise Slack URL (slack://...)."
+                    }
+                )
+
+            return destination_url

--- a/src/argus/notificationprofile/media/sms_as_email.py
+++ b/src/argus/notificationprofile/media/sms_as_email.py
@@ -13,7 +13,6 @@ from django import forms
 from django.conf import settings
 from django.core.mail import send_mail
 from phonenumber_field.formfields import PhoneNumberField
-from rest_framework.exceptions import ValidationError
 
 from ...incident.models import Event
 from .base import NotificationMedium
@@ -26,7 +25,6 @@ if TYPE_CHECKING:
     from django.contrib.auth import get_user_model
 
     from ..models import DestinationConfig
-    from ..serializers import RequestDestinationConfigSerializer
 
     User = get_user_model()
 
@@ -51,27 +49,12 @@ class SMSNotification(NotificationMedium):
         },
     }
 
-    class PhoneNumberForm(forms.Form):
+    class Form(forms.Form):
         phone_number = PhoneNumberField()
 
-    @classmethod
-    def validate(cls, instance: RequestDestinationConfigSerializer, sms_dict: dict, user: User) -> dict:
-        """
-        Validates the settings of an SMS destination and returns a dict
-        with validated and cleaned data
-        """
-        form = cls.PhoneNumberForm(sms_dict["settings"])
-        if not form.is_valid():
-            raise ValidationError(form.errors)
-
-        form.cleaned_data["phone_number"] = form.cleaned_data["phone_number"].as_e164
-
-        if user.destinations.filter(
-            media_id=cls.MEDIA_SLUG, settings__phone_number=form.cleaned_data["phone_number"]
-        ).exists():
-            raise ValidationError({"phone_number": "Phone number already exists"})
-
-        return form.cleaned_data
+        def clean_phone_number(self):
+            phone_number = self.cleaned_data["phone_number"]
+            return phone_number.as_e164
 
     @classmethod
     def send(cls, event: Event, destinations: Iterable[DestinationConfig], **_) -> bool:

--- a/src/argus/notificationprofile/models.py
+++ b/src/argus/notificationprofile/models.py
@@ -184,6 +184,14 @@ class Media(models.Model):
         verbose_name = "Medium"
         verbose_name_plural = "Media"
 
+    error_messages = {
+        "readonly_media": "Media cannot be updated, only settings.",
+        "readonly_user": "User cannot be changed, only settings.",
+        "duplicate_label": "A destination with this medium and label already exists",
+        "duplicate": "A destination with these settings already exists",
+        "settings_type": "Settings has to be a dictionary.",
+    }
+
     MEDIA_NAME_LENGTH = 20
     slug = models.SlugField(max_length=MEDIA_NAME_LENGTH, blank=True, primary_key=True)
     name = models.CharField(max_length=MEDIA_NAME_LENGTH)

--- a/src/argus/notificationprofile/v2/serializers.py
+++ b/src/argus/notificationprofile/v2/serializers.py
@@ -146,18 +146,11 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
         ]
 
     def validate(self, attrs: dict):
-        if self.instance and "media" in attrs.keys() and not attrs["media"].slug == self.instance.media.slug:
-            raise serializers.ValidationError("Media cannot be updated, only settings.")
-        if "settings" in attrs.keys():
-            if not isinstance(attrs["settings"], dict):
-                raise serializers.ValidationError("Settings has to be a dictionary.")
-            if self.instance:
-                medium = api_safely_get_medium_object(self.instance.media.slug)
-            else:
-                medium = api_safely_get_medium_object(attrs["media"].slug)
-            attrs["settings"] = medium.validate(self, attrs, self.context["request"].user)
+        media_slug = self.instance.media.slug if self.instance else attrs["media"].slug
+        medium = api_safely_get_medium_object(media_slug)
+        form = medium.validate(attrs, self.context["request"].user, self.instance)
 
-        return attrs
+        return form.cleaned_data
 
     def update(self, destination: DestinationConfig, validated_data: dict):
         medium = api_safely_get_medium_object(destination.media.slug)

--- a/src/argus/notificationprofile/v2/serializers.py
+++ b/src/argus/notificationprofile/v2/serializers.py
@@ -111,7 +111,6 @@ class JSONSchemaSerializer(serializers.Serializer):
 
 
 class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
-    version = VERSION
     media = MediaSerializer()
     suggested_label = serializers.SerializerMethodField(method_name="get_suggested_label")
     settings = serializers.SerializerMethodField(method_name="get_settings")
@@ -127,7 +126,7 @@ class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
         ]
 
     def get_suggested_label(self, destination: DestinationConfig) -> str:
-        medium = api_safely_get_medium_object(destination.media.slug, self.version)
+        medium = api_safely_get_medium_object(destination.media.slug)
         return f"{destination.media.name}: {medium.get_label(destination)}"
 
     def get_settings(self, destination: DestinationConfig) -> dict:
@@ -138,8 +137,6 @@ class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
 
 
 class RequestDestinationConfigSerializer(serializers.ModelSerializer):
-    version = VERSION
-
     class Meta:
         model = DestinationConfig
         fields = [
@@ -155,15 +152,15 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
             if not isinstance(attrs["settings"], dict):
                 raise serializers.ValidationError("Settings has to be a dictionary.")
             if self.instance:
-                medium = api_safely_get_medium_object(self.instance.media.slug, self.version)
+                medium = api_safely_get_medium_object(self.instance.media.slug)
             else:
-                medium = api_safely_get_medium_object(attrs["media"].slug, self.version)
+                medium = api_safely_get_medium_object(attrs["media"].slug)
             attrs["settings"] = medium.validate(self, attrs, self.context["request"].user)
 
         return attrs
 
     def update(self, destination: DestinationConfig, validated_data: dict):
-        medium = api_safely_get_medium_object(destination.media.slug, self.version)
+        medium = api_safely_get_medium_object(destination.media.slug)
         updated_destination = medium.update(destination, validated_data)
 
         return updated_destination

--- a/src/argus/notificationprofile/v2/views.py
+++ b/src/argus/notificationprofile/v2/views.py
@@ -119,19 +119,17 @@ class NotificationProfileViewSet(rw_viewsets.ModelViewSet):
 
 
 class SchemaView(DetailView):
-    version = VERSION
     template_name = "schemawrapper.html"
     model = Media
 
     def get_context_data(self, **kwargs):
         kwargs = super().get_context_data(**kwargs)
-        medium = api_safely_get_medium_object(self.object.slug, self.version)
+        medium = api_safely_get_medium_object(self.object.slug)
         kwargs["schema_info"] = medium.MEDIA_JSON_SCHEMA
         return kwargs
 
 
 class MediaViewSet(viewsets.ModelViewSet):
-    version = VERSION
     serializer_class = MediaSerializer
     queryset = Media.objects.none()
     http_method_names = ["get", "head"]
@@ -143,7 +141,7 @@ class MediaViewSet(viewsets.ModelViewSet):
     @action(methods=["get"], detail=True)
     def json_schema(self, request, pk, *args, **kwargs):
         try:
-            medium = api_safely_get_medium_object(pk, self.version)
+            medium = api_safely_get_medium_object(pk)
             schema = medium.MEDIA_JSON_SCHEMA
             schema["$id"] = reverse(
                 "json-schema",
@@ -169,7 +167,6 @@ class MediaViewSet(viewsets.ModelViewSet):
     ),
 )
 class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
-    version = VERSION
     permission_classes = [*rw_viewsets.ModelViewSet.permission_classes, IsOwner]
     serializer_class = ResponseDestinationConfigSerializer
     read_serializer_class = ResponseDestinationConfigSerializer
@@ -189,7 +186,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         destination = get_object_or_404(self.get_queryset(), pk=pk)
 
         try:
-            medium = api_safely_get_medium_object(destination.media.slug, self.version)
+            medium = api_safely_get_medium_object(destination.media.slug)
             medium.raise_if_not_deletable(destination)
         except NotificationMedium.NotDeletableError as e:
             raise ValidationError(str(e))
@@ -200,7 +197,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         other_destinations = DestinationConfig.objects.filter(media=destination.media).filter(
             ~Q(user_id=destination.user.id)
         )
-        medium = api_safely_get_medium_object(destination.media_id, self.version)
+        medium = api_safely_get_medium_object(destination.media_id)
         destination_in_use = medium.has_duplicate(other_destinations, destination.settings)
         return destination_in_use
 

--- a/src/argus/notificationprofile/v3/serializers.py
+++ b/src/argus/notificationprofile/v3/serializers.py
@@ -27,7 +27,7 @@ class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
         ]
 
     def get_suggested_label(self, destination: DestinationConfig) -> str:
-        medium = api_safely_get_medium_object(destination.media.slug, VERSION)
+        medium = api_safely_get_medium_object(destination.media.slug)
         return f"{destination.media.name}: {medium.get_label(destination)}"
 
 

--- a/src/argus/notificationprofile/v3/serializers.py
+++ b/src/argus/notificationprofile/v3/serializers.py
@@ -43,21 +43,14 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
         ]
 
     def validate(self, attrs: dict):
-        if self.instance and "media" in attrs.keys() and not attrs["media"].slug == self.instance.media.slug:
-            raise serializers.ValidationError("Media cannot be updated, only settings.")
-        if "settings" in attrs.keys():
-            if not isinstance(attrs["settings"], dict):
-                raise serializers.ValidationError("Settings has to be a dictionary.")
-            if self.instance:
-                medium = api_safely_get_medium_object(self.instance.media.slug, self.version)
-            else:
-                medium = api_safely_get_medium_object(attrs["media"].slug, self.version)
-            attrs["settings"] = medium.validate(self, attrs, self.context["request"].user)
+        media_slug = self.instance.media.slug if self.instance else attrs["media"].slug
+        medium = api_safely_get_medium_object(media_slug)
+        form = medium.validate(attrs, self.context["request"].user, self.instance)
 
-        return attrs
+        return form.cleaned_data
 
     def update(self, destination: DestinationConfig, validated_data: dict):
-        medium = api_safely_get_medium_object(destination.media.slug, self.version)
+        medium = api_safely_get_medium_object(destination.media.slug)
         updated_destination = medium.update(destination, validated_data)
 
         return updated_destination

--- a/src/argus/notificationprofile/v3/views.py
+++ b/src/argus/notificationprofile/v3/views.py
@@ -29,11 +29,11 @@ FilterBlobSerializer = filter_backend.FilterBlobSerializer
 
 
 class SchemaView(SchemaViewV2):
-    version = VERSION
+    pass
 
 
 class MediaViewSet(MediaViewSetV2):
-    version = VERSION
+    pass
 
 
 @extend_schema_view(
@@ -49,7 +49,6 @@ class MediaViewSet(MediaViewSetV2):
     ),
 )
 class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
-    version = VERSION
     permission_classes = [*rw_viewsets.ModelViewSet.permission_classes, IsOwner]
     serializer_class = ResponseDestinationConfigSerializer
     read_serializer_class = ResponseDestinationConfigSerializer
@@ -68,7 +67,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         destination = get_object_or_404(self.get_queryset(), pk=pk)
 
         try:
-            medium = api_safely_get_medium_object(destination.media.slug, self.version)
+            medium = api_safely_get_medium_object(destination.media.slug)
             medium.raise_if_not_deletable(destination)
         except NotificationMedium.NotDeletableError as e:
             raise ValidationError(str(e))
@@ -79,7 +78,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         other_destinations = DestinationConfig.objects.filter(media=destination.media).filter(
             ~Q(user_id=destination.user.id)
         )
-        medium = api_safely_get_medium_object(destination.media_id, self.version)
+        medium = api_safely_get_medium_object(destination.media_id)
         destination_in_use = medium.has_duplicate(other_destinations, destination.settings)
         return destination_in_use
 

--- a/tests/notificationprofile/destinations/test_base.py
+++ b/tests/notificationprofile/destinations/test_base.py
@@ -1,0 +1,199 @@
+from django import forms
+from django.test import TestCase
+
+from argus.auth.factories import PersonUserFactory
+from argus.notificationprofile.factories import DestinationConfigFactory
+from argus.notificationprofile.media.base import NotificationMedium
+from argus.notificationprofile.models import Media
+
+
+class DummyNotification(NotificationMedium):
+    MEDIA_SETTINGS_KEY = "foo"
+    MEDIA_NAME = "Dummy"
+    MEDIA_SLUG = "dummy"
+
+    class Form(forms.Form):
+        foo = forms.IntegerField()
+
+
+class ValidateSettingsTests(TestCase):
+    def setUp(self):
+        self.user = PersonUserFactory()
+
+    def test_given_valid_settings_then_return_cleaned_data(self):
+        data = {"foo": 1}
+        cleaned_data = DummyNotification.validate_settings(data, self.user)
+
+        self.assertEqual(cleaned_data, data)
+
+    def test_given_settings_with_missing_key_then_raise_validation_error(self):
+        data = {"bar": False}
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate_settings(data, self.user)
+
+        self.assertIn("This field is required", str(e.exception))
+
+    def test_given_settings_with_wrong_type_then_raise_validation_error(self):
+        data = {"foo": False}
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate_settings(data, self.user)
+
+        self.assertIn("whole number", str(e.exception))
+
+    def test_given_duplicate_settings_then_raise_validation_error(self):
+        settings = {"foo": 1}
+        dummy_medium = Media.objects.create(slug=DummyNotification.MEDIA_SLUG, name=DummyNotification.MEDIA_NAME)
+        DestinationConfigFactory(
+            user=self.user,
+            media=dummy_medium,
+            settings=settings,
+            managed=False,
+        )
+
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate_settings(settings, self.user)
+
+        self.assertIn(Media.error_messages["duplicate"], str(e.exception))
+
+    def test_given_duplicate_settings_for_same_destination_then_do_not_raise_validation_error(self):
+        settings = {"foo": 1}
+        dummy_medium = Media.objects.create(slug=DummyNotification.MEDIA_SLUG, name=DummyNotification.MEDIA_NAME)
+        destination = DestinationConfigFactory(
+            user=self.user,
+            media=dummy_medium,
+            settings=settings,
+            managed=False,
+        )
+
+        cleaned_data = DummyNotification.validate_settings(settings, self.user, destination)
+
+        self.assertEqual(cleaned_data, settings)
+
+
+class ValidateTests(TestCase):
+    def setUp(self):
+        self.user = PersonUserFactory()
+        self.dummy_medium = Media.objects.create(slug=DummyNotification.MEDIA_SLUG, name=DummyNotification.MEDIA_NAME)
+        self.destination = DestinationConfigFactory(
+            user=self.user,
+            media=self.dummy_medium,
+            settings={"foo": 999},
+            managed=False,
+        )
+
+    def test_given_valid_data_for_new_destination_then_return_form(self):
+        data = {
+            "media": self.dummy_medium,
+            "label": "Dummy destination",
+            "settings": {"foo": 1},
+        }
+        form = DummyNotification.validate(data, self.user)
+
+        self.assertEqual(form.cleaned_data["label"], data["label"])
+        self.assertEqual(form.cleaned_data["settings"], data["settings"])
+
+    def test_given_valid_data_for_existing_destination_then_return_form(self):
+        data = {
+            "media": self.dummy_medium,
+            "label": "Dummy destination",
+            "settings": {"foo": 1},
+        }
+        form = DummyNotification.validate(data, self.user, self.destination)
+
+        self.assertEqual(form.cleaned_data["label"], data["label"])
+        self.assertEqual(form.cleaned_data["settings"], data["settings"])
+
+    def test_given_changed_media_then_raise_validation_error(self):
+        different_medium = Media.objects.create(slug="different", name="Different medium")
+        data = {
+            "media": different_medium,
+            "settings": {"foo": 1},
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user, self.destination)
+
+        self.assertIn(Media.error_messages["readonly_media"], str(e.exception))
+
+    def test_given_changed_user_then_raise_validation_error(self):
+        other_user = PersonUserFactory()
+        data = {
+            "media": self.dummy_medium,
+            "settings": {"foo": 1},
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, other_user, self.destination)
+
+        self.assertIn(Media.error_messages["readonly_user"], str(e.exception))
+
+    def test_given_invalid_medium_for_new_destination_then_raise_validation_error(self):
+        data = {
+            "media": "invalid",
+            "settings": {"foo": 1},
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user)
+
+        self.assertIn("Select a valid choice.", str(e.exception))
+
+    def test_given_duplicate_label_then_raise_validation_error(self):
+        self.destination.label = "Duplicate label"
+        self.destination.save()
+        data = {
+            "media": self.dummy_medium,
+            "label": "Duplicate label",
+            "settings": {"foo": 1},
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user)
+
+        self.assertIn(Media.error_messages["duplicate_label"], str(e.exception))
+
+    def test_given_same_label_for_given_destination_then_do_not_raise_validation_error(self):
+        self.destination.label = "Duplicate label"
+        self.destination.save()
+        data = {
+            "media": self.dummy_medium,
+            "label": "Duplicate label",
+            "settings": {"foo": 1},
+        }
+        form = DummyNotification.validate(data, self.user, self.destination)
+
+        self.assertEqual(form.cleaned_data["label"], "Duplicate label")
+
+    def test_given_missing_settings_then_raise_validation_error(self):
+        data = {
+            "media": self.dummy_medium,
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user)
+        self.assertIn("This field is required", str(e.exception))
+
+    def test_given_non_dict_settings_then_raise_validation_error(self):
+        data = {
+            "media": self.dummy_medium,
+            "settings": 100,
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user)
+
+        self.assertIn(Media.error_messages["settings_type"], str(e.exception))
+
+    def test_given_empty_settings_then_raise_validation_error(self):
+        data = {
+            "media": self.dummy_medium,
+            "settings": {},
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user)
+
+        self.assertIn("This field is required", str(e.exception))
+
+    def test_given_invalid_settings_then_raise_validation_error(self):
+        data = {
+            "media": self.dummy_medium,
+            "settings": {"bar": "wrong"},
+        }
+        with self.assertRaises(forms.ValidationError) as e:
+            DummyNotification.validate(data, self.user)
+
+        self.assertIn("This field is required", str(e.exception))

--- a/tests/notificationprofile/destinations/test_email.py
+++ b/tests/notificationprofile/destinations/test_email.py
@@ -357,6 +357,28 @@ class EmailDestinationViewV2Tests(APITestCase):
         self.assertEqual(response.data["label"], "new email")
         self.assertTrue(DestinationConfig.objects.filter(label="new email").exists())
 
+    def test_given_duplicate_label_then_forbid_creating_destination(self):
+        DestinationConfigFactory(
+            user=self.user1,
+            media=Media.objects.get(slug="email"),
+            label="duplicate",
+            settings={"email_address": "a@example.com"},
+        )
+        response = self.user1_rest_client.post(
+            path=self.ENDPOINT,
+            data={
+                "media": "email",
+                "label": "duplicate",
+                "settings": {"email_address": "b@example.com"},
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("A destination with this medium and label already exists", str(response.data))
+        self.assertEqual(
+            DestinationConfig.objects.filter(media_id="email", label="duplicate").count(),
+            1,
+        )
+
     def test_given_duplicate_email_address_then_forbid_creating_destination(self):
         settings = {"email_address": "test2@example.com"}
         DestinationConfigFactory(
@@ -372,7 +394,7 @@ class EmailDestinationViewV2Tests(APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Email address already exists", str(response.data["email_address"]))
+        self.assertIn("A destination with these settings already exists", str(response.data))
         self.assertEqual(
             DestinationConfig.objects.filter(
                 media_id="email", settings__email_address=settings["email_address"]
@@ -389,7 +411,7 @@ class EmailDestinationViewV2Tests(APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Settings has to be a dictionary", str(response.data))
+        self.assertIn("Enter a valid JSON", str(response.data["settings"]))
 
     def test_given_invalid_email_address_then_forbid_creating_destination(self):
         response = self.user1_rest_client.post(
@@ -563,6 +585,24 @@ class EmailDestinationViewV2Tests(APITestCase):
         self.assertFalse(self.managed_email_destination.managed)
         self.assertTrue(DestinationConfig.objects.filter(managed=True, settings=old_settings).exists())
 
+    def test_given_duplicate_label_then_forbid_updating_destination(self):
+        DestinationConfigFactory(
+            user=self.user1,
+            media=Media.objects.get(slug="email"),
+            label="duplicate",
+            settings={"email_address": "a@example.com"},
+        )
+        response = self.user1_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.unmanaged_email_destination.pk}/",
+            data={"label": "duplicate"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("A destination with this medium and label already exists", str(response.data))
+        self.assertEqual(
+            DestinationConfig.objects.filter(media_id="email", label="duplicate").count(),
+            1,
+        )
+
     def test_given_settings_not_dict_then_forbid_updating_destination(self):
         unmanaged_email_destination_address = self.unmanaged_email_destination.settings["email_address"]
         response = self.user1_rest_client.patch(
@@ -570,7 +610,7 @@ class EmailDestinationViewV2Tests(APITestCase):
             data={"settings": "not a dict"},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Settings has to be a dictionary", str(response.data))
+        self.assertIn("Enter a valid JSON", str(response.data["settings"]))
         self.unmanaged_email_destination.refresh_from_db()
         self.assertEqual(
             self.unmanaged_email_destination.settings["email_address"], unmanaged_email_destination_address
@@ -734,6 +774,28 @@ class EmailDestinationViewV3Tests(APITestCase):
         self.assertEqual(response.data["label"], "new email")
         self.assertTrue(DestinationConfig.objects.filter(label="new email").exists())
 
+    def test_given_duplicate_label_then_forbid_creating_destination(self):
+        DestinationConfigFactory(
+            user=self.user1,
+            media=Media.objects.get(slug="email"),
+            label="duplicate",
+            settings={"email_address": "a@example.com"},
+        )
+        response = self.user1_rest_client.post(
+            path=self.ENDPOINT,
+            data={
+                "media": "email",
+                "label": "duplicate",
+                "settings": {"email_address": "b@example.com"},
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("A destination with this medium and label already exists", str(response.data))
+        self.assertEqual(
+            DestinationConfig.objects.filter(media_id="email", label="duplicate").count(),
+            1,
+        )
+
     def test_given_duplicate_email_address_then_forbid_creating_destination(self):
         settings = {"email_address": "test2@example.com"}
         DestinationConfigFactory(
@@ -749,7 +811,7 @@ class EmailDestinationViewV3Tests(APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Email address already exists", str(response.data["email_address"]))
+        self.assertIn("A destination with these settings already exists", str(response.data))
         self.assertEqual(
             DestinationConfig.objects.filter(
                 media_id="email", settings__email_address=settings["email_address"]
@@ -766,7 +828,7 @@ class EmailDestinationViewV3Tests(APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Settings has to be a dictionary", str(response.data))
+        self.assertIn("Enter a valid JSON", str(response.data["settings"]))
 
     def test_given_invalid_email_address_then_forbid_creating_destination(self):
         response = self.user1_rest_client.post(
@@ -926,6 +988,24 @@ class EmailDestinationViewV3Tests(APITestCase):
         self.assertFalse(self.managed_email_destination.managed)
         self.assertTrue(DestinationConfig.objects.filter(managed=True, settings=old_settings).exists())
 
+    def test_given_duplicate_label_then_forbid_updating_destination(self):
+        DestinationConfigFactory(
+            user=self.user1,
+            media=Media.objects.get(slug="email"),
+            label="duplicate",
+            settings={"email_address": "a@example.com"},
+        )
+        response = self.user1_rest_client.patch(
+            path=f"{self.ENDPOINT}{self.unmanaged_email_destination.pk}/",
+            data={"label": "duplicate"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("A destination with this medium and label already exists", str(response.data))
+        self.assertEqual(
+            DestinationConfig.objects.filter(media_id="email", label="duplicate").count(),
+            1,
+        )
+
     def test_given_settings_not_dict_then_forbid_updating_destination(self):
         unmanaged_email_destination_address = self.unmanaged_email_destination.settings["email_address"]
         response = self.user1_rest_client.patch(
@@ -933,7 +1013,7 @@ class EmailDestinationViewV3Tests(APITestCase):
             data={"settings": "not a dict"},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Settings has to be a dictionary", str(response.data))
+        self.assertIn("Enter a valid JSON", str(response.data["settings"]))
         self.unmanaged_email_destination.refresh_from_db()
         self.assertEqual(
             self.unmanaged_email_destination.settings["email_address"], unmanaged_email_destination_address

--- a/tests/notificationprofile/destinations/test_email.py
+++ b/tests/notificationprofile/destinations/test_email.py
@@ -91,10 +91,7 @@ class EmailDestinationConfigSerializerV2Tests(TestCase):
         self.assertTrue(serializer.is_valid())
         self.assertEqual(
             serializer.validated_data["settings"],
-            {
-                "email_address": "user@example.com",
-                "synced": False,
-            },
+            {"email_address": "user@example.com"},
         )
 
     def test_can_create_email_destination(self):

--- a/tests/notificationprofile/destinations/test_sms.py
+++ b/tests/notificationprofile/destinations/test_sms.py
@@ -60,7 +60,7 @@ class SMSDestinationConfigSerializerTests(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertTrue(serializer.errors)
 
-    def test_email_destination_serializer_is_invalid_with_invalid_phone_number(self):
+    def test_sms_destination_serializer_is_invalid_with_invalid_phone_number(self):
         request = self.request_factory.post("/")
         request.user = self.user
         data = {
@@ -74,7 +74,7 @@ class SMSDestinationConfigSerializerTests(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertTrue(serializer.errors)
 
-    def test_email_destination_serializer_is_valid_with_additional_arguments(self):
+    def test_sms_destination_serializer_is_valid_with_additional_arguments(self):
         request = self.request_factory.post("/")
         request.user = self.user
         data = {


### PR DESCRIPTION
## Scope and purpose

Heavily inspired by #936.
Updating the frontend to use this will be another PR (this PR will break the frontend), so both should be merged together. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
