### PR TITLE
Add UI element informing of new version

### DIFF
--- a/changelog.d/1882.added.md
+++ b/changelog.d/1882.added.md
@@ -1,0 +1,1 @@
+Show a "new version available" indicator in the user menu for staff users when a newer Argus release is seen on PyPI

--- a/docs/development/management-commands.rst
+++ b/docs/development/management-commands.rst
@@ -532,8 +532,9 @@ To also save the latest version in the database, use the `--save` flag:
 
         $ python manage.py check_version --save
 
-This will currently not do anything, but in the future you will be able to get
-a notification in the frontend if there is a new release registered in the database that you haven't seen yet.
+If a newer version than the currently deployed version is found, then a badge
+will be shown in the user dropdown informing you that there is a new version.
+Only visible to staff accounts.
 
 Handling source heartbeats
 ==========================

--- a/src/argus/htmx/templates/htmx/user/_user_menu.html
+++ b/src/argus/htmx/templates/htmx/user/_user_menu.html
@@ -30,16 +30,22 @@
     <div class="divider divider-secondary my-0"></div>
   </li>
   <li aria-hidden="true" class="pointer-events-none h-0 p-0 m-0"></li>
-  <div class="text-xs grid grid-cols-[1fr_auto] gap-2 px-3 py-1.5">
-    <div class="space-y-2 text-left overflow-hidden select-text">
-      <span>Argus version:</span>
-      <span class="block truncate">{{ short_version }}</span>
+  <div class="text-xs px-3 py-1.5 space-y-1">
+    <div class="grid grid-cols-[1fr_auto] gap-2">
+      <div class="space-y-2 text-left overflow-hidden select-text">
+        <span>Argus version:</span>
+        <span class="block truncate">{{ short_version }}</span>
+      </div>
+      <button class="btn btn-ghost btn-xs pointer-events-auto"
+              aria-label="Copy Argus version to clipboard"
+              title="Copy version to clipboard"
+              onclick="navigator.clipboard.writeText('{{ version }}')">
+        <i class="fa-solid fa-copy"></i>
+      </button>
     </div>
-    <button class="btn btn-ghost btn-xs pointer-events-auto"
-            aria-label="Copy Argus version to clipboard"
-            title="Copy version to clipboard"
-            onclick="navigator.clipboard.writeText('{{ version }}')">
-      <i class="fa-solid fa-copy"></i>
-    </button>
+    {% if update_available %}
+      <span class="badge badge-warning badge-sm"
+            aria-label="New Argus version {{ latest_seen_version }} is available">Update available</span>
+    {% endif %}
   </div>
 </ul>

--- a/src/argus/site/settings/base.py
+++ b/src/argus/site/settings/base.py
@@ -117,6 +117,7 @@ TEMPLATES = [
                 "argus.htmx.context_processors.static_paths",
                 "argus.htmx.context_processors.metadata",
                 "argus.htmx.context_processors.banner_message",
+                "argus.versioncheck.context_processors.update_available",
             ],
         },
     }

--- a/src/argus/versioncheck/context_processors.py
+++ b/src/argus/versioncheck/context_processors.py
@@ -1,0 +1,53 @@
+"""
+How to use:
+
+Append the "context_processors" list for the TEMPLATES-backend
+``django.template.backends.django.DjangoTemplates`` with the full dotted path.
+
+See django settings for ``TEMPLATES``.
+"""
+
+from packaging.version import InvalidVersion, Version
+
+from argus.site.views import get_version
+from argus.versioncheck.models import LastSeenVersion
+
+
+def update_available(request):
+    if not getattr(request.user, "is_staff", False):
+        return {"update_available": False, "latest_seen_version": None}
+
+    latest_seen_version = _get_latest_seen_version()
+    is_newer = bool(latest_seen_version) and _is_newer(latest_seen_version, get_version())
+
+    return {
+        "update_available": is_newer,
+        "latest_seen_version": latest_seen_version,
+    }
+
+
+def _get_latest_seen_version():
+    # Compare by parsed version rather than by timestamp/insertion order, in
+    # case a lower version was ever recorded after a higher one (e.g. a
+    # stale/retried task).
+    parsed = []
+    for v in LastSeenVersion.objects.values_list("version", flat=True):
+        try:
+            parsed.append((Version(v).base_version, v))
+        except InvalidVersion:
+            continue
+    if not parsed:
+        return None
+    return max(parsed, key=lambda pair: Version(pair[0]))[1]
+
+
+def _is_newer(candidate_version, current_version):
+    # Compare base versions on both sides so a dev/post/local build of an
+    # already-released version (e.g. "2.8.0.post44+g58afd3be.d20260424")
+    # doesn't falsely appear outdated relative to its own release ("2.8.0").
+    try:
+        candidate = Version(Version(candidate_version).base_version)
+        current = Version(Version(current_version).base_version)
+    except (InvalidVersion, TypeError):
+        return False
+    return candidate > current

--- a/tests/versioncheck/test_context_processors.py
+++ b/tests/versioncheck/test_context_processors.py
@@ -1,0 +1,78 @@
+from unittest.mock import patch
+
+from django.test import RequestFactory, TestCase, tag
+
+from argus.auth.factories import AdminUserFactory, PersonUserFactory
+from argus.util.testing import connect_signals, disconnect_signals
+from argus.versioncheck.context_processors import update_available
+from argus.versioncheck.models import LastSeenVersion
+
+
+@tag("database")
+class TestUpdateAvailableContextProcessor(TestCase):
+    def setUp(self):
+        disconnect_signals()
+        self.factory = RequestFactory()
+
+    def tearDown(self):
+        connect_signals()
+
+    def _request_for(self, user):
+        request = self.factory.get("/")
+        request.user = user
+        return request
+
+    def test_given_non_staff_user_when_newer_version_exists_then_update_available_is_false(self):
+        LastSeenVersion.objects.create(version="999.0.0")
+        request = self._request_for(PersonUserFactory())
+        context = update_available(request)
+        assert context == {"update_available": False, "latest_seen_version": None}
+
+    def test_staff_user_sees_no_update_when_table_is_empty(self):
+        request = self._request_for(AdminUserFactory())
+        context = update_available(request)
+        assert not context["update_available"]
+        assert context["latest_seen_version"] is None
+
+    @patch("argus.versioncheck.context_processors.get_version")
+    def test_staff_user_sees_update_when_newer_version_is_seen(self, get_version):
+        get_version.return_value = "1.0.0"
+        LastSeenVersion.objects.create(version="1.1.0")
+        request = self._request_for(AdminUserFactory())
+        context = update_available(request)
+        assert context["update_available"]
+        assert context["latest_seen_version"] == "1.1.0"
+
+    @patch("argus.versioncheck.context_processors.get_version")
+    def test_staff_user_sees_no_update_when_current_version_is_latest(self, get_version):
+        get_version.return_value = "1.1.0"
+        LastSeenVersion.objects.create(version="1.1.0")
+        request = self._request_for(AdminUserFactory())
+        context = update_available(request)
+        assert not context["update_available"]
+
+    @patch("argus.versioncheck.context_processors.get_version")
+    def test_given_dev_build_of_latest_release_when_checking_then_update_available_is_false(self, get_version):
+        # Regression test: a setuptools-scm dev version of an already-released
+        # version must not be flagged as outdated relative to itself.
+        get_version.return_value = "2.8.0.post44+g58afd3be.d20260424"
+        LastSeenVersion.objects.create(version="2.8.0")
+        request = self._request_for(AdminUserFactory())
+        context = update_available(request)
+        assert not context["update_available"]
+
+    @patch("argus.versioncheck.context_processors.get_version")
+    def test_given_out_of_order_insertion_when_checking_then_takes_max_seen_version(self, get_version):
+        get_version.return_value = "1.0.0"
+        LastSeenVersion.objects.create(version="1.5.0")
+        LastSeenVersion.objects.create(version="1.2.0")
+        request = self._request_for(AdminUserFactory())
+        context = update_available(request)
+        assert context["latest_seen_version"] == "1.5.0"
+
+    def test_given_unparseable_version_row_when_checking_then_it_is_ignored(self):
+        LastSeenVersion.objects.create(version="not-a-version")
+        request = self._request_for(AdminUserFactory())
+        context = update_available(request)
+        assert not context["update_available"]
+        assert context["latest_seen_version"] is None


### PR DESCRIPTION
## Scope and purpose

Fixes #1882

Adds a badge next where the current version is displayed in the user dropdown. It just says that there is a new version,
wanted a discussion of exactly how we should alert of a new version before I did too much. Is it OK as it is? Should it say what the newest version is? link to pypi (or link via the pypi proxy if that is configured, the people who deploy the site gets to set the URL themselves, so the configured URL could br to either)? a banner at the top of the site instead? please discuss

before:
<img width="319" height="562" alt="image" src="https://github.com/user-attachments/assets/c7389c8e-c18b-4f8f-9957-3b51acd01f89" />


after:
<img width="319" height="562" alt="image" src="https://github.com/user-attachments/assets/90a9f4eb-817c-497b-8249-7b2dfcda4931" />

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
