### PR TITLE
Use Django validation error for slack

### DIFF
--- a/src/argus/notificationprofile/media/slack.py
+++ b/src/argus/notificationprofile/media/slack.py
@@ -4,7 +4,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from django import forms
-from rest_framework.exceptions import ValidationError
 
 from .base import AppriseMedium
 
@@ -37,10 +36,8 @@ class SlackNotification(AppriseMedium):
         def clean_destination_url(self):
             destination_url = self.cleaned_data["destination_url"]
             if not destination_url.startswith(("https://hooks.slack.com/", "slack://")):
-                raise ValidationError(
-                    {
-                        "destination_url": "Not a valid Slack destination URL. Use a Slack incoming webhook (https://hooks.slack.com/...) or an Apprise Slack URL (slack://...)."
-                    }
+                raise forms.ValidationError(
+                    "Not a valid Slack destination URL. Use a Slack incoming webhook (https://hooks.slack.com/...) or an Apprise Slack URL (slack://...)."
                 )
 
             return destination_url


### PR DESCRIPTION
## Scope and purpose

All other plugins also use Django validation error and not DRF. This was overlooked in #2023. 

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
