### PR TITLE
Pin django-psycopg-infinity to 0.1.0

### DIFF
--- a/changelog.d/+pin-django-psycopg-infinity.fixed.md
+++ b/changelog.d/+pin-django-psycopg-infinity.fixed.md
@@ -1,0 +1,7 @@
+Pinned `django-psycopg-infinity` to 0.1.0. Version 0.1.1 changed infinity
+timestamps loaded from `timestamp with time zone` columns from local time to
+UTC. Since infinity is represented as a wall-clock sentinel rather than a true
+instant, the two are not equal, so an incident's `end_time` no longer compared
+equal to the infinity constant after being reloaded from the database. Among
+other things this made notifications for open incidents render an explicit
+far-future timestamp instead of "Still open".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "drf-rw-serializers>=1.1",
     "drf-spectacular>=0.17",
     "factory_boy",
-    "django-psycopg-infinity",
+    # Pinned: 0.1.1 changed tz-aware infinity semantics, breaking round-trip equality
+    "django-psycopg-infinity==0.1.0",
     "psycopg[c]",
     "python-dataporten-auth",
     "social-auth-core>=4.1",

--- a/requirements-django61.txt
+++ b/requirements-django61.txt
@@ -64,7 +64,7 @@ django-htmx==1.29.0
     # via argus-server (pyproject.toml)
 django-phonenumber-field[phonenumberslite]==8.5.0
     # via argus-server (pyproject.toml)
-django-psycopg-infinity==0.1.1
+django-psycopg-infinity==0.1.0
     # via argus-server (pyproject.toml)
 django-rest-knox==5.1.0
     # via argus-server (pyproject.toml)


### PR DESCRIPTION
## Scope and purpose

Pinning `django-psycopg-infinity` to 0.1.0 so today's release stays clear of a regression in 0.1.1.

0.1.1 changed how infinity comes back out of `timestamp with time zone` columns: it's UTC now, where before it got normalized to the default timezone. That sounds harmless, but infinity here is a wall-clock sentinel — `datetime.max` with a tzinfo label stuck on it — rather than a real instant. So UTC infinity and Oslo infinity are an hour apart and never compare equal.

The upshot is that `Incident.end_time` disagrees with itself. [`save()`](https://github.com/Uninett/Argus/blob/fbde6651d4dc339e3e1f3d7c041b5afed2ef8cb6/src/argus/incident/models.py#L432-L435) puts it through `to_python()` and gets local infinity back, while `refresh_from_db()` now hands over UTC infinity. Any `end_time == `[`LOCAL_INFINITY`](https://github.com/Uninett/Argus/blob/fbde6651d4dc339e3e1f3d7c041b5afed2ef8cb6/src/argus/util/datetime_utils.py#L18) check therefore stops working the moment the object has been reloaded. That's what has been failing the `django61` test environments on #1961.

While digging into that I noticed something that doesn't seem to have been spotted before: [`base.py`](https://github.com/Uninett/Argus/blob/fbde6651d4dc339e3e1f3d7c041b5afed2ef8cb6/src/argus/notificationprofile/media/base.py#L335) and [`email.py`](https://github.com/Uninett/Argus/blob/fbde6651d4dc339e3e1f3d7c041b5afed2ef8cb6/src/argus/notificationprofile/media/email.py#L78) both decide whether to print "Still open" using `end_time in {INFINITY, LOCAL_INFINITY}`. Under 0.1.1 a reloaded value matches neither member, so notifications for open incidents would show a literal `9999-12-31 23:59:59.999999+00:00` instead. `create_message_context` has no test coverage, so nothing would have warned us. The pin keeps it from biting us for now, but that logic wants rewriting regardless — testing against a set of timezone-labelled sentinels is fragile by construction.

Worth flagging that `pyproject.toml` had no version constraint at all, so even though the shipped `requirements.txt` was still on 0.1.0, a fresh `pip install argus-server` would already have pulled 0.1.1. Only `requirements-django61.txt` had 0.1.1 pinned (it came in with #2025), which is why this surfaced on Python 3.12+ and nowhere else.

This is a stopgap rather than a fix. What the library really wants is a single timezone-independent infinity sentinel that compares greater than any datetime, naive or aware, so none of this depends on which timezone label a value happens to be carrying. Once that exists the pin can come off.

### This pull request
* changes a dependency

## Contributor Checklist

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
  I added one, but doubtful it is really needed, as this doesn't really represent a user-facing change, the fix tries to prevent things changing for the user :wink:
* [ ] Added/amended tests for new/changed code
  Nothing to add for a version pin — the tests that fail against 0.1.1 pass unchanged against 0.1.0. The genuinely uncovered path (`create_message_context`) is better covered alongside the library-side fix than here.
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
  Not filed yet — the follow-up is the library-side sentinel work described above.
