### PR TITLE
Fix auto refresh and pagination undoing sorting

### DIFF
--- a/changelog.d/2036.fixed.md
+++ b/changelog.d/2036.fixed.md
@@ -1,0 +1,1 @@
+Fixed the incident list sorting configuration not being preserved after a refresh and after changing the page

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_autorefresh.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_autorefresh.html
@@ -2,7 +2,7 @@
 {% with preferences.argus_htmx.update_interval as update_interval %}
   {% if update_interval != 'never' %}
     hx-get="{% url 'htmx:incident-list' %}"
-    hx-vals='{"page": "{{ page.number }}"}'
+    hx-vals='{"page": "{{ page.number }}", "sort": "{{ current_sort }}", "sort_order": "{{ current_sort_order }}"}'
     hx-target="this"
     hx-swap="outerHTML"
     hx-trigger="every {{ update_interval }}s"

--- a/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
+++ b/src/argus/htmx/templates/htmx/incident/_incident_table_paginator_pageitem.html
@@ -6,7 +6,7 @@ displayed as clickable.
 -->
 <li>
   <a hx-get="{% url 'htmx:incident-list' %}"
-     hx-vals='{"page": "{{ page_number }}"}'
+     hx-vals='{"page": "{{ page_number }}", "sort": "{{ current_sort }}", "sort_order": "{{ current_sort_order }}"}'
      href="{% querystring page=page_number %}"
      hx-indicator="#incident-list .htmx-indicator"
      hx-include=".incident-list-param"

--- a/tests/htmx/incident/test_sorting.py
+++ b/tests/htmx/incident/test_sorting.py
@@ -1,0 +1,35 @@
+from django import test
+from django.test.client import RequestFactory
+
+from argus.auth.factories import PersonUserFactory
+from argus.htmx.incident.constants import PAGE_SIZE_DEFAULT
+from argus.htmx.incident.views import incident_list
+from argus.htmx.user.factories import ArgusHtmxPreferencesFactory
+from argus.incident.constants import Level
+from argus.incident.factories import IncidentFactory
+from argus.util.testing import connect_signals, disconnect_signals
+
+
+class TestSortingPreservation(test.TestCase):
+    def setUp(self):
+        disconnect_signals()
+        self.addCleanup(connect_signals)
+
+        IncidentFactory.create_batch(PAGE_SIZE_DEFAULT + 1)
+        request = RequestFactory().get(
+            "/incidents",
+            {"sort": "level", "sort_order": "asc", "maxlevel": max(Level).value},
+        )
+        request.session = {}
+        request.user = PersonUserFactory()
+        request.htmx = False
+        preferences = ArgusHtmxPreferencesFactory(user=request.user)
+        preferences.preferences["incidents_table_column_name"] = "default"
+        preferences.save()
+        self.response = incident_list(request)
+
+    def test_given_non_default_sort_then_autorefresh_hx_vals_should_include_current_sort(self):
+        self.assertContains(self.response, '"page": "1", "sort": "level", "sort_order": "asc"')
+
+    def test_given_non_default_sort_and_multiple_pages_then_pagination_link_hx_vals_should_include_current_sort(self):
+        self.assertContains(self.response, '"page": "2", "sort": "level", "sort_order": "asc"')


### PR DESCRIPTION
## Scope and purpose

Fixes #2036. Also fixes related bug where pagination does not preserve sorting.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
