### PR TITLE
Add management command "find_unset_last_seen"

### DIFF
--- a/changelog.d/+cmd-find-unset-lastseen.added.md
+++ b/changelog.d/+cmd-find-unset-lastseen.added.md
@@ -1,4 +1,4 @@
-Added management command to find the latest event from sources that does
+Added management command to find the latest event from sources that do
 not have `last_seen` set. Such sources might have been removed from
 production, something might be wrong with them like using an outdated
 API endpoint, or they were never put into production in the first place.

--- a/changelog.d/+cmd-find-unset-lastseen.added.md
+++ b/changelog.d/+cmd-find-unset-lastseen.added.md
@@ -1,0 +1,4 @@
+Added management command to find the latest event from sources that does
+not have `last_seen` set. Such sources might have been removed from
+production, something might be wrong with them like using an outdated
+API endpoint, or they were never put into production in the first place.

--- a/docs/development/management-commands.rst
+++ b/docs/development/management-commands.rst
@@ -259,26 +259,26 @@ To add a custom source system type, instead of the default `argus`, add the
 
         $ python manage.py create_source -t "Custom type"
 
-.. _find-unset_last-seen:
+.. _find-unset-last-seen:
 
 Find unset last seen
 --------------------
 
-For sources that does not have ``last_seen`` set, it finds when
-the latest event was received.
+For sources that do not have ``last_seen`` set, it finds when
+the latest event was received from each source.
 
     .. code:: console
 
         $ python manage.py find_unset_last_seen
 
-The ``-s``-flag saves the latest recived timetamp into the ``last_seen``
+The ``-s``-flag saves the latest received timestamp into the ``last_seen``
 field:
 
     .. code:: console
 
         $ python manage.py find_unset_last_seen -s
 
-VThe output can be hidden by setting verbosity to 0:
+The output can be hidden by setting verbosity to 0:
 
     .. code:: console
 

--- a/docs/development/management-commands.rst
+++ b/docs/development/management-commands.rst
@@ -259,6 +259,30 @@ To add a custom source system type, instead of the default `argus`, add the
 
         $ python manage.py create_source -t "Custom type"
 
+.. _find-unset_last-seen:
+
+Find unset last seen
+--------------------
+
+For sources that does not have ``last_seen`` set, it finds when
+the latest event was received.
+
+    .. code:: console
+
+        $ python manage.py find_unset_last_seen
+
+The ``-s``-flag saves the latest recived timetamp into the ``last_seen``
+field:
+
+    .. code:: console
+
+        $ python manage.py find_unset_last_seen -s
+
+VThe output can be hidden by setting verbosity to 0:
+
+    .. code:: console
+
+        $ python manage.py find_unset_last_seen -v 0
 
 .. _check-token-expiry:
 

--- a/src/argus/incident/management/commands/find_unset_last_seen.py
+++ b/src/argus/incident/management/commands/find_unset_last_seen.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from argus.incident.models import SourceSystem, Event
+from argus.incident.models import Event, SourceSystem
 
 
 def find_latest_event_by_heartbeatless_source():

--- a/src/argus/incident/management/commands/find_unset_last_seen.py
+++ b/src/argus/incident/management/commands/find_unset_last_seen.py
@@ -1,0 +1,48 @@
+from django.core.management.base import BaseCommand
+
+from argus.incident.models import SourceSystem, Event
+
+
+def find_latest_event_by_heartbeatless_source():
+    qs = SourceSystem.objects
+    changes = []
+    never_seen = []
+    for source in qs.filter(last_seen__isnull=True).order_by("name"):
+        try:
+            event = Event.objects.filter(actor=source.user).only("received").latest("received")
+        except Event.DoesNotExist:
+            never_seen.append(source)
+        else:
+            changes.append((source, event.received))
+    return changes, never_seen
+
+
+class Command(BaseCommand):
+    help = "Find timestamp of latest received events from sources with unset last_seen"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-s",
+            "--save",
+            action="store_true",
+            help="Update last_seen with latest change",
+        )
+
+    def handle(self, *args, **options):
+        changes, never_seen = find_latest_event_by_heartbeatless_source()
+
+        if changes:
+            if options["verbosity"]:
+                self.stdout.write("Possibly dead sources:\n")
+        for source, last_seen in changes:
+            if options["verbosity"]:
+                self.stdout.write(f"{source}: {last_seen}")
+            if options["save"]:
+                source.last_seen = last_seen
+                source.save()
+
+        if never_seen and options["verbosity"] > 0:
+            if changes:
+                self.stdout.write("")
+            self.stdout.write("Never seen, never put into production?")
+            self.stdout.write(", ".join(source.name for source in never_seen))

--- a/tests/incident/management_commands/test_find_unset_last_seen.py
+++ b/tests/incident/management_commands/test_find_unset_last_seen.py
@@ -1,0 +1,121 @@
+from io import StringIO
+import contextlib
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from argus.incident.factories import (
+    SourceSystemFactory,
+    SourceSystemTypeFactory,
+    SourceUserFactory,
+    StatefulIncidentFactory,
+)
+from argus.incident.management.commands.find_unset_last_seen import find_latest_event_by_heartbeatless_source
+from argus.incident.models import Event
+from argus.util.testing import connect_signals, disconnect_signals
+
+
+class FindLatestEventByHeartbeatlessSourceTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_given_no_unset_last_seen_sources_then_return_empty_lists(self):
+        name = "setlastseen"
+        user = SourceUserFactory(username=name)
+        sst = SourceSystemTypeFactory(name=name)
+        SourceSystemFactory(user=user, name=name, type=sst, last_seen=timezone.now())
+
+        changes, never_seen = find_latest_event_by_heartbeatless_source()
+        self.assertEqual(changes, [])
+        self.assertEqual(never_seen, [])
+
+    def test_given_unset_last_seen_source_with_connected_event_then_return_source_in_changes(self):
+        name = "nolastseen"
+        user = SourceUserFactory(username=name)
+        sst = SourceSystemTypeFactory(name=name)
+        source = SourceSystemFactory(user=user, name=name, type=sst)
+        incident = StatefulIncidentFactory(source=source)
+        now = timezone.now()
+        Event.objects.create(
+            incident=incident,
+            actor=source.user,
+            timestamp=now,
+            received=now,
+            type=Event.Type.INCIDENT_START,
+            description="",
+        )
+
+        changes, never_seen = find_latest_event_by_heartbeatless_source()
+        self.assertIn((source, now), changes)
+        self.assertEqual(never_seen, [])
+
+    def test_given_unset_last_seen_source_without_connected_events_then_return_source_as_never_seen(self):
+        name = "nolastseen"
+        user = SourceUserFactory(username=name)
+        sst = SourceSystemTypeFactory(name=name)
+        source = SourceSystemFactory(user=user, name=name, type=sst)
+
+        changes, never_seen = find_latest_event_by_heartbeatless_source()
+        self.assertEqual(changes, [])
+        self.assertIn(source, never_seen)
+
+
+class FindUnsetLastSeenTests(TestCase):
+    def setUp(self):
+        disconnect_signals()
+
+        self.name = "nolastseen"
+        self.user = SourceUserFactory(username=self.name)
+        self.sst = SourceSystemTypeFactory(name=self.name)
+        self.source = SourceSystemFactory(user=self.user, name=self.name, type=self.sst)
+
+    def tearDown(self):
+        connect_signals()
+
+    def test_given_unset_last_seen_source_with_connected_event_then_print_source_as_possibly_dead(self):
+        now = timezone.now()
+        incident = StatefulIncidentFactory(source=self.source)
+        Event.objects.create(
+            incident=incident,
+            actor=self.source.user,
+            timestamp=now,
+            received=now,
+            type=Event.Type.INCIDENT_START,
+            description="",
+        )
+        F = StringIO()
+
+        with contextlib.redirect_stdout(F):
+            call_command("find_unset_last_seen", verbosity=2)
+
+        output = F.getvalue().strip()
+        self.assertIn(f"Possibly dead sources:\n{self.source}: {now}", output)
+
+    def test_given_unset_last_seen_source_without_connected_events_then_print_source_as_never_seen(self):
+        F = StringIO()
+
+        with contextlib.redirect_stdout(F):
+            call_command("find_unset_last_seen", verbosity=2)
+
+        output = F.getvalue().strip()
+        self.assertIn(f"Never seen, never put into production?\n{self.name}", output)
+
+    def test_given_unset_last_seen_source_with_connected_event_then_save_last_seen_to_event_received_timestamp(self):
+        now = timezone.now()
+        incident = StatefulIncidentFactory(source=self.source)
+        Event.objects.create(
+            incident=incident,
+            actor=self.source.user,
+            timestamp=now,
+            received=now,
+            type=Event.Type.INCIDENT_START,
+            description="",
+        )
+        call_command("find_unset_last_seen", "--save", verbosity=0)
+
+        self.source.refresh_from_db()
+        self.assertEqual(self.source.last_seen, now)


### PR DESCRIPTION
## Scope and purpose

Used to find when a source without `last_seen` set last made an event, to help figure out *why* `last_seen` has not been set.

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [x] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [x] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
