### PR TITLE
Normalize version number used for UA

### DIFF
--- a/src/argus/site/views.py
+++ b/src/argus/site/views.py
@@ -1,5 +1,7 @@
 import logging
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version as import_version
+
+from packaging.version import InvalidVersion, parse as parse_version
 
 from django.conf import settings
 from django.http import (
@@ -25,6 +27,14 @@ LOG = logging.getLogger(__name__)
 
 
 def get_version():
+    version = _get_version()
+    try:
+        return str(parse_version(version))
+    except InvalidVersion:
+        return "unknown"
+
+
+def _get_version():
     try:
         from argus.version import __version__
 
@@ -32,10 +42,10 @@ def get_version():
     except (ModuleNotFoundError, ImportError):
         pass
     try:
-        return version("argus-server")
-    except PackageNotFoundError as e:
-        return str(e)
-    return "version not found"
+        return import_version("argus-server")
+    except PackageNotFoundError:
+        pass
+    return "unknown"
 
 
 # HTML


### PR DESCRIPTION
## Scope and purpose

"get_version" is insufficiently normalized for User Agent for version check purposes so we normalize it further, either to a valid version or to the string "invalid", nothing else.

Open question: instead of only changing for version check we might want to alter "get_version()" itself, but then "invalid" might be the wrong string for an invalid version.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [ ] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->