### PR TITLE
Log when /api/incidents/ POST fail

### DIFF
--- a/src/argus/incident/v2/views.py
+++ b/src/argus/incident/v2/views.py
@@ -146,6 +146,10 @@ class BaseIncidentViewSet(
     queryset = Incident.objects.prefetch_default_related()
     search_fields = ["description", "search_text"]
 
+    def raise_uncaught_exception(self, exc):
+        LOG.warning("Failed posting incident:  %s", exc)
+        return super().raise_uncaught_exception(exc)
+
     def get_serializer_class(self):
         if self.request.method in {"PUT", "PATCH"}:
             return IncidentPureDeserializer
@@ -162,20 +166,24 @@ class BaseIncidentViewSet(
         user = self.request.user
 
         if "source" in serializer.initial_data:
+            source_pk = serializer.initial_data["source"]
+
             if not user.is_superuser:
+                LOG.warning("Failed posting incident: non-super user source %i specified source-field", source_pk)
                 raise serializers.ValidationError(
                     "You must be a superuser to be allowed to specify the 'source' field."
                 )
 
-            source_pk = serializer.initial_data["source"]
             try:
                 source = SourceSystem.objects.get(pk=source_pk)
             except SourceSystem.DoesNotExist:
+                LOG.warning("Failed posting incident: source %i does not exist", source_pk)
                 raise ValidationError(f"SourceSystem with pk={source_pk} does not exist.")
         else:
             try:
                 source = user.source_system
             except SourceSystem.DoesNotExist:
+                LOG.warning("Failed posting incident: invalid source, user_id  %i", user.pk)
                 raise ValidationError("The requesting user must have a connected source system.")
 
         # TODO: send notifications to users
@@ -183,6 +191,7 @@ class BaseIncidentViewSet(
             serializer.save(user=user, source=source)
         except IntegrityError as e:
             # TODO: this should be replaced by more verbose feedback, that also doesn't reference database tables
+            LOG.warning("Failed posting incident: %s", e)
             raise serializers.ValidationError(e)
 
     def perform_update(self, serializer):


### PR DESCRIPTION
## Scope and purpose

We have entries in the logs for `POST /api/incidents/` that just says `400 Bad request`. That's not very useful for debugging!

## Contributor Checklist

Every pull request should have this checklist filled out, no matter how small it is.
More information about contributing to Argus can be found in the
[Development docs](https://argus-server.readthedocs.io/en/latest/development.html).

<!-- Add an "X" inside the brackets to confirm -->
<!-- Remove checks that do not apply -->
<!-- Of the checks that do apply: If not checking one or more of the boxes, please explain why below each. -->

* [ ] Added a changelog fragment for [towncrier](https://argus-server.readthedocs.io/en/latest/development/howtos/changelog-entry.html)
* [ ] Added/amended tests for new/changed code
* [ ] Added/changed documentation, including updates to the [user manual](https://argus-server.readthedocs.io/en/latest/user-manual.html) if feature flow or UI is considerably changed
* [x] Linted/formatted the code with ruff and djLint, easiest by using [pre-commit](https://github.com/Uninett/Argus?tab=readme-ov-file#code-style)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long. See our [how-to](https://argus-server.readthedocs.io/en/latest/development/howtos/commit-messages.html)
* [ ] If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done
* [ ] If this results in changes in the UI: Added screenshots of the before and after
* [ ] If this results in changes to the database model: Updated the [ER diagram](https://argus-server.readthedocs.io/en/latest/development/howtos/regenerate-the-ER-diagram.html)

<!-- Make this a draft PR if the content is subject to change, cannot be merged or if it is for initial feedback -->
