### PR TITLE
Fix django-tasks dependency

### DIFF
--- a/changelog.d/+django-tasks-db-upgrade.changed.md
+++ b/changelog.d/+django-tasks-db-upgrade.changed.md
@@ -1,0 +1,4 @@
+We now explicitly depend on "django-tasks" since how "django-tasks-db" depends
+on "django-tasks" has changed. We cannot do it the new way, by depending on
+"django-tasks-db[compat]", since that conflicts with Django 6.1, which we still
+want to be able to test on.

--- a/changelog.d/+django-tasks-db-upgrade.fixed.md
+++ b/changelog.d/+django-tasks-db-upgrade.fixed.md
@@ -1,0 +1,2 @@
+Fixed a dependency issue with the most recent "django-tasks-db", by always
+depending directly on "djabgo-tasks".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "dj-database-url>=0.5.0",
     "django-cors-headers>=3.2",
     "django-filter",
+    "django-tasks",
     "django-tasks-db",
     "django-phonenumber-field[phonenumberslite]",
     "djangorestframework>=3.14",

--- a/requirements-django52.txt
+++ b/requirements-django52.txt
@@ -71,8 +71,8 @@ django-stubs-ext==5.2.9
     #   django-tasks
     #   django-tasks-db
 django-tasks==0.12.0
-    # via django-tasks-db
-django-tasks-db==0.12.0
+    # via argus-server (pyproject.toml)
+django-tasks-db==0.13.0
     # via argus-server (pyproject.toml)
 django-widget-tweaks==1.5.0
     # via argus-server (pyproject.toml)

--- a/requirements-django61.txt
+++ b/requirements-django61.txt
@@ -73,8 +73,8 @@ django-stubs-ext==6.0.9
     #   django-tasks
     #   django-tasks-db
 django-tasks==0.12.0
-    # via django-tasks-db
-django-tasks-db==0.12.0
+    # via argus-server (pyproject.toml)
+django-tasks-db==0.13.0
     # via argus-server (pyproject.toml)
 django-widget-tweaks==1.5.0
     # via argus-server (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,8 +71,8 @@ django-stubs-ext==5.2.9
     #   django-tasks
     #   django-tasks-db
 django-tasks==0.12.0
-    # via django-tasks-db
-django-tasks-db==0.12.0
+    # via argus-server (pyproject.toml)
+django-tasks-db==0.13.0
     # via argus-server (pyproject.toml)
 django-widget-tweaks==1.5.0
     # via argus-server (pyproject.toml)


### PR DESCRIPTION
## Scope and purpose

"django-tasks-db" no longer directly depends on "django-tasks" meaning it was not installed if bypassing our Django version-specific requirements-files and using pyproject.toml directly.

Therefore let's specifically depend on "django-tasks".

### This pull request
* adds/changes/removes a dependency

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
