### PR TITLE
Add function to base ticket plugin to get ticket identifier for given incident

### DIFF
--- a/changelog.d/2047.added.md
+++ b/changelog.d/2047.added.md
@@ -1,0 +1,1 @@
+Added function to return a ticket identifier for an incident to the base ticket class

--- a/docs/integrations/ticket-systems/writing-ticket-system-plugins.rst
+++ b/docs/integrations/ticket-systems/writing-ticket-system-plugins.rst
@@ -34,3 +34,8 @@ page should be returned.
 
 The method ``create_ticket`` is called within Argus when a user wants to create
 a ticket.
+
+If the ticket system has some kind of identifier that is within the url then
+the method ``get_ticket_identifier`` should return that identifier (id, hash,
+etc.). This identifier will be used in the incident to easier identify a
+ticket.

--- a/src/argus/incident/ticket/base.py
+++ b/src/argus/incident/ticket/base.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from django.conf import settings
 from django.template.loader import render_to_string
 
+from ..models import Incident
+
 __all__ = [
     "TicketClientException",
     "TicketCreationException",
@@ -92,3 +94,13 @@ class TicketPlugin(ABC):
         Raises a TicketCreationException in case of any errors
         """
         return None
+
+    @staticmethod
+    def get_ticket_identifier(incident: Incident):
+        """
+        Returns an identifier (e.g. id, number, hash) for the associated ticket
+        of an incident
+
+        This can be used to easier identify a ticket in the incident list
+        """
+        return incident.ticket_url


### PR DESCRIPTION
## Scope and purpose

All ticket plugins should implement this to return a shorter identifier than the url. This will be used to show the identifier in the incident list to easier identify a ticket.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [X] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
