### PR TITLE
Update docs after media plugin refactor

### DIFF
--- a/docs/integrations/notifications/writing-notification-plugins.rst
+++ b/docs/integrations/notifications/writing-notification-plugins.rst
@@ -128,14 +128,18 @@ validate_settings
    should be raised  if the given settings are invalid, and the validated and
    cleaned data should be returned if not.
 
-``raise_if_not_deletable`` should check if a given destination can be deleted.
-This is used in case some destinations are managed by an outside source and
-should not be able to be deleted by a user. If that is the case a
-``NotDeletableError`` should be raised. If not simply return None.
+raise_if_not_deletable
+   This method by default checks if the destination is in use by a profile, or
+   if it is **managed**, that is, outside of the control of a user. It should
+   raise ``NotDeletableError`` in either case. If the destination *may* be
+   deleted it should return ``None``. It should not be necessary to alter or
+   extend this method, but if it is, ``super()`` should be used to maintain the
+   standard functionality.
 
-The method ``update`` only has to be implemented if the regular update method
-of Django isn't sufficient. This can be the case if additional settings need to
-be updated.
+update
+   This method only has to be implemented if the regular update method is
+   insufficient. This can be the case if there is more than one key-value pair
+   in settings that need to be updated.
 
 Writing destination plugins using Apprise
 -----------------------------------------


### PR DESCRIPTION
## Scope and purpose

Follow up to #2015, #2019, #2020 and #2023. Finishes the methods part of media plugin docs to follow the set formatting.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
