### PR TITLE
Manual check for new version

### DIFF
--- a/changelog.d/2052.added.md
+++ b/changelog.d/2052.added.md
@@ -1,0 +1,1 @@
+Added button to about page to trigger a check for new versions. Staff only!

--- a/src/argus/htmx/context_processors.py
+++ b/src/argus/htmx/context_processors.py
@@ -12,6 +12,7 @@ from packaging.version import InvalidVersion, Version
 
 from . import defaults
 from argus.site.views import get_version
+from argus.versioncheck.utils import get_latest_registered_version
 
 
 def static_paths(request):
@@ -31,8 +32,27 @@ def banner_message(request):
 
 def metadata(request):
     full_version = get_version()
+    latest_version = None
+    latest_version_change = None
+    support_release_watching = False
+
+    try:
+        versionobj = get_latest_registered_version()
+        support_release_watching = True
+        if versionobj:
+            latest_version = versionobj.version
+            latest_version_change = versionobj.upload_time
+    except Exception:
+        pass
+
     try:
         short_version = str(Version(full_version).base_version)
     except (InvalidVersion, TypeError):
         short_version = full_version or ""
-    return {"version": full_version, "short_version": short_version}
+    return {
+        "version": full_version,
+        "short_version": short_version,
+        "latest_version": latest_version,
+        "latest_version_change": latest_version_change,
+        "support_release_watching": support_release_watching,
+    }

--- a/src/argus/htmx/templates/htmx/about.html
+++ b/src/argus/htmx/templates/htmx/about.html
@@ -4,6 +4,27 @@
   <div class="flex justify-center p-4">
     <section class="flex flex-col gap-4 max-w-4xl w-full">
       <h1 class="text-3xl font-semibold text-center mt-3 mb-4">Argus v{{ short_version }}</h1>
+      {% if support_release_watching %}
+        {% if latest_version %}
+          <h2 class="text-2xl">Latest release: {{ latest_version }}</h2>
+          <ul>
+            <li>Uploaded {{ latest_version_change }}</li>
+            <li><a class="link"
+   href="https://pypi.org/project/argus-server/{{ latest_version }}/">PyPI: argus-server {{ latest_version }}</a></li>
+            <li><a class="link"
+   href="https://github.com/Uninett/Argus/releases/tag/v{{ latest_version }}">Changelog and tarballs on Github</a></li>
+          </ul>
+        {% else %}
+          <h2 class="text-2xl">Latest release: none fetched</h2>
+        {% endif %}
+        {% if request.user.is_authenticated and request.user.is_staff %}
+          <form method="post"
+                action="{% url "check-for-new-version" %}{% querystring next=request.path %}">
+            {% csrf_token %}
+            <input type="submit" class="btn btn-primary" value="Check for new releases">
+          </form>
+        {% endif %}
+      {% endif %}
       <h2 class="text-2xl">Contact info, mailing lists etc.</h2>
       <p><a href="https://network.geant.org/argus/" class="link">Official Argus landing page @ GÉANT</a></p>
       <h2 class="text-2xl">Documentation</h2>

--- a/src/argus/site/urls.py
+++ b/src/argus/site/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path(".error/", error, name="error"),
     path(".still-alive/", health_check),  # doesn't need a name
     path("about/", about, name="about"),
+    path("about/", include("argus.versioncheck.urls")),
     path("admin/", admin.site.urls),
     path(
         "api/schema/",

--- a/src/argus/versioncheck/urls.py
+++ b/src/argus/versioncheck/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views import check_for_new_version
+
+
+urlpatterns = [
+    path("check", check_for_new_version, name="check-for-new-version"),
+]

--- a/src/argus/versioncheck/utils.py
+++ b/src/argus/versioncheck/utils.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 import requests
 
 from django.conf import settings
+from django.db import transaction
 
 from argus.versioncheck.models import PyPIVersion
 from argus.site.views import get_version
@@ -94,6 +95,7 @@ def register_and_return_latest_version(suppress_errors: bool = True) -> Tuple[Op
     return register_version(latest_version, upload_time)
 
 
+@transaction.atomic
 def register_version(latest_version, upload_time) -> Tuple[PyPIVersion, bool]:
     """Save a new version"""
     qs = PyPIVersion.objects.select_for_update()

--- a/src/argus/versioncheck/views.py
+++ b/src/argus/versioncheck/views.py
@@ -1,0 +1,32 @@
+import logging
+from datetime import timedelta
+
+from django import forms
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.timezone import now
+from django.views.decorators.http import require_POST
+
+from .utils import get_latest_registered_version, register_and_return_latest_version
+
+LOG = logging.getLogger(__name__)
+
+
+class ParamForm(forms.Form):
+    next = forms.CharField()
+
+
+@require_POST
+def check_for_new_version(request):
+    latest_registered = get_latest_registered_version()
+    if not latest_registered or latest_registered.upload_time < now() - timedelta(hours=12):
+        LOG.info("Checking for new version of argus")
+        register_and_return_latest_version()
+
+    params = ParamForm(request.GET)
+    if params.is_valid():
+        next = params.cleaned_data["next"]
+    else:
+        next = reverse("about")
+
+    return redirect(to=next)


### PR DESCRIPTION
## Scope and purpose

Depends on #2051.

Add a button for staff to the about page to manually check for new versions.

## Screenshot

Before: <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/4afbeceb-e53c-4930-bb29-037235a44724" />

After: 
<img width="1280" height="822" alt="image" src="https://github.com/user-attachments/assets/ae96e800-4c1d-41db-b5d6-9f98aedb6082" />

## How to test

If the migrations in #2051 has not been run you should have the "before" about page.

After running migrations you should have a "Latest release: none fetched" instead of the header in the after image.

If you are staff and click the button, you should get the "after" about page.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [x] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
