### PR TITLE
Correct connecting incidents to PM tasks

### DIFF
--- a/changelog.d/2049.fixed.md
+++ b/changelog.d/2049.fixed.md
@@ -1,0 +1,1 @@
+Fixed connecting ongoing planned maintenance tasks with incidents that are being covered by them

--- a/src/argus/plannedmaintenance/models.py
+++ b/src/argus/plannedmaintenance/models.py
@@ -119,13 +119,13 @@ class PlannedMaintenanceTask(models.Model):
         self.save()
 
     def connect_covered_incidents(self):
-        """Adds all incidents that are covered by the task to the incidents field"""
+        """Set the incidents field to all incidents that are covered by the task"""
 
         from .utils import incidents_covered_by_planned_maintenance_task
 
-        queryset = Incident.objects.exclude(planned_maintenance_tasks__pk=self.pk)
-
-        covered_incidents = incidents_covered_by_planned_maintenance_task(queryset=queryset, pm_task=self)
+        # Find all incidents covered by PM, calculate this anew in case a filter was added/removed from the PM
+        covered_incidents = incidents_covered_by_planned_maintenance_task(queryset=Incident.objects.all(), pm_task=self)
+        # Set replaces the currently connected incidents with the newly calculated ones
         self.incidents.set(covered_incidents)
 
     def clean(self):

--- a/tests/plannedmaintenance/test_models.py
+++ b/tests/plannedmaintenance/test_models.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase, tag
 from django.utils import timezone
 
+from argus.filter.factories import FilterFactory
+from argus.incident.factories import StatefulIncidentFactory
 from argus.plannedmaintenance.factories import PlannedMaintenanceFactory
 from argus.plannedmaintenance.models import MODIFICATION_WINDOW_PM, PlannedMaintenanceTask
 from argus.util.testing import disconnect_signals, connect_signals
@@ -188,3 +190,74 @@ class PlannedMaintenanceTaskTests(TestCase):
             recently_ended_pm.save()
         recently_ended_pm.refresh_from_db()
         self.assertEqual(recently_ended_pm.start_time, original_start)
+
+
+@tag("database")
+class TestConnectCoveredIncidents(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+        self.incident = StatefulIncidentFactory(level=2)
+        self.incident2 = StatefulIncidentFactory(level=3)
+
+        self.filter_maxlevel_2 = FilterFactory(filter={"maxlevel": 2})
+        self.pm_maxlevel_2 = PlannedMaintenanceFactory()
+        self.pm_maxlevel_2.filters.add(self.filter_maxlevel_2)
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_given_pm_without_connected_incidents_then_connect_new_incidents_that_are_covered(self):
+        self.pm_maxlevel_2.connect_covered_incidents()
+
+        self.assertIn(self.incident, self.pm_maxlevel_2.incidents.all())
+        self.assertNotIn(self.incident2, self.pm_maxlevel_2.incidents.all())
+
+    def test_given_pm_with_connected_incidents_then_do_not_remove_those_incidents(self):
+        self.pm_maxlevel_2.incidents.add(self.incident)
+
+        self.pm_maxlevel_2.connect_covered_incidents()
+
+        self.assertIn(self.incident, self.pm_maxlevel_2.incidents.all())
+        self.assertNotIn(self.incident2, self.pm_maxlevel_2.incidents.all())
+
+    def test_given_pm_with_connected_incidents_and_new_covered_incidents_then_add_covered_incidents(self):
+        filter_maxlevel_3 = FilterFactory(filter={"maxlevel": 3})
+        pm_maxlevel_3 = PlannedMaintenanceFactory()
+        pm_maxlevel_3.filters.add(filter_maxlevel_3)
+        pm_maxlevel_3.incidents.add(self.incident)
+
+        pm_maxlevel_3.connect_covered_incidents()
+
+        self.assertIn(self.incident, pm_maxlevel_3.incidents.all())
+        self.assertIn(self.incident2, pm_maxlevel_3.incidents.all())
+
+    def test_given_pm_with_connected_incidents_and_replaced_filter_then_reset_covered_incidents(self):
+        filter_maxlevel_3 = FilterFactory(filter={"maxlevel": 3})
+        pm_maxlevel_3 = PlannedMaintenanceFactory()
+        pm_maxlevel_3.filters.add(filter_maxlevel_3)
+
+        # Call it once to sync incidents
+        pm_maxlevel_3.connect_covered_incidents()
+
+        self.assertIn(self.incident, pm_maxlevel_3.incidents.all())
+        self.assertIn(self.incident2, pm_maxlevel_3.incidents.all())
+
+        # Replace filter of PM
+        pm_maxlevel_3.filters.remove(filter_maxlevel_3)
+        pm_maxlevel_3.filters.add(self.filter_maxlevel_2)
+
+        # Call it again to sync incidents anew
+        pm_maxlevel_3.connect_covered_incidents()
+
+        self.assertIn(self.incident, pm_maxlevel_3.incidents.all())
+        self.assertNotIn(self.incident2, pm_maxlevel_3.incidents.all())
+
+    def test_given_pm_with_connected_incident_that_was_closed_then_remove_incident_from_connected_incidents(self):
+        self.pm_maxlevel_2.incidents.add(self.incident)
+        self.incident.set_end(actor=self.incident.source.user)
+
+        self.pm_maxlevel_2.connect_covered_incidents()
+
+        self.assertNotIn(self.incident, self.pm_maxlevel_2.incidents.all())
+        self.assertNotIn(self.incident2, self.pm_maxlevel_2.incidents.all())


### PR DESCRIPTION
## Scope and purpose

I've been alerted by the NOC that incidents are not correctly are being associated with ongoing PM tasks - the strange behavior is that incidents are being correctly connected (as shown in the PM column) and then on the next run of the management command `check_started_maintenance` they are disconnected again. And on the next run connected again and so forth...

How to reproduce:
1. Add a planned maintenance tasks covering some open incidents.
2. Run the management command `check_started_maintenance` once. Observe in the frontend (in the PM column) or in the admin that all the correct incidents are being connected to the PM task.
3. Run the management command `check_started_maintenance` again. Observe that now all the incidents are disconnected.

Reason:
On each run [`connect_covered_incidents`](https://github.com/Uninett/Argus/blob/e04ff94e6dc1f5eb27cd5d4eca42c0bd55442a4a/src/argus/plannedmaintenance/models.py#L121-L129) only looks for new covered incidents, but ignores the already covered incidents and then uses `set` to set these new covered incidents, but that way removing the currently connected incidents. 

With this fix we calculate all covered incidents anew from all open incidents.

Another option would have been to just add the new incidents instead of replacing the incidents, but in case of a filter being updated/removed/added from a PM task we would not know if the already added incidents are correct and they might still be counted as covered even though the current connected filter does not hit these anymore.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [X] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [X] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [X] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [X] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
