### PR TITLE
Remove API mention from `api_safely_get_medium_object`

### DIFF
--- a/src/argus/htmx/destination/forms.py
+++ b/src/argus/htmx/destination/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms import ModelForm
 
-from argus.notificationprofile.media import api_safely_get_medium_object
+from argus.notificationprofile.media import safely_get_medium_object
 from argus.notificationprofile.models import DestinationConfig, Media
 from argus.notificationprofile.v2.serializers import RequestDestinationConfigSerializer
 
@@ -124,5 +124,5 @@ def _get_settings_key_for_media(media: Media) -> str:
     """Returns the required settings key for the given media,
     e.g. "email_address", "phone_number"
     """
-    medium = api_safely_get_medium_object(media.slug)
+    medium = safely_get_medium_object(media.slug)
     return medium.MEDIA_JSON_SCHEMA["required"][0]

--- a/src/argus/htmx/destination/views.py
+++ b/src/argus/htmx/destination/views.py
@@ -7,7 +7,7 @@ from django_htmx.http import HttpResponseClientRedirect
 
 from argus.htmx.modals import DeleteModal
 from argus.notificationprofile.models import DestinationConfig
-from argus.notificationprofile.media import api_safely_get_medium_object
+from argus.notificationprofile.media import safely_get_medium_object
 from argus.notificationprofile.media.base import NotificationMedium
 
 from .forms import DestinationFormCreate, DestinationFormUpdate
@@ -24,7 +24,7 @@ def _attach_delete_state(form, make_modal):
     """
     destination = DestinationConfig.objects.get(pk=form.instance.pk)
     try:
-        medium = api_safely_get_medium_object(destination.media.slug)
+        medium = safely_get_medium_object(destination.media.slug)
         medium.raise_if_not_deletable(destination)
     except NotificationMedium.NotDeletableError as e:
         form.delete_disabled = True
@@ -167,7 +167,7 @@ class DestinationDeleteView(DestinationMixin, DeleteView):
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         try:
-            medium = api_safely_get_medium_object(self.object.media.slug)
+            medium = safely_get_medium_object(self.object.media.slug)
             medium.raise_if_not_deletable(self.object)
         except NotificationMedium.NotDeletableError as e:
             update_forms = _get_update_forms(request.user)

--- a/src/argus/notificationprofile/media/__init__.py
+++ b/src/argus/notificationprofile/media/__init__.py
@@ -29,7 +29,7 @@ LOG = logging.getLogger(__name__)
 
 
 __all__ = [
-    "api_safely_get_medium_object",
+    "safely_get_medium_object",
     "send_notification",
     "background_send_notification",
     "find_destinations_for_event",
@@ -47,7 +47,7 @@ _media_classes = [import_class_from_dotted_path(media_plugin) for media_plugin i
 MEDIA_CLASSES_DICT = {media_class.MEDIA_SLUG: media_class for media_class in _media_classes}
 
 
-def api_safely_get_medium_object(media_slug):
+def safely_get_medium_object(media_slug):
     try:
         classobj = MEDIA_CLASSES_DICT[media_slug]
     except KeyError:

--- a/src/argus/notificationprofile/v2/serializers.py
+++ b/src/argus/notificationprofile/v2/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import fields, serializers
 
 from argus.filter.serializers import FilterSerializer
-from argus.notificationprofile.media import EMAIL_DESTINATION_SLUG, api_safely_get_medium_object
+from argus.notificationprofile.media import EMAIL_DESTINATION_SLUG, safely_get_medium_object
 from argus.notificationprofile.models import DestinationConfig, Media, NotificationProfile, TimeRecurrence, Timeslot
 
 VERSION = "v2"
@@ -126,7 +126,7 @@ class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
         ]
 
     def get_suggested_label(self, destination: DestinationConfig) -> str:
-        medium = api_safely_get_medium_object(destination.media.slug)
+        medium = safely_get_medium_object(destination.media.slug)
         return f"{destination.media.name}: {medium.get_label(destination)}"
 
     def get_settings(self, destination: DestinationConfig) -> dict:
@@ -147,13 +147,13 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: dict):
         media_slug = self.instance.media.slug if self.instance else attrs["media"].slug
-        medium = api_safely_get_medium_object(media_slug)
+        medium = safely_get_medium_object(media_slug)
         form = medium.validate(attrs, self.context["request"].user, self.instance)
 
         return form.cleaned_data
 
     def update(self, destination: DestinationConfig, validated_data: dict):
-        medium = api_safely_get_medium_object(destination.media.slug)
+        medium = safely_get_medium_object(destination.media.slug)
         updated_destination = medium.update(destination, validated_data)
 
         return updated_destination

--- a/src/argus/notificationprofile/v2/views.py
+++ b/src/argus/notificationprofile/v2/views.py
@@ -14,7 +14,7 @@ from argus.drf.permissions import IsOwner
 from argus.filter import get_filter_backend
 from argus.filter.serializers import FilterSerializer
 from argus.incident.v2.serializers import IncidentSerializer
-from argus.notificationprofile.media import api_safely_get_medium_object
+from argus.notificationprofile.media import safely_get_medium_object
 from argus.notificationprofile.media.base import NotificationMedium
 from argus.notificationprofile.models import (
     DestinationConfig,
@@ -124,7 +124,7 @@ class SchemaView(DetailView):
 
     def get_context_data(self, **kwargs):
         kwargs = super().get_context_data(**kwargs)
-        medium = api_safely_get_medium_object(self.object.slug)
+        medium = safely_get_medium_object(self.object.slug)
         kwargs["schema_info"] = medium.MEDIA_JSON_SCHEMA
         return kwargs
 
@@ -141,7 +141,7 @@ class MediaViewSet(viewsets.ModelViewSet):
     @action(methods=["get"], detail=True)
     def json_schema(self, request, pk, *args, **kwargs):
         try:
-            medium = api_safely_get_medium_object(pk)
+            medium = safely_get_medium_object(pk)
             schema = medium.MEDIA_JSON_SCHEMA
             schema["$id"] = reverse(
                 "json-schema",
@@ -186,7 +186,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         destination = get_object_or_404(self.get_queryset(), pk=pk)
 
         try:
-            medium = api_safely_get_medium_object(destination.media.slug)
+            medium = safely_get_medium_object(destination.media.slug)
             medium.raise_if_not_deletable(destination)
         except NotificationMedium.NotDeletableError as e:
             raise ValidationError(str(e))
@@ -197,7 +197,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         other_destinations = DestinationConfig.objects.filter(media=destination.media).filter(
             ~Q(user_id=destination.user.id)
         )
-        medium = api_safely_get_medium_object(destination.media_id)
+        medium = safely_get_medium_object(destination.media_id)
         destination_in_use = medium.has_duplicate(other_destinations, destination.settings)
         return destination_in_use
 

--- a/src/argus/notificationprofile/v3/serializers.py
+++ b/src/argus/notificationprofile/v3/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from argus.notificationprofile.media import api_safely_get_medium_object
+from argus.notificationprofile.media import safely_get_medium_object
 from argus.notificationprofile.models import DestinationConfig
 from argus.notificationprofile.v2.serializers import MediaSerializer
 
@@ -27,7 +27,7 @@ class ResponseDestinationConfigSerializer(serializers.ModelSerializer):
         ]
 
     def get_suggested_label(self, destination: DestinationConfig) -> str:
-        medium = api_safely_get_medium_object(destination.media.slug)
+        medium = safely_get_medium_object(destination.media.slug)
         return f"{destination.media.name}: {medium.get_label(destination)}"
 
 
@@ -44,13 +44,13 @@ class RequestDestinationConfigSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: dict):
         media_slug = self.instance.media.slug if self.instance else attrs["media"].slug
-        medium = api_safely_get_medium_object(media_slug)
+        medium = safely_get_medium_object(media_slug)
         form = medium.validate(attrs, self.context["request"].user, self.instance)
 
         return form.cleaned_data
 
     def update(self, destination: DestinationConfig, validated_data: dict):
-        medium = api_safely_get_medium_object(destination.media.slug)
+        medium = safely_get_medium_object(destination.media.slug)
         updated_destination = medium.update(destination, validated_data)
 
         return updated_destination

--- a/src/argus/notificationprofile/v3/views.py
+++ b/src/argus/notificationprofile/v3/views.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 
 from argus.drf.permissions import IsOwner
 from argus.filter import get_filter_backend
-from argus.notificationprofile.media import api_safely_get_medium_object
+from argus.notificationprofile.media import safely_get_medium_object
 from argus.notificationprofile.media.base import NotificationMedium
 from argus.notificationprofile.models import DestinationConfig
 from argus.notificationprofile.v2.serializers import DuplicateDestinationSerializer
@@ -67,7 +67,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         destination = get_object_or_404(self.get_queryset(), pk=pk)
 
         try:
-            medium = api_safely_get_medium_object(destination.media.slug)
+            medium = safely_get_medium_object(destination.media.slug)
             medium.raise_if_not_deletable(destination)
         except NotificationMedium.NotDeletableError as e:
             raise ValidationError(str(e))
@@ -78,7 +78,7 @@ class DestinationConfigViewSet(rw_viewsets.ModelViewSet):
         other_destinations = DestinationConfig.objects.filter(media=destination.media).filter(
             ~Q(user_id=destination.user.id)
         )
-        medium = api_safely_get_medium_object(destination.media_id)
+        medium = safely_get_medium_object(destination.media_id)
         destination_in_use = medium.has_duplicate(other_destinations, destination.settings)
         return destination_in_use
 


### PR DESCRIPTION
## Scope and purpose

Since it will also be used in the frontend the API mention is removed. Mentioned in #2023.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
