### PR TITLE
Represent ticket with per-plugin identifier

### DIFF
--- a/changelog.d/1710.changed.md
+++ b/changelog.d/1710.changed.md
@@ -1,0 +1,1 @@
+Represent tickets using a per-plugin identifier.

--- a/src/argus/htmx/templates/htmx/incident/cells/_incident_ticket.html
+++ b/src/argus/htmx/templates/htmx/incident/cells/_incident_ticket.html
@@ -1,12 +1,5 @@
 <!-- htmx/incident/cells/_incident_ticket.html -->
+{% load argus_htmx %}
 {% if incident.ticket_url %}
-  <a class="link" href="{{ incident.ticket_url }}" target="_blank">
-    <svg class="size-5 fill-primary"
-         focusable="false"
-         viewBox="0 0 24 24"
-         aria-hidden="true">
-      <path d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z">
-      </path>
-    </svg>
-  </a>
+  <a class="link" href="{{ incident.ticket_url }}" target="_blank">{{ incident|ticket_identifier }}</a>
 {% endif %}

--- a/src/argus/htmx/templates/htmx/incident/incident_detail.html
+++ b/src/argus/htmx/templates/htmx/incident/incident_detail.html
@@ -25,7 +25,7 @@
                 <span class="badge badge-error">Unacknowledged</span>
               {% endif %}
               {% if incident.ticket_url %}
-                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
+                <span class="badge badge-success h-auto text-wrap break-all text-center"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident|ticket_identifier }}</a></span>
               {% else %}
                 <span class="badge badge-error">No ticket</span>
               {% endif %}
@@ -109,7 +109,7 @@
                 <div class="flex flex-col gap-2">
                   <div>
                     {% if incident.ticket_url %}
-                      <a class="link" href="{{ incident.ticket_url }}" target="_blank">{{ incident.ticket_url }}</a>
+                      <a class="link" href="{{ incident.ticket_url }}" target="_blank">{{ incident|ticket_identifier }}</a>
                     {% else %}
                       —
                     {% endif %}

--- a/src/argus/htmx/templatetags/argus_htmx.py
+++ b/src/argus/htmx/templatetags/argus_htmx.py
@@ -9,6 +9,9 @@ from django.core.validators import URLValidator
 from django.utils.timesince import timesince, timeuntil
 from django.utils.timezone import now as tznow
 
+from argus.incident.ticket.base import TicketPluginException
+from argus.incident.ticket.utils import get_autocreate_ticket_plugin
+
 from .. import defaults
 
 register = template.Library()
@@ -92,6 +95,22 @@ def update_interval_string(value: int | Literal["never"]):
     if value == "never":
         return "Never"
     return f"{value}s"
+
+
+@register.filter
+def ticket_identifier(incident) -> str:
+    """Return a short display identifier for an incident's ticket
+
+    Falls back to the raw ticket_url if no ticket plugin is configured
+    or resolving/calling it fails for any reason.
+    """
+    if not incident or not incident.ticket_url:
+        return ""
+    try:
+        plugin = get_autocreate_ticket_plugin()
+        return plugin.get_ticket_identifier(incident)
+    except TicketPluginException:
+        return incident.ticket_url
 
 
 @register.filter

--- a/tests/htmx/test_templatetags.py
+++ b/tests/htmx/test_templatetags.py
@@ -1,9 +1,14 @@
 from unittest import TestCase
+from unittest.mock import patch
 from datetime import timedelta
 
-from django.test import tag
+from django.test import TestCase as DjangoTestCase, override_settings, tag
 
-from argus.htmx.templatetags.argus_htmx import dictvalue, pretty_timedelta
+from argus.htmx.templatetags.argus_htmx import dictvalue, pretty_timedelta, ticket_identifier
+from argus.incident.factories import StatefulIncidentFactory
+from argus.incident.ticket.dummy import DummyPlugin
+from argus.incident.ticket.utils import SETTING_NAME
+from argus.util.testing import connect_signals, disconnect_signals
 
 
 @tag("unit")
@@ -46,3 +51,27 @@ class PrettyTimedeltaTest(TestCase):
         self.assertEqual(result, "0\xa0minutes")
         result = pretty_timedelta(timedelta(seconds=-100000))
         self.assertEqual(result, "0\xa0minutes")
+
+
+@tag("unit")
+class TicketIdentifierTests(DjangoTestCase):
+    def setUp(self):
+        disconnect_signals()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_when_incident_has_no_ticket_url_returns_empty_string(self):
+        incident = StatefulIncidentFactory(ticket_url="")
+        self.assertEqual(ticket_identifier(incident), "")
+
+    @override_settings(**{SETTING_NAME: None})
+    def test_when_no_ticket_plugin_is_configured_falls_back_to_ticket_url(self):
+        incident = StatefulIncidentFactory(ticket_url="https://example.com/ticket/123")
+        self.assertEqual(ticket_identifier(incident), incident.ticket_url)
+
+    @override_settings(**{SETTING_NAME: "argus.incident.ticket.dummy.DummyPlugin"})
+    def test_when_ticket_plugin_is_configured_uses_its_get_ticket_identifier(self):
+        incident = StatefulIncidentFactory(ticket_url="https://example.com/ticket/123")
+        with patch.object(DummyPlugin, "get_ticket_identifier", return_value="TICKET-1"):
+            self.assertEqual(ticket_identifier(incident), "TICKET-1")


### PR DESCRIPTION
## Scope and purpose

Fixes #1710 (Changes still required in repos for the individual plugins)

This PR makes use of the per-plugin function giving an identifier for a ticket, but still requires the plugins to make use of the function and override the default behavior of defaulting to the URL itself.

Before:

<img width="468" height="1314" alt="image" src="https://github.com/user-attachments/assets/eda2f0ee-0273-4d1d-bc2a-761bf6d6489d" />


<img width="189" height="132" alt="image" src="https://github.com/user-attachments/assets/8f64723d-8169-4835-ba65-6c73cd680b61" />


After:

<img width="442" height="1348" alt="image" src="https://github.com/user-attachments/assets/ad1597e2-8888-4823-91aa-b2c0e003b8d9" />

<img width="189" height="132" alt="image" src="https://github.com/user-attachments/assets/10769666-05b5-4061-8cdb-49ff81c2dd6c" />


Tested by using the DummyPlugin and overriding `get_ticket_identifier`

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [x] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [x] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
